### PR TITLE
update: monitoring

### DIFF
--- a/bundle/manifests/redhat-ods-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/redhat-ods-operator-controller-manager-metrics-service_v1_service.yaml
@@ -10,7 +10,7 @@ spec:
   - name: metrics
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8080
   selector:
     control-plane: controller-manager
 status:

--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -559,6 +559,7 @@ spec:
           resources:
           - endpoints
           verbs:
+          - get
           - list
           - watch
         - apiGroups:
@@ -1579,6 +1580,10 @@ spec:
                   initialDelaySeconds: 15
                   periodSeconds: 20
                 name: manager
+                ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP
                 readinessProbe:
                   httpGet:
                     path: /readyz

--- a/components/component.go
+++ b/components/component.go
@@ -91,7 +91,8 @@ func (c *Component) UpdatePrometheusConfig(cli client.Client, enable bool, compo
 		} `yaml:"metadata"`
 		Data struct {
 			PrometheusYML      string `yaml:"prometheus.yml"`
-			OperatorRules      string `yaml:"operator-recording.rules"`
+			OperatorRRules     string `yaml:"operator-recording.rules"`
+			OperatorARules     string `yaml:"operator-alerting.rules"`
 			DeadManSnitchRules string `yaml:"deadmanssnitch-alerting.rules"`
 			CFRRules           string `yaml:"codeflare-recording.rules"`
 			CRARules           string `yaml:"codeflare-alerting.rules"`

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,6 +41,10 @@ spec:
         image: controller:latest
         imagePullPolicy: Always
         name: manager
+        ports:
+          - containerPort: 8080
+            protocol: TCP
+            name: http 
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/config/monitoring/base/rhods-servicemonitor.yaml
+++ b/config/monitoring/base/rhods-servicemonitor.yaml
@@ -13,12 +13,10 @@ spec:
       honorLabels: true
       params:
         'match[]':
-          - '{__name__= "rhods_total_users"}'
-          - '{__name__= "rhods_active_users"}'
-          - '{__name__= "rhods_aggregate_availability"}'
+          - '{__name__= "redhat-ods-operator-controller-manager-metrics-service"}'
           - ALERTS{alertname!="DeadManSnitch", alertstate="firing"}
       path: /federate
-      port: https
+      port: http
       scheme: https
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
@@ -43,7 +41,7 @@ metadata:
 spec:
   endpoints:
     - path: /metrics
-      port: '8080'
+      port: https
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:

--- a/config/monitoring/networkpolicy/applications/applications.yaml
+++ b/config/monitoring/networkpolicy/applications/applications.yaml
@@ -25,10 +25,22 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              opendatahub.io/generated-namespace: "true"
+    - from:
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: redhat-ods-monitoring
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: openshift-monitoring
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-ingress
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redhat-ods-operator
   policyTypes:
     - Ingress

--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -8,6 +8,7 @@ data:
   prometheus.yml: |
     rule_files:
       - 'operator-recording.rules'
+      - 'operator-alerting.rules'
       - 'deadmanssnitch-alerting.rules'
 
     global:
@@ -294,7 +295,7 @@ data:
               - redhat-ods-operator
       relabel_configs:
         - source_labels: [__meta_kubernetes_service_name]
-          regex: ^(redhat-ods-operator-controller-manager-metrics)$ 
+          regex: ^(redhat-ods-operator-controller-manager-metrics-service)$ 
           target_label: kubernetes_name
           action: keep
         - source_labels: [__address__]
@@ -338,6 +339,16 @@ data:
               description: This is a DeadManSnitch to ensure RHODS monitoring and alerting pipeline is online.
               summary: Alerting DeadManSnitch
 
+  operator-alerting.rules: |
+    groups:
+      - name: RHODS operator
+        interval: 1m
+        rules:
+          - alert: RHODS Operator Aggreate Availability
+            expr: rhods_aggregate_availability <= 0
+            for: 2m
+            labels:
+              severity: critical
 
   codeflare-recording.rules: |
     groups:

--- a/config/monitoring/prometheus/base/prometheus-service.yaml
+++ b/config/monitoring/prometheus/base/prometheus-service.yaml
@@ -15,6 +15,9 @@ spec:
   - name: https
     port: 9091
     targetPort: https
+  - name: http
+    port: 9090
+    targetPort: http
   selector:
     deployment: prometheus
   sessionAffinity: None

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -10,6 +10,6 @@ spec:
   - name: metrics
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8080
   selector:
     control-plane: controller-manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -378,6 +378,7 @@ rules:
   resources:
   - endpoints
   verbs:
+  - get
   - list
   - watch
 - apiGroups:

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -147,7 +147,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="core",resources=events,verbs=get;create;watch;update;list;patch;delete
 // +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=list;watch;patch;delete
 
-// +kubebuilder:rbac:groups="core",resources=endpoints,verbs=watch;list
+// +kubebuilder:rbac:groups="core",resources=endpoints,verbs=watch;list;get
 
 // +kubebuilder:rbac:groups="core",resources=configmaps/status,verbs=get;update;patch;delete
 // +kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;create;watch;patch;delete;list


### PR DESCRIPTION

![Screenshot from 2023-10-28 17-12-32](https://github.com/red-hat-data-services/rhods-operator/assets/915053/3c00b6db-bb52-412c-a610-a211caeeb932)
  
    - add port in operator deployment which is used by SVC
    - add alerts for operator: when both UI and workbench disable == 0
    - fix wrong metric name...
    - add default networkpolicy for RHODS too
    - add missing permission
live-builder:  quay.io/wenzhou/opendatahub-operator-catalog:v2.10.28-2
![Screenshot from 2023-10-28 17-13-03](https://github.com/red-hat-data-services/rhods-operator/assets/915053/7d28aef8-254d-4a08-8be7-eed82dd288a7)

fix: https://issues.redhat.com/browse/RHODS-4050

