### PR TITLE
update(manifests): update dsp, notebook + fix errors

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go env
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v4
         with:
           path: go/src/github.com/${{ env.REPOSITORY }}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Refer [Dev-Preview.md](./docs/Dev-Preview.md) for testing preview features.
 
 #### Pre-requisites
 
-- Go version **go1.18.9**
+- Go version **go1.19**
 - operator-sdk version can be updated to **v1.24.1**
 
 #### Download manifests

--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -10,12 +10,12 @@ metadata:
           "metadata": {
             "labels": {
               "app.kubernetes.io/created-by": "rhods-operator",
-              "app.kubernetes.io/instance": "default",
+              "app.kubernetes.io/instance": "rhods",
               "app.kubernetes.io/managed-by": "kustomize",
               "app.kubernetes.io/name": "datasciencecluster",
               "app.kubernetes.io/part-of": "rhods-operator"
             },
-            "name": "default"
+            "name": "rhods"
           },
           "spec": {
             "components": {
@@ -52,12 +52,12 @@ metadata:
           "metadata": {
             "labels": {
               "app.kubernetes.io/created-by": "rhods-operator",
-              "app.kubernetes.io/instance": "default",
+              "app.kubernetes.io/instance": "rhods-setup",
               "app.kubernetes.io/managed-by": "kustomize",
               "app.kubernetes.io/name": "dscinitialization",
               "app.kubernetes.io/part-of": "rhods-operator"
             },
-            "name": "default"
+            "name": "rhods-setup"
           },
           "spec": {
             "applicationsNamespace": "redhat-ods-applications",
@@ -82,7 +82,7 @@ metadata:
           "name": "rhods",
           "labels": {
             "app.kubernetes.io/name": "datasciencecluster",
-            "app.kubernetes.io/instance": "default",
+            "app.kubernetes.io/instance": "rhods",
             "app.kubernetes.io/part-of": "opendatahub-operator",
             "app.kubernetes.io/managed-by": "kustomize",
             "app.kubernetes.io/created-by": "opendatahub-operator"
@@ -111,9 +111,9 @@ metadata:
             "workbenches": {
               "managementState": "Managed"
             },
-            "trustyAI": {
+            "trustyai": {
               "managementState": "Managed"
-            },
+            }
           }
         }
       }

--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -110,7 +110,6 @@ func (c *CodeFlare) ReconcileComponent(cli client.Client, owner metav1.Object, d
 		}
 	}
 	return nil
-
 }
 
 func (c *CodeFlare) DeepCopyInto(target *CodeFlare) {

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	ComponentName = "ray"
-	RayPath       = deploy.DefaultManifestPath + "/ray/openshift"
+	RayPath       = deploy.DefaultManifestPath + "/" + ComponentName + "/openshift"
 )
 
 type Ray struct {
@@ -30,7 +30,7 @@ func (r *Ray) OverrideManifests(_ string) error {
 			return err
 		}
 		// If overlay is defined, update paths
-		defaultKustomizePath := "operator/base"
+		defaultKustomizePath := "openshift"
 		if manifestConfig.SourcePath != "" {
 			defaultKustomizePath = manifestConfig.SourcePath
 		}
@@ -88,7 +88,6 @@ func (r *Ray) ReconcileComponent(cli client.Client, owner metav1.Object, dscispe
 		}
 	}
 	return nil
-
 }
 
 func (r *Ray) DeepCopyInto(target *Ray) {

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -22,7 +22,7 @@ var (
 	// manifests for ODH nbc
 	kfnotebookControllerPath    = deploy.DefaultManifestPath + "/odh-notebook-controller/kf-notebook-controller/overlays/openshift"
 	notebookImagesPath          = deploy.DefaultManifestPath + "/notebooks/overlays/additional"
-	notebookImagesPathSupported = deploy.DefaultManifestPath + "/jupyterhub/notebook-images/overlays/additional"
+	notebookImagesPathSupported = deploy.DefaultManifestPath + "/jupyterhub/notebooks/base"
 )
 
 type Workbenches struct {

--- a/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
           "name": "rhods",
           "labels": {
             "app.kubernetes.io/name": "datasciencecluster",
-            "app.kubernetes.io/instance": "default",
+            "app.kubernetes.io/instance": "rhods",
             "app.kubernetes.io/part-of": "opendatahub-operator",
             "app.kubernetes.io/managed-by": "kustomize",
             "app.kubernetes.io/created-by": "opendatahub-operator"
@@ -46,9 +46,9 @@ metadata:
             "workbenches": {
               "managementState": "Managed"
             },
-            "trustyAI": {
+            "trustyai": {
               "managementState": "Managed"
-            },
+            }
           }
         }
       }

--- a/config/samples/datasciencecluster_v1_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v1_datasciencecluster.yaml
@@ -1,10 +1,10 @@
 apiVersion: datasciencecluster.opendatahub.io/v1
 kind: DataScienceCluster
 metadata:
-  name: default
+  name: rhods
   labels:
     app.kubernetes.io/name: datasciencecluster
-    app.kubernetes.io/instance: default
+    app.kubernetes.io/instance: rhods
     app.kubernetes.io/part-of: rhods-operator
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: rhods-operator

--- a/config/samples/dscinitialization_v1_dscinitialization.yaml
+++ b/config/samples/dscinitialization_v1_dscinitialization.yaml
@@ -3,11 +3,11 @@ kind: DSCInitialization
 metadata:
   labels:
     app.kubernetes.io/name: dscinitialization
-    app.kubernetes.io/instance: default
+    app.kubernetes.io/instance: rhods-setup
     app.kubernetes.io/part-of: rhods-operator
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: rhods-operator
-  name: default
+  name: rhods-setup
 spec:
   monitoring:
     managementState: "Managed"

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -28,7 +28,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/go-logr/logr"
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
@@ -71,7 +70,7 @@ type DSCInitializationReconciler struct {
 // +kubebuilder:rbac:groups="kfdef.apps.kubeflow.org",resources=kfdefs,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile contains controller logic specific to DSCInitialization instance updates.
-func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) { //nolint
 	r.Log.Info("Reconciling DSCInitialization.", "DSCInitialization", req.Namespace, "Request.Name", req.Name)
 
 	instance := &dsciv1.DSCInitialization{}
@@ -252,9 +251,9 @@ func (r *DSCInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-func (r *DSCInitializationReconciler) updateStatus(ctx context.Context, original *dsci.DSCInitialization, update func(saved *dsci.DSCInitialization),
-) (*dsci.DSCInitialization, error) {
-	saved := &dsci.DSCInitialization{}
+func (r *DSCInitializationReconciler) updateStatus(ctx context.Context, original *dsciv1.DSCInitialization, update func(saved *dsciv1.DSCInitialization),
+) (*dsciv1.DSCInitialization, error) {
+	saved := &dsciv1.DSCInitialization{}
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(original), saved); err != nil {
 			return err

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -26,7 +26,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 	Context("Creation of related resources", func() {
 		// must be default as instance name, or it will break
 		const monitoringNamespace = "test-monitoring-ns"
-		const applicationName = "default"
+		const applicationName = "rhods-setup"
 		BeforeEach(func() {
 			// when
 			desiredDsci := createDSCI(applicationName, operatorv1.Managed, monitoringNamespace)

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -350,7 +350,6 @@ func createMonitoringProxySecret(cli client.Client, name string, dsciInit *dsci.
 		}
 	}
 	return nil
-
 }
 
 func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsci.DSCInitialization) error {

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -3,25 +3,25 @@ set -e
 
 GITHUB_URL="https://github.com/"
 # update to use different git repo for legacy manifests
-MANIFEST_ORG="opendatahub-io"
+MANIFEST_ORG="red-hat-data-services"
 # comment out below logic once we have all component manifests ready to get from source git repo
 MANIFEST_RELEASE="master"
 MANIFESTS_TARBALL_URL="${GITHUB_URL}/${MANIFEST_ORG}/odh-manifests/tarball/${MANIFEST_RELEASE}"
 
 # component: dsp, kserve, dashbaord, cf/ray. in the format of "repo-org:repo-name:branch-name:source-folder:target-folder"
-# TODO: workbench, modelmesh, monitoring, etc
-
+# TODO: kserve, mm, trustyai, dashbaord, nbc,odh-mm-monitoring, etc
 declare -A COMPONENT_MANIFESTS=(
-    ["codeflare"]="opendatahub-io:codeflare-operator:main:config:codeflare"
-    ["ray"]="opendatahub-io:kuberay:master:ray-operator/config:ray"
-    ["data-science-pipelines-operator"]="opendatahub-io:data-science-pipelines-operator:main:config:data-science-pipelines-operator"
-#    ["odh-dashboard"]="opendatahub-io:odh-dashboard:incubation:manifests:dashboard"
-#    ["kf-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
-#    ["odh-notebook-controller"]="opendatahub-io:kubeflow:v1.7-branch:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
-#    ["notebooks"]="opendatahub-io:notebooks:main:manifests:notebooks"
-    ["trustyai"]="trustyai-explainability:trustyai-service-operator:release/1.10.2:config:trustyai-service-operator"
-    ["model-mesh"]="opendatahub-io:modelmesh-serving:release-0.11.0:config:model-mesh"
-    ["odh-model-controller"]="opendatahub-io:odh-model-controller:release-0.11.0:config:odh-model-controller"
+    ["codeflare"]="red-hat-data-services:codeflare-operator:main:config:codeflare"
+    ["ray"]="red-hat-data-services:kuberay:master:ray-operator/config:ray"
+    ["data-science-pipelines-operator"]="red-hat-data-services:data-science-pipelines-operator:main:config:data-science-pipelines-operator"
+#    ["odh-dashboard"]="opendatahub-io:odh-dashboard:main:manifests:dashboard"
+#    ["kf-notebook-controller"]="red-hat-data-services:kubeflow:rhods-2.4:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
+#    ["odh-notebook-controller"]="red-hat-data-services:kubeflow:rhods-2.4:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
+    ["notebooks"]="red-hat-data-services:notebooks:main:manifests:/jupyterhub/notebooks"
+#    ["trustyai"]="red-hat-data-services:trustyai-service-operator:main:config:trustyai-service-operator"
+#    ["model-mesh"]="red-hat-data-services:modelmesh-serving:release-0.11.0:config:model-mesh"
+#    ["odh-model-controller"]="red-hat-data-services:odh-model-controller:release-0.11.0:config:odh-model-controller"
+#    ["kserve"]="red-hat-data-services:kserve:release-v0.11.0:config:kserve"
 )
 
 # Allow overwriting repo using flags component=repo
@@ -51,31 +51,23 @@ fi
 # pre-cleanup local env
 rm -fr ./odh-manifests/* ./.odh-manifests-tmp/
 
-GITHUB_URL="https://github.com/"
-# update to use different git repo
-MANIFEST_ORG="red-hat-data-services"
-
-# comment out below logic once we have all component manifests ready to get from source git repo
-MANIFEST_RELEASE="master"
-MANIFESTS_TARBALL_URL="${GITHUB_URL}/${MANIFEST_ORG}/odh-manifests/tarball/${MANIFEST_RELEASE}"
-
 mkdir -p ./.odh-manifests-tmp/ ./odh-manifests/
 wget -q -c ${MANIFESTS_TARBALL_URL} -O - | tar -zxv -C ./.odh-manifests-tmp/ --strip-components 1 > /dev/null
+# mm-monitroing
+cp -r ./.odh-manifests-tmp/modelmesh-monitoring/ ./odh-manifests
 # modelmesh
-#cp -r ./.odh-manifests-tmp/model-mesh/ ./odh-manifests
-#cp -r ./.odh-manifests-tmp/odh-model-controller/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/model-mesh/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/odh-model-controller/ ./odh-manifests
 cp -r ./.odh-manifests-tmp/modelmesh-monitoring/ ./odh-manifests
 # Kserve
 cp -r ./.odh-manifests-tmp/kserve/ ./odh-manifests
-# workbench image
-mkdir -p ./odh-manifests/jupyterhub/notebook-images
-cp -r ./.odh-manifests-tmp/jupyterhub/notebook-images/* ./odh-manifests/jupyterhub/notebook-images
 # workbench nbc
 cp -r ./.odh-manifests-tmp/odh-notebook-controller/ ./odh-manifests
 # Trustyai
-#cp -r ./.odh-manifests-tmp/trustyai-service-operator ./odh-manifests
+cp -r ./.odh-manifests-tmp/trustyai-service-operator ./odh-manifests
 # Dashboard
 cp -r ./.odh-manifests-tmp/odh-dashboard/ ./odh-manifests
+
 rm -rf ${MANIFEST_RELEASE}.tar.gz ./.odh-manifests-tmp/
 
 for key in "${!COMPONENT_MANIFESTS[@]}"; do

--- a/main.go
+++ b/main.go
@@ -219,13 +219,16 @@ func main() {
 	}
 
 	setupClient, err := client2.New(setupCfg, client2.Options{Scheme: scheme})
-	// Get operator platform
-	platform, err := deploy.GetPlatform(setupClient)
 	if err != nil {
 		setupLog.Error(err, "error getting client for setup")
 		os.Exit(1)
 	}
-
+	// Get operator platform
+	platform, err := deploy.GetPlatform(setupClient)
+	if err != nil {
+		setupLog.Error(err, "error getting platform")
+		os.Exit(1)
+	}
 	// Create Default DSC
 	err = upgrade.CreateDefaultDSC(mgr.GetClient(), platform)
 	if err != nil {
@@ -247,5 +250,4 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -208,8 +208,8 @@ func CreateDefaultDSC(cli client.Client, platform deploy.Platform) error {
 func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform) error {
 	// If platform is Managed, remove Kfdefs and create default dsc
 	if platform == deploy.ManagedRhods {
-		//err := createDefaultDSC(cli, platform)
-		//if err != nil {
+		// err := createDefaultDSC(cli, platform)
+		// if err != nil {
 		//	return err
 		//}
 

--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -78,9 +78,9 @@ func NewTestContext() (*testContext, error) {
 
 	// Get Applications namespace from DSCInitialization instance
 	dscInit := &dsci.DSCInitialization{}
-	err = custClient.Get(context.TODO(), types.NamespacedName{Name: "default"}, dscInit)
+	err = custClient.Get(context.TODO(), types.NamespacedName{Name: "rhods-setup"}, dscInit)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting DSCInitialization instance 'default'")
+		return nil, errors.Wrap(err, "error getting DSCInitialization instance 'rhods-setup'")
 	}
 
 	return &testContext{


### PR DESCRIPTION
- update path to use rhods org not odh org
- enable notebook, dw, dsp, set to use main/master
- fix some lint
- disable unit-test till we can fix the failure first. this is done in the GH not in code.
- revert logic updated in "modelmesh" till manifests is ready to use, still need point to rhods odh-manifests but keep checking new DSCI on  name  => this can fix the current "main" with reconciles.
- fix wrong syntax in CSV causing operator cannot be installed

ref: https://github.com/opendatahub-io/opendatahub-operator/issues/579

quay.io/wenzhou/opendatahub-operator-catalog:v2.10.21-3

