### PR TITLE
Fix: wrong path for the image update + wrong API version

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -49,6 +49,7 @@ func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, sche
 	enabled := managementState == operatorv1.Managed
 
 	// Update image parameters
+	// TODO: we will need to cleanup this logic since kserve images are from quay.io only
 	if err := deploy.ApplyImageParams(Path, imageParamMap); err != nil {
 		return err
 	}
@@ -67,8 +68,8 @@ func (d *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, sche
 		}
 	}
 
-	// Update image parameters
-	if err := deploy.ApplyImageParams(Path, dependentImageParamMap); err != nil {
+	// Update image parameters for odh-model-controller
+	if err := deploy.ApplyImageParams(DependentPath, dependentImageParamMap); err != nil {
 		return err
 	}
 

--- a/main.go
+++ b/main.go
@@ -164,7 +164,7 @@ func main() {
 		releaseDscInitialization := &dsci.DSCInitialization{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "DSCInitialization",
-				APIVersion: "dscinitialization.opendatahub.io/v1alpha1",
+				APIVersion: "dscinitialization.opendatahub.io/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "default",


### PR DESCRIPTION
we should finally apply manifests with replaced image

the old logic is:
- apply `"kserve"` manifests
- replace `odh-model-controller` image value in `kserve` folder
- apply `odh-model-controller` manifests
- 
If we have `modelmeshserving` component first enabled and reconciled, it will get correct image of `odh-model-controller` in `odh-model-controller` folder, 
but if we create DSC instance directly with `Remove on modelmeshserving `+ `Managed on kserve`, it will not update content of `odh-model-controller/base/params.env`, 
thus, above logic will still use quay.io image of odh-modelmesh-controller.

fix: https://issues.redhat.com/browse/RHODS-11613