### PR TITLE
Update: change default for DSCI monitoring to "true" 

### DIFF
--- a/apis/dscinitialization/v1alpha1/dscinitialization_types.go
+++ b/apis/dscinitialization/v1alpha1/dscinitialization_types.go
@@ -38,8 +38,8 @@ type DSCInitializationSpec struct {
 }
 
 type Monitoring struct {
-	// +kubebuilder:default=false
-	// If enabled monitoring, default 'false'
+	// +kubebuilder:default=true
+	// If enabled monitoring, default 'true'
 	Enabled bool `json:"enabled,omitempty"`
 	// +kubebuilder:default=redhat-ods-monitoring
 	// Namespace for monitoring if it is enabled, default 'redhat-ods-monitoring'

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -57,8 +57,8 @@ spec:
                 description: Enable monitoring on specified namespace
                 properties:
                   enabled:
-                    default: false
-                    description: If enabled monitoring, default 'false'
+                    default: true
+                    description: If enabled monitoring, default 'true'
                     type: boolean
                   namespace:
                     default: redhat-ods-monitoring

--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -130,7 +130,7 @@ metadata:
           "spec": {
             "applicationsNamespace": "redhat-ods-applications",
             "monitoring": {
-              "enabled": false,
+              "enabled": true,
               "namespace": "redhat-ods-monitoring"
             }
           }

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -58,8 +58,8 @@ spec:
                 description: Enable monitoring on specified namespace
                 properties:
                   enabled:
-                    default: false
-                    description: If enabled monitoring, default 'false'
+                    default: true
+                    description: If enabled monitoring, default 'true'
                     type: boolean
                   namespace:
                     default: redhat-ods-monitoring

--- a/config/samples/dscinitialization_v1alpha1_dscinitialization.yaml
+++ b/config/samples/dscinitialization_v1alpha1_dscinitialization.yaml
@@ -10,6 +10,6 @@ metadata:
   name: default
 spec:
   monitoring:
-    enabled: false
+    enabled: true
     namespace: 'redhat-ods-monitoring'
   applicationsNamespace: 'redhat-ods-applications'

--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 			Spec: dsci.DSCInitializationSpec{
 				ApplicationsNamespace: dscApplicationsNamespace,
 				Monitoring: dsci.Monitoring{
-					Enabled: false,
+					Enabled: true,
 				},
 			},
 		}


### PR DESCRIPTION
- once DSCI installed will create monitoring namespace
- when modelmesh component is Managed it will not cause issue
- This is based on we do not release v2 operator to CloudService yet => it wont create addon related monitoring resource.

ref: https://github.com/opendatahub-io/opendatahub-operator/issues/479


local build image: quay.io/wenzhou/opendatahub-operator-catalog:v2.8.479


after installation done, check DSCI yaml
![Screenshot from 2023-08-25 15-46-03](https://github.com/red-hat-data-services/rhods-operator/assets/915053/56764d59-880e-487b-8430-4ddf85282b80)
