### PR TITLE
Fix: odh-model-controller images are not using digest instead they are using tag for RHODS 1.33 v2

### DIFF
--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -95,7 +95,7 @@ func (k *Kserve) ReconcileComponent(owner metav1.Object, cli client.Client, sche
 		}
 		// Update image parameters for keserve
 		if dscispec.DevFlags.ManifestsUri == "" {
-			if err := deploy.ApplyImageParams(Path, dependentImageParamMap); err != nil {
+			if err := deploy.ApplyImageParams(DependentPath, dependentImageParamMap); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/RHODS-12074