### PR TITLE
Revert: back to use default for DSCI instance default name

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -52,12 +52,12 @@ metadata:
           "metadata": {
             "labels": {
               "app.kubernetes.io/created-by": "rhods-operator",
-              "app.kubernetes.io/instance": "default-dsci",
+              "app.kubernetes.io/instance": "default",
               "app.kubernetes.io/managed-by": "kustomize",
               "app.kubernetes.io/name": "dscinitialization",
               "app.kubernetes.io/part-of": "rhods-operator"
             },
-            "name": "default-dsci"
+            "name": "default"
           },
           "spec": {
             "applicationsNamespace": "redhat-ods-applications",

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -135,7 +135,7 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 	// Get monitoring namespace
 	dscInit := &dsciv1.DSCInitialization{}
 	err = cli.Get(context.TODO(), client.ObjectKey{
-		Name: "default-dsci",
+		Name: "default",
 	}, dscInit)
 	if err != nil {
 		return err

--- a/config/samples/dscinitialization_v1_dscinitialization.yaml
+++ b/config/samples/dscinitialization_v1_dscinitialization.yaml
@@ -3,11 +3,11 @@ kind: DSCInitialization
 metadata:
   labels:
     app.kubernetes.io/name: dscinitialization
-    app.kubernetes.io/instance: default-dsci
+    app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: rhods-operator
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: rhods-operator
-  name: default-dsci
+  name: default
 spec:
   monitoring:
     managementState: "Managed"

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -79,14 +79,14 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	// Second check if default instance not exists, return error
 	// TODO: update logic if we support multiple DSCI CR or different name
-	defaultDSCI := types.NamespacedName{Name: "default-dsci"}
+	defaultDSCI := types.NamespacedName{Name: "default"}
 	err := r.Client.Get(ctx, defaultDSCI, instance)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			// DSCInitialization instance not found
 			return ctrl.Result{}, nil
 		}
-		r.Log.Error(err, "Failed to retrieve DSCInitialization resource.", "DSCInitialization", req.Namespace, "Request.Name", "default-dsci")
+		r.Log.Error(err, "Failed to retrieve DSCInitialization resource.", "DSCInitialization", req.Namespace, "Request.Name", "default")
 		r.Recorder.Eventf(instance, corev1.EventTypeWarning, "DSCInitializationReconcileError", "Failed to retrieve DSCInitialization instance default")
 		return ctrl.Result{}, err
 	}

--- a/controllers/dscinitialization/dscinitialization_test.go
+++ b/controllers/dscinitialization/dscinitialization_test.go
@@ -26,7 +26,7 @@ var _ = Describe("DataScienceCluster initialization", func() {
 	Context("Creation of related resources", func() {
 		// must be default as instance name, or it will break
 		const monitoringNamespace = "test-monitoring-ns"
-		const applicationName = "default-dsci"
+		const applicationName = "default"
 		BeforeEach(func() {
 			// when
 			desiredDsci := createDSCI(applicationName, operatorv1.Managed, monitoringNamespace)

--- a/main.go
+++ b/main.go
@@ -177,7 +177,7 @@ func main() {
 				APIVersion: "dscinitialization.opendatahub.io/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "default-dsci",
+				Name: "default",
 			},
 			Spec: dsci.DSCInitializationSpec{
 				ApplicationsNamespace: dscApplicationsNamespace,

--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -79,9 +79,9 @@ func NewTestContext() (*testContext, error) {
 
 	// Get Applications namespace from DSCInitialization instance
 	dscInit := &dsci.DSCInitialization{}
-	err = custClient.Get(context.TODO(), types.NamespacedName{Name: "default-dsci"}, dscInit)
+	err = custClient.Get(context.TODO(), types.NamespacedName{Name: "default"}, dscInit)
 	if err != nil {
-		return nil, errors.Wrap(err, "error getting DSCInitialization instance 'default-dsci'")
+		return nil, errors.Wrap(err, "error getting DSCInitialization instance 'default'")
 	}
 
 	return &testContext{


### PR DESCRIPTION
ref: https://gitlab.cee.redhat.com/data-hub/rhods-cpaas-midstream/-/merge_requests/1355