### PR TITLE
Update: change default for DSCI monitoring to "true"

### DIFF
--- a/apis/dscinitialization/v1alpha1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1alpha1/dscinitialization_types.go
@@ -40,8 +40,8 @@ type DSCInitializationSpec struct {
 }
 
 type Monitoring struct {
-	// +kubebuilder:default=false
-	// If enabled monitoring, default 'false'
+	// +kubebuilder:default=true
+	// If enabled monitoring, default 'true'
 	Enabled bool `json:"enabled,omitempty"`
 	// +kubebuilder:default=opendatahub
 	// Namespace for monitoring if it is enabled

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -57,8 +57,8 @@ spec:
                 description: Enable monitoring on specified namespace
                 properties:
                   enabled:
-                    default: false
-                    description: If enabled monitoring, default 'false'
+                    default: true
+                    description: If enabled monitoring, default 'true'
                     type: boolean
                   namespace:
                     default: opendatahub

--- a/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/opendatahub-operator.clusterserviceversion.yaml
@@ -130,7 +130,7 @@ metadata:
           "spec": {
             "applicationsNamespace": "opendatahub",
             "monitoring": {
-              "enabled": false,
+              "enabled": true,
               "namespace": "opendatahub"
             }
           }

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -58,8 +58,8 @@ spec:
                 description: Enable monitoring on specified namespace
                 properties:
                   enabled:
-                    default: false
-                    description: If enabled monitoring, default 'false'
+                    default: true
+                    description: If enabled monitoring, default 'true'
                     type: boolean
                   namespace:
                     default: opendatahub

--- a/config/samples/dscinitialization_v1alpha1_dscinitialization.yaml
+++ b/config/samples/dscinitialization_v1alpha1_dscinitialization.yaml
@@ -10,6 +10,6 @@ metadata:
   name: default
 spec:
   monitoring:
-    enabled: false
+    enabled: true
     namespace: 'opendatahub'
   applicationsNamespace: 'opendatahub'

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 			Spec: dsci.DSCInitializationSpec{
 				ApplicationsNamespace: dscApplicationsNamespace,
 				Monitoring: dsci.Monitoring{
-					Enabled: false,
+					Enabled: true,
 				},
 			},
 		}


### PR DESCRIPTION
- once DSCI installed will create monitoring namespace
- when modelmesh component is Managed it will not cause issue
This is based on we do not release v2 operator to CloudService yet => it wont create addon related monitoring resource. 

cherry-pick https://github.com/opendatahub-io/opendatahub-operator/pull/478
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/479