### PR TITLE
fix: a brunch of changes for 2.4

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -33,7 +33,7 @@ func (c *CodeFlare) OverrideManifests(_ string) error {
 			return err
 		}
 		// If overlay is defined, update paths
-		defaultKustomizePath := "base"
+		defaultKustomizePath := "manifests"
 		if manifestConfig.SourcePath != "" {
 			defaultKustomizePath = manifestConfig.SourcePath
 		}
@@ -49,7 +49,7 @@ func (c *CodeFlare) GetComponentName() string {
 // Verifies that CodeFlare implements ComponentInterface.
 var _ components.ComponentInterface = (*CodeFlare)(nil)
 
-func (c *CodeFlare) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+func (c *CodeFlare) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec) error {
 	var imageParamMap = map[string]string{
 		"odh-codeflare-operator-controller-image": "RELATED_IMAGE_ODH_CODEFLARE_OPERATOR_IMAGE", // no need mcad, embedded in cfo
 		"namespace": dscispec.ApplicationsNamespace,
@@ -82,7 +82,7 @@ func (c *CodeFlare) ReconcileComponent(cli client.Client, owner metav1.Object, d
 
 		// Update image parameters only when we do not have customized manifests set
 		if dscispec.DevFlags.ManifestsUri == "" && len(c.DevFlags.Manifests) == 0 {
-			if err := deploy.ApplyParams(CodeflarePath+"/base", c.SetImageParamsMap(imageParamMap), true); err != nil {
+			if err := deploy.ApplyParams(CodeflarePath+"/bases", c.SetImageParamsMap(imageParamMap), true); err != nil {
 				return err
 			}
 		}

--- a/components/component.go
+++ b/components/component.go
@@ -1,17 +1,15 @@
 package components
 
 import (
+	"fmt"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"fmt"
-	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"os"
 	"path/filepath"
-	"strings"
-
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 )
 
 type Component struct {
@@ -35,6 +33,10 @@ type Component struct {
 
 func (c *Component) GetManagementState() operatorv1.ManagementState {
 	return c.ManagementState
+}
+
+func (c *Component) SetImageParamsMap(imageMap map[string]string) map[string]string {
+	return imageMap
 }
 
 // DevFlags defines list of fields that can be used by developers to test customizations. This is not recommended
@@ -167,8 +169,4 @@ func (c *Component) UpdatePrometheusConfig(cli client.Client, enable bool, compo
 		return err
 	}
 	return nil
-}
-
-func (c *Component) SetImageParamsMap(imageMap map[string]string) map[string]string {
-	return imageMap
 }

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -5,7 +5,7 @@ package datasciencepipelines
 import (
 	"path/filepath"
 
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -46,7 +46,7 @@ func (d *DataSciencePipelines) GetComponentName() string {
 // Verifies that Dashboard implements ComponentInterface.
 var _ components.ComponentInterface = (*DataSciencePipelines)(nil)
 
-func (d *DataSciencePipelines) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+func (d *DataSciencePipelines) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec) error {
 	var imageParamMap = map[string]string{
 		"IMAGES_APISERVER":         "RELATED_IMAGE_ODH_ML_PIPELINES_API_SERVER_IMAGE",
 		"IMAGES_ARTIFACT":          "RELATED_IMAGE_ODH_ML_PIPELINES_ARTIFACT_MANAGER_IMAGE",

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -3,10 +3,11 @@ package kserve
 
 import (
 	"fmt"
+
 	"path/filepath"
 	"strings"
 
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
@@ -70,7 +71,7 @@ func (k *Kserve) GetComponentName() string {
 // Verifies that Kserve implements ComponentInterface.
 var _ components.ComponentInterface = (*Kserve)(nil)
 
-func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec) error {
 	// paramMap for Kserve to use.
 	var imageParamMap = map[string]string{}
 
@@ -114,6 +115,7 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 			}
 		}
 	}
+
 	if err := deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
 		return err
 	}
@@ -124,7 +126,7 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 		if err != nil {
 			return err
 		}
-		// Update image parameters for odh-maodel-controller
+		// Update image parameters for odh-model-controller
 		if dscispec.DevFlags.ManifestsUri == "" && len(k.DevFlags.Manifests) == 0 {
 			if err := deploy.ApplyParams(DependentPath, k.SetImageParamsMap(dependentParamMap), false); err != nil {
 				return err
@@ -132,7 +134,7 @@ func (k *Kserve) ReconcileComponent(cli client.Client, owner metav1.Object, dsci
 		}
 	}
 
-	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, k.GetComponentName(), enabled); err != nil {
+	if err := deploy.DeployManifestsFromPath(cli, owner, DependentPath, dscispec.ApplicationsNamespace, ComponentName, enabled); err != nil {
 		if strings.Contains(err.Error(), "spec.selector") && strings.Contains(err.Error(), "field is immutable") {
 			// ignore this error
 		} else {

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -5,7 +5,7 @@ package ray
 import (
 	"path/filepath"
 
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -46,7 +46,7 @@ func (r *Ray) GetComponentName() string {
 // Verifies that Ray implements ComponentInterface.
 var _ components.ComponentInterface = (*Ray)(nil)
 
-func (r *Ray) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+func (r *Ray) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec) error {
 	var imageParamMap = map[string]string{
 		"odh-kuberay-operator-controller-image": "RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE",
 		"namespace":                             dscispec.ApplicationsNamespace,

--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -4,7 +4,7 @@ package trustyai
 import (
 	"path/filepath"
 
-	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -45,7 +45,7 @@ func (t *TrustyAI) GetComponentName() string {
 // Verifies that TrustyAI implements ComponentInterface
 var _ components.ComponentInterface = (*TrustyAI)(nil)
 
-func (t *TrustyAI) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsci.DSCInitializationSpec) error {
+func (t *TrustyAI) ReconcileComponent(cli client.Client, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec) error {
 	var imageParamMap = map[string]string{
 		"trustyaiServiceImage":  "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
 		"trustyaiOperatorImage": "RELATED_IMAGE_ODH_TRUSTYAI_OPERATOR_IMAGE",

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -18,7 +18,7 @@ var (
 	ComponentName          = "workbenches"
 	DependentComponentName = "notebooks"
 	// manifests for nbc in ODH and downstream + downstream use it for imageparams
-	notebookControllerPath = deploy.DefaultManifestPath + "/odh-notebook-controller/base"
+	notebookControllerPath = deploy.DefaultManifestPath + "/odh-notebook-controller/odh-notebook-controller/base"
 	// manifests for ODH nbc
 	kfnotebookControllerPath    = deploy.DefaultManifestPath + "/odh-notebook-controller/kf-notebook-controller/overlays/openshift"
 	notebookImagesPath          = deploy.DefaultManifestPath + "/notebooks/overlays/additional"
@@ -135,6 +135,7 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 	if enabled {
 		if dscispec.DevFlags.ManifestsUri == "" && len(w.DevFlags.Manifests) == 0 {
 			if platform == deploy.ManagedRhods || platform == deploy.SelfManagedRhods {
+				// TODO: fix for nbc new path if want to split into two params.env
 				if err := deploy.ApplyParams(notebookControllerPath, w.SetImageParamsMap(imageParamMap), false); err != nil {
 					return err
 				}

--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -11,14 +11,14 @@ MANIFESTS_TARBALL_URL="${GITHUB_URL}/${MANIFEST_ORG}/odh-manifests/tarball/${MAN
 # component: dsp, kserve, dashbaord, cf/ray. in the format of "repo-org:repo-name:branch-name:source-folder:target-folder"
 # TODO: kserve, mm, trustyai, dashbaord, nbc,odh-mm-monitoring, etc
 declare -A COMPONENT_MANIFESTS=(
-    ["codeflare"]="red-hat-data-services:codeflare-operator:main:config:codeflare"
-    ["ray"]="red-hat-data-services:kuberay:master:ray-operator/config:ray"
-    ["data-science-pipelines-operator"]="red-hat-data-services:data-science-pipelines-operator:main:config:data-science-pipelines-operator"
+    ["codeflare"]="red-hat-data-services:codeflare-operator:rhods-2.4:config:codeflare"
+    ["ray"]="red-hat-data-services:kuberay:rhods-2.4:ray-operator/config:ray"
+    ["data-science-pipelines-operator"]="red-hat-data-services:data-science-pipelines-operator:rhods-2.4:config:data-science-pipelines-operator"
 #    ["odh-dashboard"]="opendatahub-io:odh-dashboard:main:manifests:dashboard"
 #    ["kf-notebook-controller"]="red-hat-data-services:kubeflow:rhods-2.4:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
 #    ["odh-notebook-controller"]="red-hat-data-services:kubeflow:rhods-2.4:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
-    ["notebooks"]="red-hat-data-services:notebooks:main:manifests:/jupyterhub/notebooks"
-#    ["trustyai"]="red-hat-data-services:trustyai-service-operator:main:config:trustyai-service-operator"
+    ["notebooks"]="red-hat-data-services:notebooks:rhods-2.4:manifests:/jupyterhub/notebooks"
+    ["trustyai"]="red-hat-data-services:trustyai-service-operator:rhods-2.4:config:trustyai-service-operator"
 #    ["model-mesh"]="red-hat-data-services:modelmesh-serving:release-0.11.0:config:model-mesh"
 #    ["odh-model-controller"]="red-hat-data-services:odh-model-controller:release-0.11.0:config:odh-model-controller"
 #    ["kserve"]="red-hat-data-services:kserve:release-v0.11.0:config:kserve"
@@ -63,10 +63,8 @@ cp -r ./.odh-manifests-tmp/modelmesh-monitoring/ ./odh-manifests
 cp -r ./.odh-manifests-tmp/kserve/ ./odh-manifests
 # workbench nbc
 cp -r ./.odh-manifests-tmp/odh-notebook-controller/ ./odh-manifests
-# Trustyai
-cp -r ./.odh-manifests-tmp/trustyai-service-operator ./odh-manifests
 # Dashboard
-cp -r ./.odh-manifests-tmp/odh-dashboard/ ./odh-manifests
+cp -r ./.odh-manifests-tmp/odh-dashboard/ ./odh-manifests/dashboard
 
 rm -rf ${MANIFEST_RELEASE}.tar.gz ./.odh-manifests-tmp/
 

--- a/main.go
+++ b/main.go
@@ -83,7 +83,6 @@ func init() {
 	utilruntime.Must(ocuserv1.Install(scheme))
 	utilruntime.Must(ofapiv2.AddToScheme(scheme))
 	utilruntime.Must(kfdefv1.AddToScheme(scheme))
-	//+kubebuilder:scaffold:scheme
 }
 
 func main() {
@@ -167,7 +166,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	//+kubebuilder:scaffold:builder
 	// Check if user opted for disabling DSC configuration
 	_, disableDSCConfig := os.LookupEnv("DISABLE_DSC_CONFIG")
 	if !disableDSCConfig {

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -22,16 +22,15 @@ import (
 	"crypto/sha256"
 	b64 "encoding/base64"
 	"fmt"
-	"os"
-	"regexp"
-	"strings"
-
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	authv1 "k8s.io/api/rbac/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"regexp"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 )
 
 const (
@@ -40,7 +39,7 @@ const (
 )
 
 // UpdatePodSecurityRolebinding update default rolebinding which is created in namespace by manifests
-// being used by different components and sre monitoring
+// being used by different components and sre monitoring.
 func UpdatePodSecurityRolebinding(cli client.Client, serviceAccountsList []string, namespace string) error {
 	foundRoleBinding := &authv1.RoleBinding{}
 	err := cli.Get(context.TODO(), client.ObjectKey{Name: namespace, Namespace: namespace}, foundRoleBinding)

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -343,11 +343,6 @@ func ApplyParams(componentPath string, imageParamsMap map[string]string, isUpdat
 		return err
 	}
 
-	// Update namespace variable with applicationNamepsace
-	if isUpdateNamespace {
-		envMap["namespace"] = imageParamsMap["namespace"]
-	}
-
 	file, err = os.Create(envFilePath)
 	if err != nil {
 		// If create fails, try to restore the backup file

--- a/pkg/deploy/setup.go
+++ b/pkg/deploy/setup.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	// ManagedRhods defines expected addon catalogsource
+	// ManagedRhods defines expected addon catalogsource.
 	ManagedRhods Platform = "addon-managed-odh-catalog"
-	// SelfManagedRhods defines display name in csv
+	// SelfManagedRhods defines display name in csv.
 	SelfManagedRhods Platform = "Red Hat OpenShift Data Science"
 	// OpenDataHub defines display name in csv.
 	OpenDataHub Platform = "Open Data Hub Operator"

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -208,11 +208,6 @@ func CreateDefaultDSC(cli client.Client, platform deploy.Platform) error {
 func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform) error {
 	// If platform is Managed, remove Kfdefs and create default dsc
 	if platform == deploy.ManagedRhods {
-		// err := createDefaultDSC(cli, platform)
-		// if err != nil {
-		//	return err
-		//}
-
 		err := RemoveKfDefInstances(cli, platform)
 		if err != nil {
 			return err


### PR DESCRIPTION
- fix wrong path for nbc
- fix missing https://github.com/opendatahub-io/opendatahub-operator/pull/649
- enable notebook to use get_manifests
- update get_manifests to use rhods-2.4 branch
- fix lint
- cleanup code
- sync changes from ODH
- fix wrong applyimage for codeflare
- remove duplicated code

test image:
quay.io/wenzhou/opendatahub-operator-catalog:v2.10.579-30