### PR TITLE
Rename prefix and set clear label on resource

### DIFF
--- a/bundle/manifests/redhat-ods-operator-metrics-service_v1_service.yaml
+++ b/bundle/manifests/redhat-ods-operator-metrics-service_v1_service.yaml
@@ -3,8 +3,8 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    control-plane: controller-manager
-  name: redhat-ods-operator-controller-manager-metrics-service
+    app.kubernetes.io/part-of: rhods-operator
+  name: redhat-ods-operator-metrics-service
 spec:
   ports:
   - name: https
@@ -12,6 +12,6 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/part-of: rhods-operator
 status:
   loadBalancer: {}

--- a/bundle/manifests/redhat-ods-operator_v1_configmap.yaml
+++ b/bundle/manifests/redhat-ods-operator_v1_configmap.yaml
@@ -24,4 +24,4 @@ data:
     # leaderElectionReleaseOnCancel: true
 kind: ConfigMap
 metadata:
-  name: redhat-ods-operator-manager-config
+  name: redhat-ods-operator

--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -392,23 +392,27 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: redhat-ods-operator-controller-manager
+        serviceAccountName: redhat-ods-controller-manager
       deployments:
       - label:
-          control-plane: controller-manager
-        name: redhat-ods-operator-controller-manager
+          app.kubernetes.io/component: manager
+          app.kubernetes.io/created-by: rhods-operator
+          app.kubernetes.io/instance: controller-manager
+          app.kubernetes.io/name: deployment
+          app.kubernetes.io/part-of: rhods-operator
+        name: redhat-ods-rhods-operator
         spec:
           replicas: 1
           selector:
             matchLabels:
-              control-plane: controller-manager
+              app.kubernetes.io/part-of: rhods-operator
           strategy: {}
           template:
             metadata:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
-                control-plane: controller-manager
+                app.kubernetes.io/part-of: rhods-operator
             spec:
               containers:
               - args:
@@ -446,7 +450,7 @@ spec:
                     - ALL
               securityContext:
                 runAsNonRoot: true
-              serviceAccountName: redhat-ods-operator-controller-manager
+              serviceAccountName: redhat-ods-controller-manager
               terminationGracePeriodSeconds: 10
       permissions:
       - rules:
@@ -481,7 +485,7 @@ spec:
           verbs:
           - create
           - patch
-        serviceAccountName: redhat-ods-operator-controller-manager
+        serviceAccountName: redhat-ods-controller-manager
     strategy: deployment
   installModes:
   - supported: false

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -8,8 +8,8 @@ namespace: redhat-ods-operator
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: redhat-ods-operator-
+# field above. e.g redhat-ods-rhods-operator is the deployment's name
+namePrefix: redhat-ods-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: rhods-operator
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: rhods-operator   #this is for v1 upgrade reason to keep same name
   namespace: system
 spec:
   template:
@@ -17,4 +17,4 @@ spec:
       volumes:
       - name: manager-config
         configMap:
-          name: manager-config
+          name: redhat-ods-operator

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ generatorOptions:
 configMapGenerator:
 - files:
   - controller_manager_config.yaml
-  name: manager-config
+  name: operator

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,27 +2,31 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: rhods-operator
   name: system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: rhods-operator  #this is for v1 upgrade reason to keep same name
   namespace: system
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: rhods-operator
+    app.kubernetes.io/part-of: rhods-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/part-of: rhods-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        app.kubernetes.io/part-of: rhods-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    app.kubernetes.io/part-of: rhods-operator
   name: controller-manager-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      app.kubernetes.io/part-of: rhods-operator

--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: metrics-reader
+  name: operator-metrics-reader
 rules:
 - nonResourceURLs:
   - "/metrics"

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-service
+    app.kubernetes.io/part-of: rhods-operator
+  name: operator-metrics-service
   namespace: system
 spec:
   ports:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    app.kubernetes.io/part-of: rhods-operator

--- a/docs/Dev-Preview.md
+++ b/docs/Dev-Preview.md
@@ -28,7 +28,7 @@ spec:
   sourceType: grpc
   image: quay.io/opendatahub/opendatahub-operator-catalog:$RELEASE_TAG
   displayName: Open Data Hub Operator (Preview)
-  publisher: ODH
+  publisher: RHODS
 EOF
 ```
 


### PR DESCRIPTION
replace old lable "control-plane: controller-manager" to "app.kubernetes.io/part-of: rhods-ods-operator" as most of rhods components have done this change.
