### PR TITLE
Cherry-pick: ODH PR 494

### DIFF
--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func main() {
 		releaseDscInitialization := &dsci.DSCInitialization{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "DSCInitialization",
-				APIVersion: "dscinitialization.opendatahub.io/v1alpha1",
+				APIVersion: "dscinitialization.opendatahub.io/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "default",


### PR DESCRIPTION
part of https://github.com/opendatahub-io/opendatahub-operator/pull/494


error:
```
I0901 08:09:54.697109       1 request.go:682] Waited for 1.037429368s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/console.openshift.io/v1alpha1?timeout=32s
2023-09-01T08:09:58Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "0.0.0.0:8080"}
2023-09-01T08:09:58Z	INFO	secret-generator	Adding controller for Secret Generation.
2023-09-01T08:09:58Z	INFO	setup	DscInitialization resource already exists. Updating it.
2023-09-01T08:09:58Z	ERROR	setup	failed to update DscInitialization custom resource	{"error": "Incorrect version specified in apply patch. Specified patch version: dscinitialization.opendatahub.io/v1alpha1, expected: dscinitialization.opendatahub.io/v1"}
main.main
	/workspace/main.go:194
runtime.main
	/usr/lib/golang/src/runtime/proc.go:250
```