### PR TITLE
Move RHODS ods-manifests to  rhods-operator/config

### DIFF
--- a/config/monitoring/alertmanager/alertmanager-configs.yaml
+++ b/config/monitoring/alertmanager/alertmanager-configs.yaml
@@ -1,0 +1,686 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager
+  namespace: redhat-ods-monitoring
+data:
+  default.tmpl: |
+    {{ define "email.rhods.subject" }}
+        {{ if gt (len .Alerts.Firing) 1 }}
+            Red Hat OpenShift Data Science Notifications
+        {{ else }}
+            {{ (index .Alerts.Firing 0).Annotations.summary }}
+        {{ end }}
+    {{ end }}
+    {{ define "email.rhods.html" }}
+
+    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+    <html xmlns="http://www.w3.org/1999/xhtml">
+
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Alert fired</title>
+        <style>
+            @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Display:wght@400;700&display=swap');
+            @import url('https://fonts.googleapis.com/css2?family=Red+Hat+Text&display=swap');
+
+            .rh-masthead__content-title,
+            .rh-masthead__metric-block-count,
+            .rh-masthead__metric-block-text,
+            .rh-masthead__subhead {
+                font-family: 'Red Hat Display', Helvetica, sans-serif;
+            }
+
+            body,
+            .rh-content__block,
+            .rh-data-table,
+            .rh-masthead__subhead {
+                font-family: 'Red Hat Text', Helvetica, sans-serif;
+            }
+
+            #outlook a {
+                padding: 0;
+            }
+
+            /* Force Outlook to provide a "view in browser" message */
+            body,
+            table,
+            td,
+            p,
+            a,
+            li,
+            blockquote {
+                -webkit-text-size-adjust: 100%;
+                -ms-text-size-adjust: 100%;
+            }
+
+            /* Prevent WebKit and Windows mobile changing default text sizes */
+            table,
+            td {
+                mso-table-lspace: 0pt;
+                mso-table-rspace: 0pt;
+            }
+
+            /* Remove spacing between tables in Outlook 2007 and up */
+            img {
+                -ms-interpolation-mode: bicubic;
+            }
+
+            /* Allow smoother rendering of resized image in Internet Explorer */
+
+            /* reset styles */
+            img {
+                border: 0;
+                height: auto;
+                line-height: 100%;
+                outline: none;
+                text-decoration: none;
+            }
+
+            table {
+                border-collapse: collapse !important;
+            }
+
+            a {
+                text-decoration: none !important;
+            }
+
+            /* Remove space around email design */
+            html,
+            body {
+                margin: 0 auto !important;
+                padding: 0 !important;
+                height: 100% !important;
+                width: 100% !important;
+                background-color: #fff;
+            }
+
+            /* Stop Outlook resizing small text */
+            * {
+                -ms-text-size-adjust: 100%;
+            }
+
+            /* Stop Outlook from adding extra spacing to tables */
+            table,
+            td {
+                mso-table-lspace: 0pt !important;
+                mso-table-rspace: 0pt !important;
+            }
+
+            /* Better rendering method when resizing impages in Outlook IE */
+            img {
+                -ms-interpolation-mode: bicubic;
+            }
+
+            a {
+                text-decoration: none;
+                color: #fff;
+            }
+
+            h1,
+            h2,
+            h3,
+            h4,
+            h5,
+            h6 {
+                font-family: 'Red Hat Display', sans-serif;
+                font-size: 16px;
+            }
+
+            h1,
+            h2,
+            h3,
+            h4,
+            h5,
+            h6,
+            p {
+                margin-top: 0;
+            }
+
+            
+            h1:last-child,
+            h2:last-child,
+            h3:last-child,
+            h4:last-child,
+            h5:last-child,
+            h6:last-child,
+            p:last-child {
+                margin-bottom: 0;
+            }
+
+            .fh-inline-title {
+                margin-bottom: 6px !important;
+            }
+
+
+            .rh-masthead__content-title h1,
+            .rh-masthead__content-title h2,
+            .rh-masthead__content-title h3,
+            .rh-masthead__content-title h4,
+            .rh-masthead__subhead h1,
+            .rh-masthead__subhead h2,
+            .rh-masthead__subhead h3,
+            .rh-masthead__subhead h4 {
+                font-weight: 400;
+                line-height: 1;
+            }
+
+            .rh-body-table,
+            .rh-body-cell {
+                height: 100% !important;
+                margin: 0;
+                padding: 0;
+                width: 100% !important;
+            }
+
+            .rh-body-table {
+                background-color: #f5f5f5;
+                background-color: #fff;
+            }
+
+            .rh-page {
+                padding: 0 0 30px 0;
+                background: #efefef;
+            }
+
+            .rh-template-container {
+                padding: 0 0 30px 0;
+                width: 600px;
+            }
+
+            .rh-template-container,
+            .rh-template-container>tbody {
+                background: #ededed;
+            }
+
+            .rh-head,
+            .rh-body,
+            .rh-footer {
+                margin: 0;
+                mso-line-height-rule: exactly;
+                font-family: arial;
+                font-size: 16px;
+                box-sizing: border-box;
+            }
+
+            .rh-body {
+                padding: 0 20px 20px 20px;
+            }
+
+            .rh-body,
+            .rh-masthead,
+            .rh-content,
+            .rh-data-table,
+            .rh-head {
+                width: 100% !important;
+            }
+
+            .rh-head {
+                padding: 0 0 20px 0;
+            }
+
+            .rh-footer {
+                padding: 10px 20px 30px 20px;
+            }
+
+            .rh-masthead__content {
+                background-color: #090a0a !important;
+                background-color: #030303 !important;
+                background-image: url(https://cloud.redhat.com/apps/frontend-assets/email-assets/bg_masthead-hat.png);
+                background-size: cover;
+            }
+
+            .rh-masthead__subhead {
+                background-color: #282828 !important;
+                padding: 20px;
+                color: #ffffff !important;
+                font-size: 18px;
+                text-align: center;
+            }
+
+            .rh-masthead__block {
+                width: 200px;
+            }
+
+            .rh-masthead__brand {
+                padding: 5px 20px 5px 20px;
+                background-color: #c0c0c0 !important;
+                background-repeat: repeat;
+
+                text-align: center;
+            }
+
+            .rh-masthead__brand-link {
+                display: block;
+                text-align: center;
+            }
+
+            .rh-masthead__content {
+                background-color: #151515;
+                background-size: cover;
+                background-repeat: no-repeat;
+            }
+
+            .rh-masthead__content-title {
+                padding: 20px 20px 20px 20px;
+                margin: 0 0 10px 0;
+                color: #ffffff;
+                font-size: 18px;
+                position: relative;
+                font-weight: 400;
+            }
+
+            .rh-masthead__metric-block-count {
+                display: block;
+                padding-bottom: 10px;
+                text-align: center;
+                font-size: 28px;
+                word-break: break-all;
+                color: #ffffff !important;
+                line-height: 1;
+            }
+
+            .rh-masthead__metric-block-text {
+                display: block;
+                padding: 0 20px 40px 20px;
+                word-break: break-all;
+                color: #ffffff !important;
+                line-height: 1;
+                font-size: 14px;
+            }
+
+            .rh-masthead__metric-block-icon {
+                padding: 0 0 20px;
+                display: block;
+            }
+
+            .rh-content+.rh-content {
+                padding: 0 0 20px 0;
+            }
+
+            .rh-content a {
+                color: #0066cc;
+            }
+
+            .rh-content {
+                background: #efefef;
+            }
+
+            .rh-content table {
+                background: #fff;
+            }
+
+            /* Content block */
+            .rh-content__block {
+                max-width: 100%;
+                padding: 20px 20px 20px 20px;
+                overflow: hidden;
+            }
+
+            .rh-title__block {
+                max-width: 100%;
+                padding: 20px 20px 20px 20px;
+                overflow: hidden;
+            }
+
+            .rh-alert__block {
+                max-width: 100%;
+                padding: 20px;
+                margin: 4px;
+                overflow: hidden;
+                background: #ececec;
+            }
+
+            .rh-content tr+tr .rh-content__block {
+                padding-top: 0;
+                padding-bottom: 0;
+            }
+
+            .rh-content tr:last-child {
+                padding-top: 0;
+                padding-bottom: 20px;
+            }
+
+            .rh-content .rh-content__block {
+                background-color: #fff;
+            }
+
+            .rh-content .rh-title__block {
+                background-color: #fff;
+            }
+
+            .rh-footer__text {
+                font-size: 14px;
+                text-align: center;
+            }
+
+            .rh-footer__text a {
+                color: #0066cc;
+            }
+
+            .rh-content__spacer {
+                font-size: 0;
+                line-height: 0;
+                height: 20px;
+                background-color: #ffffff;
+            }
+
+            .rh-cta-link {
+                display: block;
+                padding: 10px 20px;
+                background-color: #0066cc;
+                border-radius: 3px;
+                text-decoration: none;
+                font-weight: bold;
+            }
+
+            .rh-cta-link a {
+                color: #ffffff;
+                text-decoration: none;
+            }
+
+            .rh-data-table thead th {
+                font-weight: 700;
+                text-align: left;
+            }
+
+            .rh-data-table tbody th {
+                font-weight: 500;
+                text-align: left;
+                width: 200px;
+            }
+
+            .rh-data-table.rh-m-bordered th {
+                padding: 10px;
+                text-align: left;
+                font-size: 14px;
+                font-weight: 500;
+                text-transform: uppercase;
+                background-color: #ededed;
+            }
+
+            .rh-data-table.rh-m-bordered td {
+                padding: 10px;
+                text-align: left;
+            }
+
+            .rh-data-table.rh-m-bordered {
+                border-collapse: collapse;
+            }
+
+            .rh-table-header {
+                text-align: left;
+                padding-bottom: 0;
+            }
+
+            .rh-m-bordered th,
+            .rh-m-bordered td {
+                border-width: 1px;
+                border-color: #b8bbbe;
+                border-style: solid;
+            }
+
+            .rh-m-bordered tr:nth-child(even) {
+                background-color: #fafafa;
+            }
+
+            .rh-color__red {
+                color: #a30000;
+            }
+
+            .rh-color__orange {
+                color: #ec7a08;
+            }
+
+            .rh-color__green {
+                color: #486b00;
+            }
+
+            .rh-m-block {
+                display: block;
+            }
+
+            .rh-url {
+                word-break: break-word;
+            }
+
+            .rh-stack>*+* {
+                margin-top: 10px;
+            }
+
+            .rh-inline {
+                display: flex;
+                align-items: center;
+            }
+
+            .rh-icon {
+                display: inline-block;
+                width: 16px;
+                height: 16px;
+                line-height: 1;
+            }
+
+            .rh-inline>*+* {
+                display: inline-block;
+                margin-left: 5px;
+            }
+
+            /* dark mode hacks */
+            [data-ogsc] .rh-masthead__brand,
+            [data-ogsb] .rh-masthead__brand {
+                background-color: #151515 !important;
+            }
+
+            @media only screen and (max-width: 320px) {
+                .rh-masthead__block {
+                    width: 100% !important;
+                    display: block !important;
+                }
+            }
+
+            @media only screen and (max-width: 480px) {
+                .rh-template-container {
+                    max-width: 480px !important;
+                    /*@editable*/
+                    width: 100% !important;
+                }
+
+                .rh-data-table tbody th {
+                    width: auto !important;
+                }
+
+                .rh-data-table th,
+                .rh-data-table td {
+                    font-size: 14px;
+                }
+
+                .rh-data-table.rh-m-bordered th,
+                .rh-data-table.rh-m-bordered td {
+                    padding: 5px;
+                    text-align: left;
+                }
+            }
+
+            @media only screen and (max-width: 600px) {
+                body {
+                    width: 100% !important;
+                    min-width: 100% !important;
+                }
+
+                .rh-template-container {
+                    max-width: 600px !important;
+                    /*@editable*/
+                    width: 100% !important;
+                }
+
+                .rh-masthead__block {
+                    width: 33%;
+                    max-width: 200px;
+                }
+            }
+
+            .rh-masthead__brand-img {
+                width: 282px;
+                padding: 20px 0px;
+            }
+
+            .rh-spacer {
+                height: 20px;
+                width: 100%;
+            }
+        </style>
+    </head>
+
+    <body leftmargin="0" marginwidth="0" topmargin="0" marginheight="0" offset="0" class="rh-body">
+        <center>
+            <table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%"
+                class="rh-body-table">
+                <tr>
+                    <td align="center" valign="top" class="rh-body-cell">
+                        <table border="0" cellpadding="0" cellspacing="0" class="rh-template-container">
+
+                            <!-- Head -->
+                            <tr>
+                                <td class="rh-head">
+                                    <table class="rh-masthead" role="presentation" align="center" border="0" cellpadding="0"
+                                        cellspacing="0" width="100%">
+                                        <tr>
+                                            <!--Red Hat logo-->
+                                            <td align="center" class="rh-masthead__brand" bgcolor="#151515">
+                                                <a href="https://cloud.redhat.com/" target="_blank"
+                                                    class="rh-masthead__brand-link">
+                                                    <img class="rh-masthead__brand-img" src="https://raw.githubusercontent.com/red-hat-data-services/odh-deployer/main/resources/logos/LogoRHODS.png" />
+                                                </a>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td class="rh-masthead__subhead">
+                                                <!-- <h1>{#insert content-title}{/}</h1> -->
+                                                <h1>Notifications</h1>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                            <!-- end head -->
+
+                            <!-- Body section -->
+                            <tr>
+                                <td class="rh-body">
+                                    <table class="rh-content" role="presentation" align="center" border="0" cellpadding="0"
+                                        cellspacing="0" width="100%">
+                                        {{ range .Alerts.Firing }}
+                                            {{ if .Annotations.message }}
+                                                <tr>
+                                                    <td class="rh-content__block">
+                                                        <div class="rh-alert__block">
+                                                            <h4 class="fh-inline-title"> {{ .Annotations.summary }}</h4> 
+                                                            {{ .Annotations.message }}
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            {{ end }}             
+                                        {{ end }}
+                                        <tr><td class="rh-content__block"><div class="rh-spacer"></div></td></tr>
+                                    </table>
+                                </td>
+                            </tr>
+                            <!-- end body section -->
+
+                            <!-- Footer -->
+                            <tr>
+                                <td class="rh-footer">
+                                    <table role="presentation" border="0" align="center" cellpadding="0" cellspacing="0"
+                                        width="100%">
+                                        <tr>
+                                            <td class="rh-footer__text">
+                                                This email was sent by Red Hat OpenShift Data Science
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
+                            <!-- end footer -->
+
+                            <!-- Ensure padding bottom - don't remove empty row -->
+                            <tr>
+                                <td>
+                                </td>
+                            </tr>
+                            <!-- leave - empty row -->
+
+                        </table>
+                    </td>
+                </tr>
+            </table>
+        </center>
+    </body>
+    </html>
+    {{ end }}
+
+
+  alertmanager.yml: |
+    global:
+      smtp_from: 'redhat-openshift-alert@devshift.net'
+      smtp_smarthost: '<smtp_host>:<smtp_port>'
+      smtp_auth_username: '<smtp_username>'
+      smtp_auth_password: '<smtp_password>'
+      smtp_require_tls: true
+
+    # The root route on which each incoming alert enters.
+    route:
+      group_by: ['alertname', 'cluster', 'service', 'job', 'email_to']
+
+      group_wait: 30s
+
+      # When the first notification was sent, wait 'group_interval' to send a batch
+      # of new alerts that started firing for that group.
+      group_interval: 5m
+
+      # If an alert has successfully been sent, wait 'repeat_interval' to
+      # resend them.
+      repeat_interval: 4h
+
+      # A default receiver
+      receiver: alerts-sink
+
+      routes:
+      - match:
+          alertname: DeadManSnitch
+        receiver: deadman-snitch
+        repeat_interval: 5m
+      
+      - match:
+          route: user-notifications
+        receiver: user-notifications
+        repeat_interval: 12h
+
+      - match:
+          severity: critical
+        receiver: PagerDuty
+
+    receivers:
+
+    - name: 'alerts-sink'
+
+    - name: 'user-notifications'
+      email_configs:
+      - to: '<user_emails>'
+        send_resolved: false
+        html: '{{ template "email.rhods.html" . }}'
+        headers: 
+          subject: '{{ template "email.rhods.subject" . }}'
+
+    - name: 'PagerDuty'
+      pagerduty_configs:
+      - service_key: <pagerduty_token>
+        send_resolved: true
+
+    - name: 'deadman-snitch'
+      webhook_configs:
+        - url: '<snitch_url>?m=just+checking+in'
+          send_resolved: false
+
+    templates:
+      - '/etc/alertmanager/default.tmpl'

--- a/config/monitoring/alertmanager/alertmanager-pvc.yaml
+++ b/config/monitoring/alertmanager/alertmanager-pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: alertmanager-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/config/monitoring/alertmanager/alertmanager-route.yaml
+++ b/config/monitoring/alertmanager/alertmanager-route.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    kubernetes.io/tls-acme: 'true'
+  name: alertmanager
+  namespace: redhat-ods-monitoring
+spec:
+  port:
+    targetPort: alertmanager
+  to:
+    kind: Service
+    name: alertmanager
+  tls:
+    termination: Reencrypt
+    insecureEdgeTerminationPolicy: Redirect

--- a/config/monitoring/alertmanager/alertmanager-service.yaml
+++ b/config/monitoring/alertmanager/alertmanager-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: alertmanager-tls
+  labels:
+    name: alertmanager
+  name: alertmanager
+  namespace: "redhat-ods-monitoring"
+spec:
+  ports:
+    - name: alertmanager
+      port: 443
+      protocol: TCP
+      targetPort: 10443
+  selector:
+    deployment: prometheus

--- a/config/monitoring/alertmanager/kustomization.yaml
+++ b/config/monitoring/alertmanager/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - alertmanager-service.yaml
+  - alertmanager-route.yaml
+  - alertmanager-configs.yaml
+  - alertmanager-pvc.yaml

--- a/config/monitoring/base/cluster-monitor-rbac.yaml
+++ b/config/monitoring/base/cluster-monitor-rbac.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-monitor-rhods-reader
+  namespace: redhat-ods-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/config/monitoring/base/kustomization.yaml
+++ b/config/monitoring/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-monitor-rbac.yaml
+- rhods-rules.yaml
+- rhods-service-monitor.yaml

--- a/config/monitoring/base/rhods-rules.yaml
+++ b/config/monitoring/base/rhods-rules.yaml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: recording-rules
+    app: rhods
+  name: rhods-rules
+spec:
+  groups:
+  - name: rhods-usage.rules
+    rules:
+    - record: cluster:usage:consumption:rhods:cpu:seconds:rate1h
+      expr: sum(rate(container_cpu_usage_seconds_total{container="",pod=~"jupyter-nb.*",namespace="rhods-notebooks"}[1h]))
+    - record: cluster:usage:consumption:rhods:pod:up
+      expr: count(kube_pod_container_status_ready{namespace="rhods-notebooks", pod=~"jupyter-nb.*",container=~"jupyter-nb-.*"}==1)
+    - record: cluster:usage:consumption:rhods:active_users
+      expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
+      labels:
+        instance: jupyter-notebooks
+    - record: cluster:usage:consumption:rhods:cpu_requests_runtime
+      expr: sum(kube_pod_container_resource_requests{namespace="rhods-notebooks",resource="cpu", container=~"jupyter-nb-.*"} * on(pod) kube_pod_status_phase{phase="Running", namespace="rhods-notebooks"})
+    - record: cluster:usage:consumption:rhods:cpu_limits_runtime
+      expr: sum(kube_pod_container_resource_limits{namespace="rhods-notebooks",resource="cpu", container=~"jupyter-nb-.*"} * on(pod) kube_pod_status_phase{phase="Running", namespace="rhods-notebooks"})

--- a/config/monitoring/base/rhods-service-monitor.yaml
+++ b/config/monitoring/base/rhods-service-monitor.yaml
@@ -1,0 +1,32 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: rhods-monitor-federation
+  labels:
+    monitor-component: rhods-resources
+    team: rhods
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenSecret:
+        key: ""
+      honorLabels: true
+      params:
+        'match[]':
+          - '{__name__= "rhods_total_users"}'
+          - '{__name__= "rhods_aggregate_availability"}'
+          - ALERTS{alertname!="DeadManSnitch", alertstate="firing"}
+      path: /federate
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: prometheus.redhat-ods-monitoring.svc
+      scrapeTimeout: 10s
+      interval: 30s
+  namespaceSelector:
+    matchNames:
+      - redhat-ods-monitoring
+  selector:
+    matchLabels:
+      app: prometheus

--- a/config/monitoring/blackbox-exporter/base/blackbox-exporter-configmap.yaml
+++ b/config/monitoring/blackbox-exporter/base/blackbox-exporter-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox
+data:
+  blackbox.yml : ""

--- a/config/monitoring/blackbox-exporter/base/blackbox-exporter-deployment.yaml
+++ b/config/monitoring/blackbox-exporter/base/blackbox-exporter-deployment.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    deployment: blackbox-exporter
+  name: blackbox-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      deployment: blackbox-exporter
+  template:
+    metadata:
+      labels:
+        deployment: blackbox-exporter
+    spec:
+      volumes:
+      - name: config-volume
+        configMap:
+          name: blackbox
+      - name: prometheus-tls
+        secret:
+          defaultMode: 420
+          secretName: prometheus-tls
+      - name: prometheus-proxy
+        secret:
+          defaultMode: 420
+          secretName: prometheus-proxy
+      serviceAccountName: prometheus
+      containers:
+      - name: oauth-proxy
+        args:
+        - -provider=openshift
+        - -https-address=:9114
+        - -http-address=
+        - -email-domain=*
+        - -upstream=http://localhost:9115
+        - -openshift-service-account=prometheus
+        - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "redhat-ods-monitoring",
+          "namespace": "redhat-ods-monitoring"}'
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get",
+          "name": "redhat-ods-monitoring", "namespace": "redhat-ods-monitoring"}}'
+        - -tls-cert=/etc/tls/private/tls.crt
+        - -tls-key=/etc/tls/private/tls.key
+        - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - -cookie-secret-file=/etc/proxy/secrets/session_secret
+        - -openshift-ca=/etc/pki/tls/cert.pem
+        - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -client-id=system:serviceaccount:redhat-ods-monitoring:prometheus
+        - -skip-auth-regex=^/metrics
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        ports:
+        - containerPort: 9114
+          name: https
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: 9114
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: 9114
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: prometheus-tls
+          readOnly: false
+        - mountPath: /etc/proxy/secrets
+          name: prometheus-proxy
+          readOnly: false
+      - image: quay.io/integreatly/prometheus-blackbox-exporter@sha256:35b9d2c1002201723b7f7a9f54e9406b2ec4b5b0f73d114f47c70e15956103b5
+        name: blackbox-exporter
+        args:
+        - --log.level=debug
+        - --config.file=/tmp/blackbox.yml
+        volumeMounts:
+        - name: config-volume
+          mountPath: /tmp
+        ports:
+        - containerPort: 9115
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9115
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9115
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          limits:
+            cpu: 50m
+            memory: 50Mi
+          requests:
+            cpu: 50m
+            memory: 50Mi
+      restartPolicy: Always

--- a/config/monitoring/blackbox-exporter/base/blackbox-exporter-service.yaml
+++ b/config/monitoring/blackbox-exporter/base/blackbox-exporter-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: blackbox-exporter
+  name: blackbox-exporter
+spec:
+  ports:
+    - name: 9114-tcp
+      port: 9114
+      protocol: TCP
+      targetPort: 9114
+  selector:
+    deployment: blackbox-exporter

--- a/config/monitoring/blackbox-exporter/base/kustomization.yaml
+++ b/config/monitoring/blackbox-exporter/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - blackbox-exporter-deployment.yaml
+  - blackbox-exporter-service.yaml
+  - blackbox-exporter-configmap.yaml

--- a/config/monitoring/blackbox-exporter/external/blackbox-exporter-external-configmap.yaml
+++ b/config/monitoring/blackbox-exporter/external/blackbox-exporter-external-configmap.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox
+data:
+  blackbox.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 10s
+        http:
+          valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208]
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          method: GET
+          no_follow_redirects: false
+          fail_if_ssl: false
+          fail_if_not_ssl: false
+          tls_config:
+            insecure_skip_verify: false
+          preferred_ip_protocol: "ip4"

--- a/config/monitoring/blackbox-exporter/external/kustomization.yaml
+++ b/config/monitoring/blackbox-exporter/external/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: blackbox-exporter-external-configmap.yaml
+    target:
+      kind: Configmap

--- a/config/monitoring/blackbox-exporter/internal/blackbox-exporter-internal-configmap.yaml
+++ b/config/monitoring/blackbox-exporter/internal/blackbox-exporter-internal-configmap.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox
+data:
+  blackbox.yml: |
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 10s
+        http:
+          valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+          method: GET
+          valid_status_codes: [200, 201, 202, 203, 204, 205, 206, 207, 208]
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+          tls_config:
+            insecure_skip_verify: true
+          preferred_ip_protocol: "ip4"

--- a/config/monitoring/blackbox-exporter/internal/kustomization.yaml
+++ b/config/monitoring/blackbox-exporter/internal/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+patches:
+  - path: blackbox-exporter-internal-configmap.yaml
+    target:
+      kind: Configmap

--- a/config/monitoring/prometheus/components/kustomization.yaml
+++ b/config/monitoring/prometheus/components/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+# can split to component based file
+  - prometheus-configs.yaml

--- a/config/monitoring/prometheus/components/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/components/prometheus-configs.yaml
@@ -1,0 +1,266 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-service-ca
+  namespace: redhat-ods-monitoring
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-general-metrics
+  namespace: redhat-ods-monitoring
+data:
+  recording.rules: |
+    groups:
+      - name: Usage Metrics
+        rules:
+        - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
+          record: rhods_total_users
+          labels:
+            instance: jupyter-notebooks
+        - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
+          record: rhods_active_users
+          labels:
+            instance: jupyter-notebooks
+
+      - name: Availability Metrics
+        rules:
+        - expr: ((min(probe_success{name=~"rhods-dashboard|notebook-spawner"}) by (name) or on() vector(0)) or label_replace(min(probe_success{name=~"rhods-dashboard|notebook-spawner"}), "name", "combined", "name", ".*"))
+          record: rhods_aggregate_availability
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-general-alerting
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: DeadManSnitch
+        interval: 1m
+        rules:
+          - alert: DeadManSnitch
+            expr: vector(1)
+            labels:
+              severity: critical
+            annotations:
+              description: This is a DeadManSnitch to ensure RHODS monitoring and alerting pipeline is online.
+              summary: Alerting DeadManSnitch
+           
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus
+  namespace: redhat-ods-monitoring
+data:
+  prometheus.yml: |
+    rule_files:
+      - '*.rules'
+    global:
+      scrape_interval:     10s
+      evaluation_interval: 10s
+
+    scrape_configs:
+    - job_name: 'Federate Prometheus'
+      scrape_interval: 30s
+      scheme: https
+      tls_config:
+        server_name: prometheus-k8s.openshift-monitoring.svc
+        ca_file: /etc/prometheus/ca/service-ca.crt
+      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honor_labels: true
+      metrics_path: '/federate'
+
+      params:
+        'match[]':
+          - '{__name__= "haproxy_backend_http_responses_total"}'
+          - '{__name__= "controller_runtime_reconcile_total"}'
+          - '{__name__= "container_cpu_usage_seconds_total"}'
+          - '{__name__= "container_memory_rss"}'
+          - '{__name__= "kubelet_volume_stats_used_bytes"}'
+          - '{__name__= "kubelet_volume_stats_capacity_bytes"}'
+          - '{__name__= "kube_pod_container_status_waiting_reason"}'
+          - '{__name__= "kube_pod_container_status_restarts_total"}'
+          - '{__name__= "kube_pod_container_status_terminated_reason"}'
+          - '{__name__= "openshift_build_status_phase_total"}'
+          - '{__name__= "kube_statefulset_replicas"}'
+
+
+      static_configs:
+        - targets:
+          - "prometheus-k8s.openshift-monitoring.svc.cluster.local:9091"
+
+    - job_name: 'user_facing_endpoints_status'
+      scrape_interval: 10s
+      metrics_path: /probe
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+      params:
+        module: [http_2xx]
+      authorization:
+        credentials_file: /run/secrets/kubernetes.io/serviceaccount/token
+      static_configs:
+      - targets: [<rhods_dashboard_host>]
+        labels:
+          name: rhods-dashboard
+      - targets: [<notebook_spawner_host>]
+        labels:
+          name: notebook-spawner
+      - targets: [<data_science_pipelines_operator_host>]
+        labels:
+          name: data-science-pipelines-operator
+      relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter.redhat-ods-monitoring.svc.cluster.local:9114
+
+    - job_name: 'Kubeflow Notebook Controller Service Metrics'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(notebook-controller-service)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
+
+    - job_name: 'ODH Notebook Controller Service Metrics'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(odh-notebook-controller-service)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
+    
+    - job_name: 'ODH Model Controller'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(odh-model-controller-metrics-service)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
+
+    - job_name: 'Modelmesh Controller'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(modelmesh-controller)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
+
+    - job_name: 'Data Science Pipelines Operator'
+      honor_labels: true
+      metrics_path: /metrics
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-applications
+      relabel_configs:
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8080
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(data-science-pipelines-operator-service)$
+          target_label: kubernetes_name
+          action: keep
+      metric_relabel_configs:
+        - target_label: namespace
+          replacement: redhat-ods-applications
+
+    - job_name: 'Data Science Pipelines Application'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(ds-pipeline-.*)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):8888
+          target_label: __address__
+          action: keep
+        - source_labels: [__meta_kubernetes_service_name]
+          target_label: dspa_service
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+
+    - job_name: 'RHODS Metrics'
+      honor_labels: true
+      scheme: http
+      kubernetes_sd_configs:
+        - role: endpoints
+          namespaces:
+            names:
+              - redhat-ods-operator
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: ^(rhods-operator-metrics)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.+):(\d+)
+          target_label: __address__
+          replacement: ${1}:8383
+
+    alerting:
+      alertmanagers:
+      - scheme: http
+        static_configs:
+        - targets:
+          - "localhost:9093"

--- a/config/monitoring/prometheus/components/prometheus-dashboard.yaml
+++ b/config/monitoring/prometheus/components/prometheus-dashboard.yaml
@@ -1,0 +1,216 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-recording-dashboard
+  namespace: redhat-ods-monitoring
+data:
+  recording.rules: |
+    groups:
+      - name: SLOs - ODH Dashboard
+        rules:
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[1d]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[1d]))
+          labels:
+            route: rhods-dashboard
+          record: haproxy_backend_http_responses_total:burnrate1d
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[1h]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[1h]))
+          labels:
+            route: rhods-dashboard
+          record: haproxy_backend_http_responses_total:burnrate1h
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[2h]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[2h]))
+          labels:
+            route: rhods-dashboard
+          record: haproxy_backend_http_responses_total:burnrate2h
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[30m]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[30m]))
+          labels:
+            route: rhods-dashboard
+          record: haproxy_backend_http_responses_total:burnrate30m
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[3d]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[3d]))
+          labels:
+            route: rhods-dashboard
+          record: haproxy_backend_http_responses_total:burnrate3d
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[5m]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[5m]))
+          labels:
+            route: rhods-dashboard
+          record: haproxy_backend_http_responses_total:burnrate5m
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard",code=~"5.."}[6h]))
+            /
+            sum(rate(haproxy_backend_http_responses_total{route="rhods-dashboard"}[6h]))
+          labels:
+            route: rhods-dashboard
+          record: haproxy_backend_http_responses_total:burnrate6h
+
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[1d])
+          labels:
+            instance: rhods-dashboard
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[1h])
+          labels:
+            instance: rhods-dashboard
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[2h])
+          labels:
+            instance: rhods-dashboard
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[30m])
+          labels:
+            instance: rhods-dashboard
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[3d])
+          labels:
+            instance: rhods-dashboard
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[5m])
+          labels:
+            instance: rhods-dashboard
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"rhods-dashboard-.*", job="user_facing_endpoints_status"}[6h])
+          labels:
+            instance: rhods-dashboard
+          record: probe_success:burnrate6h
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-backend-dashboard
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: SLOs-haproxy_backend_http_responses_dashboard
+        rules:
+        - alert: RHODS Dashboard Route Error Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+            summary: RHODS Dashboard Route Error Burn Rate
+          expr: |
+            sum(haproxy_backend_http_responses_total:burnrate5m{route=~"rhods-dashboard"}) by (route) > (14.40 * (1-0.99950))
+            and
+            sum(haproxy_backend_http_responses_total:burnrate1h{route=~"rhods-dashboard"}) by (route) > (14.40 * (1-0.99950))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: RHODS Dashboard Route Error Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+            summary: RHODS Dashboard Route Error Burn Rate
+          expr: |
+            sum(haproxy_backend_http_responses_total:burnrate30m{route=~"rhods-dashboard"}) by (route) > (6.00 * (1-0.99950))
+            and
+            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"rhods-dashboard"}) by (route) > (6.00 * (1-0.99950))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: RHODS Dashboard Route Error Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+            summary: RHODS Dashboard Route Error Burn Rate
+          expr: |
+            sum(haproxy_backend_http_responses_total:burnrate2h{route=~"rhods-dashboard"}) by (route) > (3.00 * (1-0.99950))
+            and
+            sum(haproxy_backend_http_responses_total:burnrate1d{route=~"rhods-dashboard"}) by (route) > (3.00 * (1-0.99950))
+          for: 1h
+          labels:
+            severity: warning
+        - alert: RHODS Dashboard Route Error Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-error-burn-rate.md'
+            summary: RHODS Dashboard Route Error Burn Rate
+          expr: |
+            sum(haproxy_backend_http_responses_total:burnrate6h{route=~"rhods-dashboard"}) by (route) > (1.00 * (1-0.99950))
+            and
+            sum(haproxy_backend_http_responses_total:burnrate3d{route=~"rhods-dashboard"}) by (route) > (1.00 * (1-0.99950))
+          for: 3h
+          labels:
+            severity: warning
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-probe-dashboard
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: SLOs-probe_success
+        rules:
+        - alert: RHODS Dashboard Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
+            summary: RHODS Dashboard Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{name=~"rhods-dashboard"}) by (name) > (14.40 * (1-0.99950))
+            and
+            sum(probe_success:burnrate1h{name=~"rhods-dashboard"}) by (name) > (14.40 * (1-0.99950))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: RHODS Dashboard Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
+            summary: RHODS Dashboard Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{name=~"rhods-dashboard"}) by (name) > (6.00 * (1-0.99950))
+            and
+            sum(probe_success:burnrate6h{name=~"rhods-dashboard"}) by (name) > (6.00 * (1-0.99950))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: RHODS Dashboard Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
+            summary: RHODS Dashboard Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{name=~"rhods-dashboard"}) by (name) > (3.00 * (1-0.99950))
+            and
+            sum(probe_success:burnrate1d{name=~"rhods-dashboard"}) by (name) > (3.00 * (1-0.99950))
+          for: 1h
+          labels:
+            severity: warning
+        - alert: RHODS Dashboard Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
+            summary: RHODS Dashboard Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate6h{name=~"rhods-dashboard"}) by (name) > (1.00 * (1-0.99950))
+            and
+            sum(probe_success:burnrate3d{name=~"rhods-dashboard"}) by (name) > (1.00 * (1-0.99950))
+          for: 3h
+          labels:
+            severity: warning

--- a/config/monitoring/prometheus/components/prometheus-datasciencepipelines.yaml
+++ b/config/monitoring/prometheus/components/prometheus-datasciencepipelines.yaml
@@ -1,0 +1,253 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-recording-dsp
+  namespace: redhat-ods-monitoring
+data:
+  recording.rules: |
+    groups:
+      - name: SLOs - Data Science Pipelines Operator
+        rules:
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"data-science-pipelines-operator-.*", job="user_facing_endpoints_status"}[1d])
+          labels:
+            instance: data-science-pipelines-operator
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"data-science-pipelines-operator-.*", job="user_facing_endpoints_status"}[1h])
+          labels:
+            instance: data-science-pipelines-operator
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"data-science-pipelines-operator-.*", job="user_facing_endpoints_status"}[2h])
+          labels:
+            instance: data-science-pipelines-operator
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"data-science-pipelines-operator-.*", job="user_facing_endpoints_status"}[30m])
+          labels:
+            instance: data-science-pipelines-operator
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"data-science-pipelines-operator-.*", job="user_facing_endpoints_status"}[3d])
+          labels:
+            instance: data-science-pipelines-operator
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"data-science-pipelines-operator-.*", job="user_facing_endpoints_status"}[5m])
+          labels:
+            instance: data-science-pipelines-operator
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - avg_over_time(probe_success{instance=~"data-science-pipelines-operator-.*", job="user_facing_endpoints_status"}[6h])
+          labels:
+            instance: data-science-pipelines-operator
+          record: probe_success:burnrate6h
+
+      - name: SLOs - Data Science Pipelines Application
+        rules:
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[1d])) by (exported_namespace)
+            /
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[1d])) by (exported_namespace)
+          labels:
+            component: dsp
+          record: haproxy_backend_http_responses_total:burnrate1d
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[1h])) by (exported_namespace)
+            /
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[1h])) by (exported_namespace)
+          labels:
+            component: dsp
+          record: haproxy_backend_http_responses_total:burnrate1h
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[2h])) by (exported_namespace)
+            /
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[2h])) by (exported_namespace)
+          labels:
+            component: dsp
+          record: haproxy_backend_http_responses_total:burnrate2h
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[30m])) by (exported_namespace)
+            /
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[30m])) by (exported_namespace)
+          labels:
+            component: dsp
+          record: haproxy_backend_http_responses_total:burnrate30m
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[3d])) by (exported_namespace)
+            /
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[3d])) by (exported_namespace)
+          labels:
+            component: dsp
+          record: haproxy_backend_http_responses_total:burnrate3d
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[5m])) by (exported_namespace)
+            /
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[5m])) by (exported_namespace)
+          labels:
+            component: dsp
+          record: haproxy_backend_http_responses_total:burnrate5m
+        - expr: |
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*",code=~"5.."}[6h])) by (exported_namespace)
+            /
+            sum(rate(haproxy_backend_http_responses_total{route=~"ds-pipeline-.*"}[6h])) by (exported_namespace)
+          labels:
+            component: dsp
+          record: haproxy_backend_http_responses_total:burnrate6h
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-backend-dsp
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: SLOs-haproxy_backend_http_responses_dsp
+        rules:
+        - alert: Data Science Pipelines Application Route Error Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+            summary: Data Science Pipelines Application Route Error Burn Rate
+          expr: |
+            sum(haproxy_backend_http_responses_total:burnrate5m{component="dsp"}) by (exported_namespace) > (14.40 * (1-0.99950))
+            and
+            sum(haproxy_backend_http_responses_total:burnrate1h{component="dsp"}) by (exported_namespace) > (14.40 * (1-0.99950))
+          for: 2m
+          labels:
+            severity: info
+        - alert: Data Science Pipelines Application Route Error Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+            summary: Data Science Pipelines Application Route Error Burn Rate
+          expr: |
+            sum(haproxy_backend_http_responses_total:burnrate30m{component="dsp"}) by (exported_namespace) > (6.00 * (1-0.99950))
+            and
+            sum(haproxy_backend_http_responses_total:burnrate6h{component="dsp"}) by (exported_namespace) > (6.00 * (1-0.99950))
+          for: 15m
+          labels:
+            severity: info
+        - alert: Data Science Pipelines Application Route Error Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+            summary: Data Science Pipelines Application Route Error Burn Rate
+          expr: |
+            sum(haproxy_backend_http_responses_total:burnrate2h{component="dsp"}) by (exported_namespace) > (3.00 * (1-0.99950))
+            and
+            sum(haproxy_backend_http_responses_total:burnrate1d{component="dsp"}) by (exported_namespace) > (3.00 * (1-0.99950))
+          for: 1h
+          labels:
+            severity: info
+        - alert: Data Science Pipelines Application Route Error Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.route }} (current value: {{ $value }}).'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-error-burn-rate.md'
+            summary: Data Science Pipelines Application Route Error Burn Rate
+          expr: |
+            sum(haproxy_backend_http_responses_total:burnrate6h{component="dsp"}) by (exported_namespace) > (1.00 * (1-0.99950))
+            and
+            sum(haproxy_backend_http_responses_total:burnrate3d{component="dsp"}) by (exported_namespace) > (1.00 * (1-0.99950))
+          for: 3h
+          labels:
+            severity: info
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-probe-dsp
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: SLOs-probe_success
+        - alert: Data Science Pipelines Operator Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-operator-probe-success-burn-rate.md"
+            summary: Data Science Pipelines Operator Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"data-science-pipelines-operator"}) by (instance) > (14.40 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1h{instance=~"data-science-pipelines-operator"}) by (instance) > (14.40 * (1-0.98000))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: Data Science Pipelines Operator Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-operator-probe-success-burn-rate.md"
+            summary: Data Science Pipelines Operator Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"data-science-pipelines-operator"}) by (instance) > (6.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate6h{instance=~"data-science-pipelines-operator"}) by (instance) > (6.00 * (1-0.98000))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: Data Science Pipelines Operator Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-operator-probe-success-burn-rate.md"
+            summary: Data Science Pipelines Operator Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"data-science-pipelines-operator"}) by (instance) > (3.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1d{instance=~"data-science-pipelines-operator"}) by (instance) > (3.00 * (1-0.98000))
+          for: 1h
+          labels:
+            severity: warning
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-dsp
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: RHODS Data Science Pipelines
+        rules:
+        - alert: Data Science Pipeline Application Unavailable
+          annotations:
+            message: 'Data Science Pipelines Application is down!'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
+            summary: The Data Science Pipelines Application CustomResource "{{ $labels.dspa_name }}" in namespace "{{ $labels.dspa_namespace }}" has been NotReady for more than 5 minutes
+          expr: min(max_over_time(data_science_pipelines_application_ready[3m])) by (dspa_name, dspa_namespace) == 0
+          for: 2m
+          labels:
+            severity: info
+        - alert: Data Science Pipeline APIServer Unavailable
+          annotations:
+            message: 'Data Science Pipelines APIServer component is down!'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
+            summary: A Data Science Pipelines APIServer pod owned by DSPA "{{ $labels.dspa_name }}" in namespace "{{ $labels.dspa_namespace }}" has been NotReady for more than 5 minutes
+          expr: min(max_over_time(data_science_pipelines_application_apiserver_ready[3m])) by (dspa_name, dspa_namespace) == 0
+          for: 2m
+          labels:
+            severity: info
+        - alert: Data Science Pipeline PersistenceAgent Unavailable
+          annotations:
+            message: 'Data Science Pipelines PersistenceAgent component is down!'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
+            summary: A Data Science Pipelines PersistenceAgent pod owned by DSPA "{{ $labels.dspa_name }}" in namespace "{{ $labels.dspa_namespace }}" has been NotReady for more than 5 minutes
+          expr: min(max_over_time(data_science_pipelines_application_persistenceagent_ready[3m])) by (dspa_name, dspa_namespace) == 0
+          for: 2m
+          labels:
+            severity: info
+        - alert: Data Science Pipeline ScheduledWorkflows Unavailable
+          annotations:
+            message: 'Data Science Pipelines ScheduledWorkflows component is down!'
+            triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Data-Science-Pipelines/data-science-pipelines-application-component-readiness-status.md'
+            summary: A Data Science Pipelines ScheduledWorkflow controller pod owned by DSPA "{{ $labels.dspa_name }}" in namespace "{{ $labels.dspa_namespace }}" has been NotReady for more than 5 minutes
+          expr: min(max_over_time(data_science_pipelines_application_scheduledworkflow_ready[3m])) by (dspa_name, dspa_namespace) == 0
+          for: 2m
+          labels:
+            severity: info

--- a/config/monitoring/prometheus/components/prometheus-modelmesh.yaml
+++ b/config/monitoring/prometheus/components/prometheus-modelmesh.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus
+  namespace: redhat-ods-monitoring
+data:
+  recording.rules: |
+    groups:
+      - name: SLOs - Modelmesh Controller
+        rules:
+        - expr: |
+            absent(up{job=~'Modelmesh Controller'}) * 0 or vector(1)
+          labels:
+            instance: modelmesh-controller
+          record: probe_success
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[1d]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[1h]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[2h]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[30m]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[3d]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[5m]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="modelmesh-controller"}[6h]))
+          labels:
+            instance: modelmesh-controller
+          record: probe_success:burnrate6h
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-probe-modelmesh
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: SLOs-probe_success
+        rules:
+        - alert: Modelmesh Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/ModelMesh-Serving/rhods-modelmesh-controller-probe-success-burn-rate.md"
+            summary: Modelmesh Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1h{instance=~"modelmesh-controller"}) by (instance) > (14.40 * (1-0.98000))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: Modelmesh Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/ModelMesh-Serving/rhods-modelmesh-controller-probe-success-burn-rate.md"
+            summary: Modelmesh Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate6h{instance=~"modelmesh-controller"}) by (instance) > (6.00 * (1-0.98000))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: Modelmesh Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/ModelMesh-Serving/rhods-modelmesh-controller-probe-success-burn-rate.md"
+            summary: Modelmesh Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1d{instance=~"modelmesh-controller"}) by (instance) > (3.00 * (1-0.98000))
+          for: 1h
+          labels:
+            severity: warning

--- a/config/monitoring/prometheus/components/prometheus-odh-model-controller.yaml
+++ b/config/monitoring/prometheus/components/prometheus-odh-model-controller.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-recording-odh-model-controller
+  namespace: redhat-ods-monitoring
+data:
+  recording.rules: |
+    groups:
+      - name: SLOs - ODH Model Controller
+        rules:
+        - expr: |
+            absent(up{job=~'ODH Model Controller'}) * 0 or vector(1)
+          labels:
+            instance: odh-model-controller
+          record: probe_success
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[1d]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[1h]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[2h]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[30m]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[3d]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[5m]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="odh-model-controller"}[6h]))
+          labels:
+            instance: odh-model-controller
+          record: probe_success:burnrate6h
+
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-probe-odh-model-controller
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: SLOs-probe_success
+        rules:
+        - alert: ODH Model Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/ModelMesh-Serving/rhods-odh-controller-probe-success-burn-rate.md"
+            summary: ODH Model Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1h{instance=~"odh-model-controller"}) by (instance) > (14.40 * (1-0.98000))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: ODH Model Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/ModelMesh-Serving/rhods-odh-controller-probe-success-burn-rate.md"
+            summary: ODH Model Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate6h{instance=~"odh-model-controller"}) by (instance) > (6.00 * (1-0.98000))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: ODH Model Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/ModelMesh-Serving/rhods-odh-controller-probe-success-burn-rate.md"
+            summary: ODH Model Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1d{instance=~"odh-model-controller"}) by (instance) > (3.00 * (1-0.98000))
+          for: 1h
+          labels:
+            severity: warning

--- a/config/monitoring/prometheus/components/prometheus-operator.yaml
+++ b/config/monitoring/prometheus/components/prometheus-operator.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-opendatahub-operator
+  namespace: redhat-ods-monitoring
+data:
+  recording.rules: |
+    groups:
+      - name: SLOs - RHODS Operator v2
+        interval: 15m
+        rules:
+        - expr: |
+            rate(controller_runtime_reconcile_total{controller="manager", job="RHODS Metrics", result!="success"}[15m])
+          labels:
+            instance: rhods-controller
+          record: controller_runtime_reconcile_total:rate15m

--- a/config/monitoring/prometheus/components/prometheus-workbenches.yaml
+++ b/config/monitoring/prometheus/components/prometheus-workbenches.yaml
@@ -1,0 +1,182 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-recording-workbenches
+  namespace: redhat-ods-monitoring
+data:
+  recording.rules: |
+    groups:
+      - name: SLOs - Notebook Controller
+        rules:
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner", job="user_facing_endpoints_status"}[1d]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner",job="user_facing_endpoints_status"}[1h]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner", job="user_facing_endpoints_status"}[2h]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner",job="user_facing_endpoints_status"}[30m]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner", job="user_facing_endpoints_status"}[3d]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner", job="user_facing_endpoints_status"}[5m]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - min(avg_over_time(probe_success{name=~"notebook-spawner",job="user_facing_endpoints_status"}[6h]))
+          labels:
+            instance: notebook-spawner
+          record: probe_success:burnrate6h
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-pvc-workbenches
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: RHODS-PVC-Usage
+        rules:
+        - alert: User notebook pvc usage above 90%
+          annotations:
+            message: 'The user notebook {{ $labels.persistentvolumeclaim }} is using 90% of its Volume. You might want to decrease the amount of data stored on the server or you can reach out to your cluster admin to increase the storage capacity to prevent disruptions and loss of data. Please back up your data before increasing the storage limit.'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            summary: User notebook pvc usage above 90%
+          expr: kubelet_volume_stats_used_bytes{persistentvolumeclaim=~".*jupyterhub-nb-.*"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"jupyterhub-nb-.*"} > 0.9 and kubelet_volume_stats_used_bytes{persistentvolumeclaim=~".*jupyterhub-nb-.*"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"jupyterhub-nb-.*"} < 0.99
+          for: 2m
+          labels:
+            severity: warning
+            route: user-notifications
+        - alert: User notebook pvc usage at 100%
+          annotations:
+            message: 'The user notebook {{ $labels.persistentvolumeclaim }} is using 100% of its Volume. You might want to decrease the amount of data stored on the server or you can reach out to your cluster admin to increase the storage capacity to prevent disruptions and loss of data. Please back up your data before increasing the storage limit.'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/tree/main/RHODS"
+            summary: User notebook pvc usage at 100%
+          expr: kubelet_volume_stats_used_bytes{persistentvolumeclaim=~".*jupyterhub-nb-.*"}/kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"jupyterhub-nb-.*"} > 0.99
+          for: 2m
+          labels:
+            severity: warning
+            route: user-notifications
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-probe-workbenches
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: SLOs-probe_success
+        rules:
+        - alert: RHODS Jupyter Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: RHODS Jupyter Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"notebook-spawner"}) by (instance) > (14.40 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1h{instance=~"notebook-spawner"}) by (instance) > (14.40 * (1-0.98000))
+          for: 2m
+          labels:
+            severity: critical
+        - alert: RHODS Jupyter Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: RHODS Jupyter Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"notebook-spawner"}) by (instance) > (6.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate6h{instance=~"notebook-spawner"}) by (instance) > (6.00 * (1-0.98000))
+          for: 15m
+          labels:
+            severity: critical
+        - alert: RHODS Jupyter Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: RHODS Jupyter Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"notebook-spawner"}) by (instance) > (3.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1d{instance=~"notebook-spawner"}) by (instance) > (3.00 * (1-0.98000))
+          for: 1h
+          labels:
+            severity: warning
+        - alert: RHODS Jupyter Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md"
+            summary: RHODS Jupyter Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate6h{instance=~"notebook-spawner"}) by (instance) > (1.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate3d{instance=~"notebook-spawner"}) by (instance) > (1.00 * (1-0.98000))
+          for: 3h
+          labels:
+            severity: warning
+        - alert: RHODS Dashboard Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
+            summary: RHODS Dashboard Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{name=~"rhods-dashboard"}) by (name) > (14.40 * (1-0.99950))
+            and
+            sum(probe_success:burnrate1h{name=~"rhods-dashboard"}) by (name) > (14.40 * (1-0.99950))
+          for: 2m
+          labels:
+            severity: critical
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-alerting-nbc
+  namespace: redhat-ods-monitoring
+data:
+  alerting.rules: |
+    groups:
+      - name: RHODS Notebook controllers
+        rules:
+        - alert: Kubeflow notebook controller pod is not running
+          annotations:
+            message: 'Kubeflow Notebook controller is down!'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-kfnbc-notebook-controller-alert.md"
+            summary: Kubeflow notebook controller pod is not running
+          expr: absent(up{job=~'Kubeflow Notebook Controller Service Metrics'})
+          for: 5m
+          labels:
+            severity: warning
+        - alert: ODH notebook controller pod is not running
+          annotations:
+            message: 'ODH notebook controller is down!'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"
+            summary: ODH notebook controller pod is not running
+          expr: absent(up{job=~'ODH Notebook Controller Service Metrics'})
+          for: 5m
+          labels:
+            severity: warning

--- a/config/monitoring/prometheus/kustomization.yaml
+++ b/config/monitoring/prometheus/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - prometheus.yaml
+  - prometheus-secrets.yaml
+  - prometheus-deployment.yaml
+  - prometheus-pvc.yaml
+  - prometheus-service.yaml
+  - prometheus-sa.yaml
+  - prometheus-roles.yaml
+  - prometheus-scraper-rolebindings.yaml
+  - prometheus-viewer-rolebinding.yaml
+  - prometheus-route.yaml

--- a/config/monitoring/prometheus/prometheus-deployment.yaml
+++ b/config/monitoring/prometheus/prometheus-deployment.yaml
@@ -1,0 +1,288 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: prometheus
+  name: prometheus
+  namespace: redhat-ods-monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      deployment: prometheus
+  template:
+    metadata:
+      labels:
+        deployment: prometheus
+      annotations:
+        alertmanager: <alertmanager_config_hash>
+        prometheus: <prometheus_config_hash>
+    spec:
+      serviceAccountName: prometheus
+      containers:
+      - name: oauth-proxy
+        args:
+        - -provider=openshift
+        - -https-address=:9091
+        - -http-address=
+        - -email-domain=*
+        - -upstream=http://localhost:9090
+        - -openshift-service-account=prometheus
+        - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "redhat-ods-monitoring",
+          "namespace": "redhat-ods-monitoring"}'
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get",
+          "name": "redhat-ods-monitoring", "namespace": "redhat-ods-monitoring"}}'
+        - -tls-cert=/etc/tls/private/tls.crt
+        - -tls-key=/etc/tls/private/tls.key
+        - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - -cookie-secret-file=/etc/proxy/secrets/session_secret
+        - -openshift-ca=/etc/pki/tls/cert.pem
+        - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -client-id=system:serviceaccount:redhat-ods-monitoring:prometheus
+        - -skip-auth-regex=^/metrics
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        ports:
+        - containerPort: 9091
+          name: https
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: 9091
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: 9091
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: prometheus-tls
+          readOnly: false
+        - mountPath: /etc/proxy/secrets
+          name: prometheus-proxy
+          readOnly: false
+
+      - name: prometheus
+        image: registry.redhat.io/openshift4/ose-prometheus@sha256:62c89e82fdf9639eace286d11c91e6d1c3fdd3437e081ed9dce6f5ea783c660f
+        args:
+          - --storage.tsdb.retention.time=6h
+          - --storage.tsdb.min-block-duration=2h
+          - --storage.tsdb.max-block-duration=2h
+          - --storage.tsdb.path=/prometheus/data
+          - --config.file=/etc/prometheus/prometheus.yml
+          - --web.listen-address=0.0.0.0:9090
+          - --web.enable-lifecycle
+          - --web.enable-admin-api
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9090
+          name: http
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9090
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9090
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          limits:
+            cpu: 400m
+            memory: 4Gi
+          requests:
+            cpu: 200m
+            memory: 2Gi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /prometheus
+          name: prometheus-data
+        - mountPath: /etc/prometheus
+          name: prometheus-config
+        - mountPath: /var/run/secrets/kubernetes.io/scraper
+          name: prometheus-secret
+        - mountPath: /etc/prometheus/ca
+          name: prometheus-service-ca
+
+      - name: alertmanager-proxy
+        args:
+        - -provider=openshift
+        - -https-address=:10443
+        - -http-address=
+        - -email-domain=*
+        - -upstream=http://localhost:9093
+        - -openshift-service-account=prometheus
+        - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "redhat-ods-monitoring",
+          "namespace": "redhat-ods-monitoring"}'
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get",
+          "name": "redhat-ods-monitoring", "namespace": "redhat-ods-monitoring"}}'
+        - -tls-cert=/etc/tls/private/tls.crt
+        - -tls-key=/etc/tls/private/tls.key
+        - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        - -cookie-secret-file=/etc/proxy/secrets/session_secret
+        - -openshift-ca=/etc/pki/tls/cert.pem
+        - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        - -client-id=system:serviceaccount:redhat-ods-monitoring:prometheus
+        - -skip-auth-regex=^/metrics
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 10443
+          name: web
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: 10443
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthz
+            port: 10443
+            scheme: HTTPS
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          limits:
+            cpu: 100m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: alertmanager-tls
+          readOnly: false
+        - mountPath: /etc/proxy/secrets
+          name: alertmanager-proxy
+          readOnly: false
+
+      - name: alertmanager
+        resources:
+          limits:
+            cpu: 200m
+            memory: 512Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
+        args:
+          - --log.level=info
+          - --storage.path=/alertmanager
+          - --config.file=/etc/alertmanager/alertmanager.yml
+          - --web.external-url=https://<set_alertmanager_host>
+        image: registry.redhat.io/openshift4/ose-prometheus-alertmanager@sha256:b180f86ebeccbab28b05f75a570ead59fc1462a77dde648b2b1d1ebe9e33cbdb
+        imagePullPolicy: Always
+        ports:
+          - containerPort: 9093
+            name: web
+        livenessProbe:
+          httpGet:
+            path: /-/healthy
+            port: 9093
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /-/ready
+            port: 9093
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        volumeMounts:
+          - mountPath: /etc/alertmanager
+            name: alertmanager-config
+          - mountPath: /alertmanager
+            name: alertmanager-data
+
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 2000
+        runAsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000
+      terminationGracePeriodSeconds: 90
+      volumes:
+      - name: prometheus-data
+        persistentVolumeClaim:
+          claimName: prometheus-data
+      - name: alertmanager-data
+        persistentVolumeClaim:
+          claimName: "alertmanager-data"
+      - name: alertmanager-config
+        configMap:
+          defaultMode: 420
+          name: alertmanager
+      - name: prometheus-config
+        configMap:
+          defaultMode: 420
+          name: prometheus
+      - name: prometheus-secret
+        secret:
+          secretName: prometheus-secret
+      - name: prometheus-tls
+        secret:
+          defaultMode: 420
+          secretName: prometheus-tls
+      - name: alertmanager-tls
+        secret:
+          defaultMode: 420
+          secretName: alertmanager-tls
+      - name: prometheus-proxy
+        secret:
+          defaultMode: 420
+          secretName: prometheus-proxy
+      - name: alertmanager-proxy
+        secret:
+          defaultMode: 420
+          secretName: alertmanager-proxy
+      - name: prometheus-service-ca
+        configMap:
+          name: prometheus-service-ca
+          defaultMode: 420
+  strategy:
+    type: Recreate

--- a/config/monitoring/prometheus/prometheus-pvc.yaml
+++ b/config/monitoring/prometheus/prometheus-pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/config/monitoring/prometheus/prometheus-roles.yaml
+++ b/config/monitoring/prometheus/prometheus-roles.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-scraper
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routers/metrics
+  - routers/federate
+  verbs:
+  - get
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - registry/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  - services
+  - namespaces
+  verbs:
+  - list
+  - get
+  - watch

--- a/config/monitoring/prometheus/prometheus-route.yaml
+++ b/config/monitoring/prometheus/prometheus-route.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    kubernetes.io/tls-acme: 'true'
+  labels:
+    app: prometheus
+  name: prometheus
+  namespace: redhat-ods-monitoring
+spec:
+  port:
+    targetPort: https
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: reencrypt
+  to:
+    kind: Service
+    name: prometheus
+  wildcardPolicy: None

--- a/config/monitoring/prometheus/prometheus-sa.yaml
+++ b/config/monitoring/prometheus/prometheus-sa.yaml
@@ -1,0 +1,7 @@
+---
+# Create a service account for accessing prometheus data
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-reader
+  namespace: redhat-ods-monitoring

--- a/config/monitoring/prometheus/prometheus-scraper-rolebindings.yaml
+++ b/config/monitoring/prometheus/prometheus-scraper-rolebindings.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: authorization.openshift.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-scraper
+roleRef:
+  name: prometheus-scraper
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: redhat-ods-monitoring

--- a/config/monitoring/prometheus/prometheus-secrets.yaml
+++ b/config/monitoring/prometheus/prometheus-secrets.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.prometheus: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"prometheus"}}'
+      serviceaccounts.openshift.io/oauth-redirectreference.alertmanager: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"alertmanager"}}'
+  name: prometheus
+  namespace: redhat-ods-monitoring
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prometheus-secret
+  namespace: redhat-ods-monitoring
+  annotations:
+    kubernetes.io/service-account.name: prometheus
+type: kubernetes.io/service-account-token

--- a/config/monitoring/prometheus/prometheus-service.yaml
+++ b/config/monitoring/prometheus/prometheus-service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: prometheus-tls
+    prometheus.io/scheme: https
+    prometheus.io/scrape: 'true'
+  labels:
+    app: prometheus
+  name: prometheus
+  namespace: redhat-ods-monitoring
+spec:
+  ports:
+  - name: https
+    port: 9091
+    targetPort: https
+  selector:
+    deployment: prometheus
+  sessionAffinity: None
+  type: ClusterIP

--- a/config/monitoring/prometheus/prometheus-viewer-rolebinding.yaml
+++ b/config/monitoring/prometheus/prometheus-viewer-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rhods-prometheus-viewer
+subjects:
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: "<odh_monitoring_project>"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view

--- a/config/monitoring/segment/kustomization.yaml
+++ b/config/monitoring/segment/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - segment-key-config.yaml
+  - segment-key-secret.yaml

--- a/config/monitoring/segment/segment-key-config.yaml
+++ b/config/monitoring/segment/segment-key-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odh-segment-key-config
+  namespace: redhat-ods-applications
+data:
+  segmentKeyEnabled: "true"

--- a/config/monitoring/segment/segment-key-secret.yaml
+++ b/config/monitoring/segment/segment-key-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: odh-segment-key
+  namespace: redhat-ods-applications
+type: Opaque
+data:
+   segmentKey: S1JVaG9BSUVwV2xHdXo0c1dpeGFlMXZBWEtLR2xENUs=

--- a/config/partners/anaconda/base/anaconda-ce-validator-cron.yaml
+++ b/config/partners/anaconda/base/anaconda-ce-validator-cron.yaml
@@ -1,0 +1,116 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: anaconda-ce-periodic-validator
+  namespace: redhat-ods-applications
+  labels:
+    opendatahub.io/modified: "false"
+spec:
+  schedule: "0 0 * * *"
+  concurrencyPolicy: "Replace"
+  startingDeadlineSeconds: 200
+  suspend: true
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            parent: "anaconda-ce-periodic-validator"
+        spec:
+          serviceAccount: "rhods-dashboard"
+          imagePullSecrets:
+            - name: addon-managed-odh-pullsecret
+          containers:
+          - name: anaconda-ce-validator
+            image: registry.redhat.io/openshift4/ose-cli@sha256:75bf9b911b6481dcf29f7942240d1555adaa607eec7fc61bedb7f624f87c36d4
+            command:
+              - /bin/sh
+              - -c
+              - >
+                #!/bin/sh
+
+                IMAGESTREAM_NAME='s2i-minimal-notebook-anaconda'
+                CONFIGMAP_NAME='anaconda-ce-validation-result'
+                BUILDCONFIG_NAME='s2i-minimal-notebook-anaconda'
+                ANACONDA_VERSION='v0.2.2-anaconda'
+
+                function generate_imagestream() {
+                  echo '{"apiVersion":"image.openshift.io/v1","kind":"ImageStream","metadata":{"annotations":{"opendatahub.io/notebook-image-order":"10","opendatahub.io/notebook-image-desc":"Notebook with Anaconda CE tools instead of pip.","opendatahub.io/notebook-image-name":"Anaconda Commercial Edition","opendatahub.io/notebook-image-url":"https://github.com/red-hat-data-services/notebooks"},"labels":{"component.opendatahub.io/name":"jupyterhub","opendatahub.io/modified":"false","opendatahub.io/notebook-image":"true"},"name":"s2i-minimal-notebook-anaconda"},"spec":{"lookupPolicy":{"local":true},"tags":[{"name":"2023.1","annotations":{"opendatahub.io/default-image":"true","opendatahub.io/notebook-python-dependencies":"[{\"name\":\"JupyterLab\",\"version\": \"3.5\"}, {\"name\": \"Notebook\",\"version\": \"6.5\"}]","opendatahub.io/notebook-software":"[{\"name\":\"Python\",\"version\":\"v3.8\"}]","opendatahub.io/workbench-image-recommended":"true","openshift.io/imported-from":"quay.io/modh/odh-anaconda-notebook"},"from":{"kind":"DockerImage","name":"quay.io/modh/odh-anaconda-notebook@sha256:380c07bf79f5ec7d22441cde276c50b5eb2a459485cde05087837639a566ae3d"},"generation":2,"importPolicy":{"importMode":"Legacy"},"referencePolicy":{"type":"Local"}}]}}'
+                }
+
+                function create_imagestream() {
+                  generate_imagestream | oc apply -f-
+                }
+
+                function delete_imagestream() {
+                  generate_imagestream | oc delete -f-
+                }
+
+                function get_variable() {
+                  cat "/etc/secret-volume/${1}"
+                }
+
+                function verify_configmap_exists() {
+                  if ! oc get configmap "${CONFIGMAP_NAME}" &>/dev/null; then
+                    echo "Result ConfigMap doesn't exist, creating"
+                    oc create configmap "${CONFIGMAP_NAME}" --from-literal validation_result="false"
+                  fi
+                }
+
+                function write_configmap_value() {
+                  oc patch configmap "${CONFIGMAP_NAME}" -p '"data": { "validation_result": "'${1}'" }'
+                }
+
+                function write_last_valid_time() {
+                  oc patch configmap "${CONFIGMAP_NAME}" -p '"data": { "last_valid_time": "'$(date -Is)'" }'
+                }
+
+                function success() {
+                  echo "Validation succeeded, enabling image"
+                  create_imagestream
+                  verify_configmap_exists
+                  write_configmap_value true
+                  write_last_valid_time
+                }
+
+                function failure() {
+                  echo "Validation failed, disabling image"
+                  verify_configmap_exists
+                  write_configmap_value false
+                }
+
+                CURL_RESULT=$(curl -w 'RESP_CODE:%{response_code}' -IHEAD "https://repo.anaconda.cloud/repo/t/$(get_variable Anaconda_ce_key)/main/noarch/repodata.json" 2>/dev/null)
+                CURL_CODE=$(echo "${CURL_RESULT}" | grep -o 'RESP_CODE:[1-5][0-9][0-9]'| cut -d':' -f2)
+
+                echo "Validation result: ${CURL_CODE}"
+
+                if [ "${CURL_CODE}" == 200 ]; then
+                  success
+                elif [ "${CURL_CODE}" == 403 ]; then
+                  failure
+                else
+                  echo "Return code ${CURL_CODE} from validation check, possibly upstream error. Exiting."
+                  echo "Result from curl:"
+                  echo "${CURL_RESULT}"
+                fi
+
+                exit 0
+                
+            volumeMounts:
+                - name: secret-volume
+                  mountPath: /etc/secret-volume
+                  readOnly: true
+            resources:
+              limits:
+                cpu: 100m
+                memory: 256Mi
+              requests:
+                cpu: 100m
+                memory: 256Mi
+          volumes:
+            - name: secret-volume
+              secret:
+                secretName: anaconda-ce-access
+          restartPolicy: Never

--- a/config/partners/anaconda/base/kustomization.yaml
+++ b/config/partners/anaconda/base/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- anaconda-ce-validator-cron.yaml
+
+commonLabels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: anaconda-ce


### PR DESCRIPTION
- 	move RHODS ods-manifests/monitoring to rhods-operator/config/monitoring
-       move ods-manifests/partners/anaconda to rhods-oeprator/config/partner
-       to create config/monitoring/components for prometheus configmap

eventually, we will remove these from odh-manifests.

Ref: https://github.com/opendatahub-io/opendatahub-operator/issues/357

related to https://github.com/red-hat-data-services/rhods-operator/pull/43

- [ ] still need https://github.com/red-hat-data-services/odh-deployer/pull/380 then get changes in a separate PR


