### PR TITLE
Fix: missing "." in consolelink

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -164,7 +164,7 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 		domainIndex := strings.Index(consoleRoute.Spec.Host, ".")
 		consolelinkDomain := consoleRoute.Spec.Host[domainIndex+1:]
 		err = common.ReplaceStringsInFile(PathConsoleLink+"/consolelink.yaml", map[string]string{
-			"<rhods-dashboard-url>": "https://rhods-dashboard-" + namespace + consolelinkDomain,
+			"<rhods-dashboard-url>": "https://rhods-dashboard-" + namespace + "." + consolelinkDomain,
 		})
 		if err != nil {
 			return fmt.Errorf("error replacing with correct dashboard url for ConsoleLink: %v", err)
@@ -194,7 +194,7 @@ func (d *Dashboard) ReconcileComponent(owner metav1.Object, cli client.Client, s
 		domainIndex := strings.Index(consoleRoute.Spec.Host, ".")
 		consolelinkDomain := consoleRoute.Spec.Host[domainIndex+1:]
 		err = common.ReplaceStringsInFile(PathConsoleLink+"/consolelink.yaml", map[string]string{
-			"<rhods-dashboard-url>": "https://rhods-dashboard-" + namespace + consolelinkDomain,
+			"<rhods-dashboard-url>": "https://rhods-dashboard-" + namespace + "." + consolelinkDomain,
 		})
 		if err != nil {
 			return fmt.Errorf("Error replacing with correct dashboard url for ConsoleLink: %v", err)


### PR DESCRIPTION
cherry-pick : https://github.com/opendatahub-io/opendatahub-operator/pull/420

# description
from test:

wrong link:
 https://rhods-dashboard-redhat-ods-applicationsapps.ods-qe-01.rhods.ccitredhat.com/

should be:
https://rhods-dashboard-redhat-ods-applications.apps.ods-qe-01.rhods.ccitredhat.com/

Ref: https://github.com/opendatahub-io/opendatahub-operator/issues/261 