### PR TITLE
update(monitoring): metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-IMAGE_OWNER ?= wenzhou
-VERSION ?= 2.11.9-13
+IMAGE_OWNER ?= opendatahub
+VERSION ?= 2.4.0
 # IMAGE_TAG_BASE defines the opendatahub.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #
@@ -12,7 +12,7 @@ VERSION ?= 2.11.9-13
 # opendatahub.io/opendatahub-operator-bundle:$VERSION and opendatahub.io/opendatahub-operator-catalog:$VERSION.
 IMAGE_TAG_BASE ?= quay.io/$(IMAGE_OWNER)/opendatahub-operator
 # Update IMG to a variable, to keep it consistent across versions for OpenShift CI
-IMG ?= $(IMAGE_TAG_BASE):dev-$(VERSION) #REPLACE_IMAGE
+IMG ?= REPLACE_IMAGE
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-IMAGE_OWNER ?= opendatahub
-VERSION ?= 2.4.0
+IMAGE_OWNER ?= wenzhou
+VERSION ?= 2.11.9-13
 # IMAGE_TAG_BASE defines the opendatahub.io namespace and part of the image name for remote images.
 # This variable is used to construct full image tags for bundle and catalog images.
 #
@@ -12,7 +12,7 @@ VERSION ?= 2.4.0
 # opendatahub.io/opendatahub-operator-bundle:$VERSION and opendatahub.io/opendatahub-operator-catalog:$VERSION.
 IMAGE_TAG_BASE ?= quay.io/$(IMAGE_OWNER)/opendatahub-operator
 # Update IMG to a variable, to keep it consistent across versions for OpenShift CI
-IMG ?= REPLACE_IMAGE
+IMG ?= $(IMAGE_TAG_BASE):dev-$(VERSION) #REPLACE_IMAGE
 # BUNDLE_IMG defines the image:tag used for the bundle.
 # You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)

--- a/components/component.go
+++ b/components/component.go
@@ -92,7 +92,6 @@ func (c *Component) UpdatePrometheusConfig(cli client.Client, enable bool, compo
 		Data struct {
 			PrometheusYML      string `yaml:"prometheus.yml"`
 			OperatorRRules     string `yaml:"operator-recording.rules"`
-			OperatorARules     string `yaml:"operator-alerting.rules"`
 			DeadManSnitchRules string `yaml:"deadmanssnitch-alerting.rules"`
 			CFRRules           string `yaml:"codeflare-recording.rules"`
 			CRARules           string `yaml:"codeflare-alerting.rules"`

--- a/config/monitoring/base/rhods-prometheusrules.yaml
+++ b/config/monitoring/base/rhods-prometheusrules.yaml
@@ -1,5 +1,7 @@
 # rhods_aggregate_availability, rhods_total_users, rhods_actvie_users should not be needed
 # they should be from traditional prometheus pod but from prometheus operator
+# but to get PSI work with some, put it here
+# TODO: revisit if when we decomision customized prometheus instance
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -31,5 +33,17 @@ spec:
         instance: jupyter-notebooks
     - record: cluster:usage:consumption:rhods:cpu_limits_runtime
       expr: sum(kube_pod_container_resource_limits{namespace="rhods-notebooks",resource="cpu", container=~"jupyter-nb-.*"} * on(pod) kube_pod_status_phase{phase="Running", namespace="rhods-notebooks"})
+      labels:
+        instance: jupyter-notebooks
+    - record: rhods_total_users
+      expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
+      labels:
+        instance: jupyter-notebooks
+    - record: rhods_active_users
+      expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
+      labels:
+        instance: jupyter-notebooks
+    - record: rhods_aggregate_availability
+      expr: ((min(probe_success{name=~"rhods-dashboard|notebook-spawner"}) by (name) or on() vector(0)) or label_replace(min(probe_success{name=~"rhods-dashboard|notebook-spawner"}), "name", "combined", "name", ".*"))
       labels:
         instance: jupyter-notebooks

--- a/config/monitoring/base/rhods-prometheusrules.yaml
+++ b/config/monitoring/base/rhods-prometheusrules.yaml
@@ -33,11 +33,3 @@ spec:
       expr: sum(kube_pod_container_resource_limits{namespace="rhods-notebooks",resource="cpu", container=~"jupyter-nb-.*"} * on(pod) kube_pod_status_phase{phase="Running", namespace="rhods-notebooks"})
       labels:
         instance: jupyter-notebooks
-    - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
-      record: rhods_total_users
-      labels:
-        instance: jupyter-notebooks
-    - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
-      record: rhods_active_users
-      labels:
-        instance: jupyter-notebooks

--- a/config/monitoring/base/rhods-prometheusrules.yaml
+++ b/config/monitoring/base/rhods-prometheusrules.yaml
@@ -10,15 +10,35 @@ spec:
   groups:
   - name: rhods-usage.rules
     rules:
+    - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
+      record: rhods_total_users
+      labels:
+        instance: jupyter-notebooks
+    - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
+      record: rhods_active_users
+      labels:
+        instance: jupyter-notebooks
     - record: cluster:usage:consumption:rhods:cpu:seconds:rate1h
       expr: sum(rate(container_cpu_usage_seconds_total{container="",pod=~"jupyter-nb.*",namespace="rhods-notebooks"}[1h]))
+      labels:
+        instance: jupyter-notebooks
     - record: cluster:usage:consumption:rhods:pod:up
       expr: count(kube_pod_container_status_ready{namespace="rhods-notebooks", pod=~"jupyter-nb.*",container=~"jupyter-nb-.*"}==1)
+      labels:
+        instance: jupyter-notebooks
     - record: cluster:usage:consumption:rhods:active_users
       expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
       labels:
         instance: jupyter-notebooks
     - record: cluster:usage:consumption:rhods:cpu_requests_runtime
       expr: sum(kube_pod_container_resource_requests{namespace="rhods-notebooks",resource="cpu", container=~"jupyter-nb-.*"} * on(pod) kube_pod_status_phase{phase="Running", namespace="rhods-notebooks"})
+      labels:
+        instance: jupyter-notebooks
     - record: cluster:usage:consumption:rhods:cpu_limits_runtime
       expr: sum(kube_pod_container_resource_limits{namespace="rhods-notebooks",resource="cpu", container=~"jupyter-nb-.*"} * on(pod) kube_pod_status_phase{phase="Running", namespace="rhods-notebooks"})
+      labels:
+        instance: jupyter-notebooks
+    - record: rhods_aggregate_availability
+      expr: ((min(probe_success{name=~"rhods-dashboard|notebook-spawner"}) by (name) or on() vector(0)) or label_replace(min(probe_success{name=~"rhods-dashboard|notebook-spawner"}), "name", "combined", "name", ".*"))
+      labels:
+        instance: jupyter-notebooks

--- a/config/monitoring/base/rhods-prometheusrules.yaml
+++ b/config/monitoring/base/rhods-prometheusrules.yaml
@@ -1,3 +1,6 @@
+# rhods_aggregate_availability, rhods_total_users, rhods_actvie_users should not be needed
+# they should be from traditional prometheus pod but from prometheus operator
+---
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -10,14 +13,6 @@ spec:
   groups:
   - name: rhods-usage.rules
     rules:
-    - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
-      record: rhods_total_users
-      labels:
-        instance: jupyter-notebooks
-    - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
-      record: rhods_active_users
-      labels:
-        instance: jupyter-notebooks
     - record: cluster:usage:consumption:rhods:cpu:seconds:rate1h
       expr: sum(rate(container_cpu_usage_seconds_total{container="",pod=~"jupyter-nb.*",namespace="rhods-notebooks"}[1h]))
       labels:
@@ -40,5 +35,13 @@ spec:
         instance: jupyter-notebooks
     - record: rhods_aggregate_availability
       expr: ((min(probe_success{name=~"rhods-dashboard|notebook-spawner"}) by (name) or on() vector(0)) or label_replace(min(probe_success{name=~"rhods-dashboard|notebook-spawner"}), "name", "combined", "name", ".*"))
+      labels:
+        instance: jupyter-notebooks
+    - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
+      record: rhods_total_users
+      labels:
+        instance: jupyter-notebooks
+    - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
+      record: rhods_active_users
       labels:
         instance: jupyter-notebooks

--- a/config/monitoring/base/rhods-prometheusrules.yaml
+++ b/config/monitoring/base/rhods-prometheusrules.yaml
@@ -33,10 +33,6 @@ spec:
       expr: sum(kube_pod_container_resource_limits{namespace="rhods-notebooks",resource="cpu", container=~"jupyter-nb-.*"} * on(pod) kube_pod_status_phase{phase="Running", namespace="rhods-notebooks"})
       labels:
         instance: jupyter-notebooks
-    - record: rhods_aggregate_availability
-      expr: ((min(probe_success{name=~"rhods-dashboard|notebook-spawner"}) by (name) or on() vector(0)) or label_replace(min(probe_success{name=~"rhods-dashboard|notebook-spawner"}), "name", "combined", "name", ".*"))
-      labels:
-        instance: jupyter-notebooks
     - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
       record: rhods_total_users
       labels:

--- a/config/monitoring/base/rhods-servicemonitor.yaml
+++ b/config/monitoring/base/rhods-servicemonitor.yaml
@@ -13,7 +13,9 @@ spec:
       honorLabels: true
       params:
         'match[]':
-          - '{__name__= "redhat-ods-operator-controller-manager-metrics-service"}'
+          - '{__name__= "rhods_total_users"}'
+          - '{__name__= "rhods_aggregate_availability"}'
+          - '{__name__= "rhods_active_users"}'
           - ALERTS{alertname!="DeadManSnitch", alertstate="firing"}
       path: /federate
       port: http
@@ -46,6 +48,9 @@ spec:
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
         insecureSkipVerify: true
+      params:
+        'match[]':
+          - '{__name__= "redhat-ods-operator-controller-manager-metrics-service"}'
   namespaceSelector:
     matchNames:
       - redhat-ods-operator

--- a/config/monitoring/base/rhods-servicemonitor.yaml
+++ b/config/monitoring/base/rhods-servicemonitor.yaml
@@ -18,7 +18,7 @@ spec:
           - '{__name__= "rhods_active_users"}'
           - ALERTS{alertname!="DeadManSnitch", alertstate="firing"}
       path: /federate
-      port: http
+      port: https
       scheme: https
       tlsConfig:
         caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
@@ -91,7 +91,7 @@ spec:
       bearerTokenSecret:
         key: ""
       path: /federate
-      port: metrics
+      port: web
       scheme: https
       tlsConfig:
         ca: {}

--- a/config/monitoring/base/rhods-servicemonitor.yaml
+++ b/config/monitoring/base/rhods-servicemonitor.yaml
@@ -33,34 +33,37 @@ spec:
       app: prometheus
 ---
 # servicemonitoring for rhods operator
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: rhods-controller-manager-metrics-monitor
-  namespace: redhat-ods-operator
-spec:
-  endpoints:
-    - path: /metrics
-      port: https
-      scheme: https
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      tlsConfig:
-        insecureSkipVerify: true
-      params:
-        'match[]':
-          - '{__name__= "redhat-ods-operator-controller-manager-metrics-service"}'
-  namespaceSelector:
-    matchNames:
-      - redhat-ods-operator
-  selector:
-    matchLabels:
-      control-plane: controller-manager
+# this is not in use, we need to implement operator metrics in logic first
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   labels:
+#     control-plane: controller-manager
+#   name: rhods-controller-manager-metrics-monitor
+#   namespace: redhat-ods-operator
+# spec:
+#   endpoints:
+#     - path: /metrics
+#       port: metrics
+#       scheme: https
+#       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+#       tlsConfig:
+#         insecureSkipVerify: true
+#       params:
+#         'match[]':
+#           - '{__name__= "redhat-ods-operator-controller-manager-metrics-service"}'
+#   namespaceSelector:
+#     matchNames:
+#       - redhat-ods-operator
+#   selector:
+#     matchLabels:
+#       control-plane: controller-manager
 
 ---
 # servicemonitoring for openshift-monitoring scrap
 # move from modelmesh-monitoring
+# this one is duplicated as the old modelmesh-federated-metrics
+# in order to keep metrics there if user set modelmesh to Removed
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/config/monitoring/networkpolicy/monitoring/monitoring.yaml
+++ b/config/monitoring/networkpolicy/monitoring/monitoring.yaml
@@ -2,6 +2,8 @@
 # the services residing in redhat-ods-monitoring. namespaceSelector
 # ensures that traffic from only the desired namespaces is allowed
 # 9114 for blackbox or user_facing_endpoints* all down
+# 9115 for blackbox health
+# 10443 and 9091 for web
 ---
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
@@ -32,6 +34,15 @@ spec:
               kubernetes.io/metadata.name: openshift-monitoring
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: redhat-ods-operator
+        - namespaceSelector:
+            matchLabels:
               opendatahub.io/generated-namespace: "true"
+  egress:
+  - {}
   policyTypes:
     - Ingress
+    - Egress

--- a/config/monitoring/networkpolicy/operator/operator.yaml
+++ b/config/monitoring/networkpolicy/operator/operator.yaml
@@ -18,6 +18,9 @@ spec:
               kubernetes.io/metadata.name: openshift-monitoring
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: openshift-user-workload-monitoring
+        - namespaceSelector:
+            matchLabels:
               opendatahub.io/generated-namespace: "true"
   policyTypes:
     - Ingress

--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -8,7 +8,6 @@ data:
   prometheus.yml: |
     rule_files:
       - 'operator-recording.rules'
-      - 'operator-alerting.rules'
       - 'deadmanssnitch-alerting.rules'
 
     global:
@@ -343,18 +342,6 @@ data:
               description: This is a DeadManSnitch to ensure RHODS monitoring and alerting pipeline is online.
               summary: Alerting DeadManSnitch
 
-  operator-alerting.rules: |
-    groups:
-      - name: RHODS operator
-        interval: 1m
-        rules:
-          - alert: RHODS Operator Aggreate Availability
-            expr: rhods_aggregate_availability <= 0
-            for: 2m
-            labels:
-              severity: info
-              namespace: redhat-ods-applicataions
-
   codeflare-recording.rules: |
     groups:
       - name: SLOs - MCAD Controller
@@ -435,7 +422,7 @@ data:
 
   codeflare-alerting.rules: |
     groups:
-      - name: SLOs-probe_success
+      - name: SLOs-probe_success_codeflare
         rules:
         - alert: CodeFlare Operator Probe Success Burn Rate
           annotations:
@@ -644,7 +631,7 @@ data:
           labels:
             severity: warning
             namespace: redhat-ods-applications
-      - name: SLOs-probe_success
+      - name: SLOs-probe_success_dashboard
         rules:
         - alert: RHODS Dashboard Probe Success Burn Rate
           annotations:
@@ -847,7 +834,7 @@ data:
           labels:
             severity: info
             namespace: redhat-ods-applications
-      - name: SLOs-probe_success
+      - name: SLOs-probe_success_dsp
         rules:
         - alert: Data Science Pipelines Operator Probe Success Burn Rate
           annotations:
@@ -978,7 +965,7 @@ data:
 
   model-mesh-alerting.rules: |
     groups:
-      - name: SLOs-probe_success
+      - name: SLOs-probe_success_modelmesh
         rules:
         - alert: Modelmesh Controller Probe Success Burn Rate
           annotations:
@@ -1067,7 +1054,7 @@ data:
 
   odh-model-controller-alerting.rules: |
     groups:
-      - name: SLOs-probe_success
+      - name: SLOs-probe_success_model_controller
         rules:
         - alert: ODH Model Controller Probe Success Burn Rate
           annotations:
@@ -1163,6 +1150,44 @@ data:
             instance: notebook-spawner
           record: probe_success:burnrate6h
 
+      - name: Usage Metrics
+        rules:
+        - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
+          record: rhods_total_users
+          labels:
+            instance: jupyter-notebooks
+        - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
+          record: rhods_active_users
+          labels:
+            instance: jupyter-notebooks
+        - record: cluster:usage:consumption:rhods:cpu:seconds:rate1h
+          expr: sum(rate(container_cpu_usage_seconds_total{container="",pod=~"jupyter-nb.*",namespace="rhods-notebooks"}[1h]))
+          labels:
+            instance: jupyter-notebooks
+        - record: cluster:usage:consumption:rhods:pod:up
+          expr: count(kube_pod_container_status_ready{namespace="rhods-notebooks", pod=~"jupyter-nb.*",container=~"jupyter-nb-.*"}==1)
+          labels:
+            instance: jupyter-notebooks
+        - record: cluster:usage:consumption:rhods:active_users
+          expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
+          labels:
+            instance: jupyter-notebooks
+        - record: cluster:usage:consumption:rhods:cpu_requests_runtime
+          expr: sum(kube_pod_container_resource_requests{namespace="rhods-notebooks",resource="cpu", container=~"jupyter-nb-.*"} * on(pod) kube_pod_status_phase{phase="Running", namespace="rhods-notebooks"})
+          labels:
+            instance: jupyter-notebooks
+        - record: cluster:usage:consumption:rhods:cpu_limits_runtime
+          expr: sum(kube_pod_container_resource_limits{namespace="rhods-notebooks",resource="cpu", container=~"jupyter-nb-.*"} * on(pod) kube_pod_status_phase{phase="Running", namespace="rhods-notebooks"})
+          labels:
+            instance: jupyter-notebooks
+        
+      - name: Availability Metrics
+        rules:
+        - expr: ((min(probe_success{name=~"rhods-dashboard|notebook-spawner"}) by (name) or on() vector(0)) or label_replace(min(probe_success{name=~"rhods-dashboard|notebook-spawner"}), "name", "combined", "name", ".*"))
+          record: rhods_aggregate_availability
+          labels:
+            instance: jupyter-notebooks
+
   workbenches-alerting.rules: |
     groups:
       - name: RHODS-PVC-Usage
@@ -1187,24 +1212,31 @@ data:
           labels:
             severity: warning
             route: user-notifications
-      
-      - name: Usage Metrics
-        rules:
-        - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"})
-          record: rhods_total_users
-          labels:
-            instance: jupyter-notebooks
-        - expr: count(kube_statefulset_replicas{namespace=~"rhods-notebooks", statefulset=~"jupyter-nb-.*"} ==1)
-          record: rhods_active_users
-          labels:
-            instance: jupyter-notebooks
 
-      - name: Availability Metrics
+      - name: RHODS Notebook controllers
         rules:
-        - expr: ((min(probe_success{name=~"rhods-dashboard|notebook-spawner"}) by (name) or on() vector(0)) or label_replace(min(probe_success{name=~"rhods-dashboard|notebook-spawner"}), "name", "combined", "name", ".*"))
-          record: rhods_aggregate_availability
+        - alert: Kubeflow notebook controller pod is not running
+          annotations:
+            message: 'Kubeflow Notebook controller is down!'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-kfnbc-notebook-controller-alert.md"
+            summary: Kubeflow notebook controller pod is not running
+          expr: absent(up{job=~'Kubeflow Notebook Controller Service Metrics'})
+          for: 5m
+          labels:
+            severity: warning
+            namespace: redhat-ods-applications
+        - alert: ODH notebook controller pod is not running
+          annotations:
+            message: 'ODH notebook controller is down!'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"
+            summary: ODH notebook controller pod is not running
+          expr: absent(up{job=~'ODH Notebook Controller Service Metrics'})
+          for: 5m
+          labels:
+            severity: warning
+            namespace: redhat-ods-applications
 
-      - name: SLOs-probe_success
+      - name: SLOs-probe_success_workbench
         rules:
         - alert: RHODS Jupyter Probe Success Burn Rate
           annotations:
@@ -1270,27 +1302,4 @@ data:
           for: 2m
           labels:
             severity: critical
-            namespace: redhat-ods-applications
-
-      - name: RHODS Notebook controllers
-        rules:
-        - alert: Kubeflow notebook controller pod is not running
-          annotations:
-            message: 'Kubeflow Notebook controller is down!'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-kfnbc-notebook-controller-alert.md"
-            summary: Kubeflow notebook controller pod is not running
-          expr: absent(up{job=~'Kubeflow Notebook Controller Service Metrics'})
-          for: 5m
-          labels:
-            severity: warning
-            namespace: redhat-ods-applications
-        - alert: ODH notebook controller pod is not running
-          annotations:
-            message: 'ODH notebook controller is down!'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"
-            summary: ODH notebook controller pod is not running
-          expr: absent(up{job=~'ODH Notebook Controller Service Metrics'})
-          for: 5m
-          labels:
-            severity: warning
             namespace: redhat-ods-applications

--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -1290,16 +1290,4 @@ data:
           labels:
             severity: warning
             instance: notebook-spawner
-        - alert: RHODS Dashboard Probe Success Burn Rate
-          annotations:
-            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
-            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
-            summary: RHODS Dashboard Probe Success Burn Rate
-          expr: |
-            sum(probe_success:burnrate5m{name=~"rhods-dashboard"}) by (name) > (14.40 * (1-0.99950))
-            and
-            sum(probe_success:burnrate1h{name=~"rhods-dashboard"}) by (name) > (14.40 * (1-0.99950))
-          for: 2m
-          labels:
-            severity: critical
-            namespace: redhat-ods-applications
+        

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -128,6 +128,7 @@ func configureAlertManager(ctx context.Context, dsciInit *dsci.DSCInitialization
 		return fmt.Errorf("error getting console route URL : %v", err)
 	}
 	if strings.Contains(consolelinkDomain, "devshift.org") {
+		r.Log.Info("inject alertmanage-configs.yaml for dev mode1")
 		err = common.ReplaceStringsInFile(filepath.Join(alertManagerPath, "alertmanager-configs.yaml"),
 			map[string]string{
 				"@devshift.net": "@rhmw.io",
@@ -138,7 +139,7 @@ func configureAlertManager(ctx context.Context, dsciInit *dsci.DSCInitialization
 		}
 	}
 	if strings.Contains(consolelinkDomain, "aisrhods") {
-		r.Log.Info("inject alertmanage-configs.yaml for dev mode")
+		r.Log.Info("inject alertmanage-configs.yaml for dev mode2")
 		err = common.ReplaceStringsInFile(filepath.Join(alertManagerPath, "alertmanager-configs.yaml"),
 			map[string]string{
 				"receiver: PagerDuty": "receiver: alerts-sink",

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -138,6 +138,7 @@ func configureAlertManager(ctx context.Context, dsciInit *dsci.DSCInitialization
 		}
 	}
 	if strings.Contains(consolelinkDomain, "aisrhods") {
+		r.Log.Info("inject alertmanage-configs.yaml for dev mode")
 		err = common.ReplaceStringsInFile(filepath.Join(alertManagerPath, "alertmanager-configs.yaml"),
 			map[string]string{
 				"receiver: PagerDuty": "receiver: alerts-sink",

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -90,7 +90,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 						Labels: map[string]string{
 							"opendatahub.io/generated-namespace": "true",
 							"pod-security.kubernetes.io/enforce": "baseline",
-							"openshift.io/cluster-monitoring": "true",
+							"openshift.io/cluster-monitoring":    "true",
 						},
 					},
 				}
@@ -105,7 +105,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 			}
 		} else { // force to patch monitoring namespace with label for cluster-monitoring
 			r.Log.Info("Patching monitoring namespace for Managed cluster", "name", monitoringName)
-			lablePatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true", "pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}` 
+			lablePatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true", "pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}`
 
 			err = r.Patch(ctx, foundMonitoringNamespace, client.RawPatch(types.MergePatchType, []byte(lablePatch)))
 			if err != nil {

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -69,7 +69,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 		}
 	} else if dscInit.Spec.Monitoring.ManagementState == operatorv1.Managed {
 		r.Log.Info("Patching application namespace for Managed cluster", "name", name)
-		lablePatch := `{"metadata":{"labels":{"openshift.io/user-monitoring":"true","pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}` //nolint
+		lablePatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true","pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}` //nolint
 		err = r.Patch(ctx, foundNamespace, client.RawPatch(types.MergePatchType,
 			[]byte(lablePatch)))
 		if err != nil {

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -90,7 +90,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 						Labels: map[string]string{
 							"opendatahub.io/generated-namespace": "true",
 							"pod-security.kubernetes.io/enforce": "baseline",
-							"openshift.io/user-monitoring": "true",
+							"openshift.io/cluster-monitoring": "true",
 						},
 					},
 				}
@@ -105,7 +105,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 			}
 		} else { // force to patch monitoring namespace with label for cluster-monitoring
 			r.Log.Info("Patching monitoring namespace for Managed cluster", "name", monitoringName)
-			lablePatch := `{"metadata":{"labels":{"openshift.io/user-monitoring":"true", "pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}` 
+			lablePatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true", "pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}` 
 
 			err = r.Patch(ctx, foundMonitoringNamespace, client.RawPatch(types.MergePatchType, []byte(lablePatch)))
 			if err != nil {

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -69,7 +69,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 		}
 	} else if dscInit.Spec.Monitoring.ManagementState == operatorv1.Managed {
 		r.Log.Info("Patching application namespace for Managed cluster", "name", name)
-		lablePatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true","pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}` //nolint
+		lablePatch := `{"metadata":{"labels":{"openshift.io/user-monitoring":"true","pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}` //nolint
 		err = r.Patch(ctx, foundNamespace, client.RawPatch(types.MergePatchType,
 			[]byte(lablePatch)))
 		if err != nil {
@@ -90,7 +90,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 						Labels: map[string]string{
 							"opendatahub.io/generated-namespace": "true",
 							"pod-security.kubernetes.io/enforce": "baseline",
-							"openshift.io/cluster-monitoring":    "true",
+							"openshift.io/user-monitoring": "true",
 						},
 					},
 				}
@@ -105,7 +105,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 			}
 		} else { // force to patch monitoring namespace with label for cluster-monitoring
 			r.Log.Info("Patching monitoring namespace for Managed cluster", "name", monitoringName)
-			lablePatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true","pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}` //nolint
+			lablePatch := `{"metadata":{"labels":{"openshift.io/user-monitoring":"true", "pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}` 
 
 			err = r.Patch(ctx, foundMonitoringNamespace, client.RawPatch(types.MergePatchType, []byte(lablePatch)))
 			if err != nil {
@@ -118,7 +118,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 	if dscInit.Spec.Monitoring.ManagementState == operatorv1.Managed {
 		operatorNS := "redhat-ods-operator"
 		r.Log.Info("Patching operator namespace for Managed cluster", "name", operatorNS)
-		lablePatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true","pod-security.kubernetes.io/enforce":"baseline"}}}`
+		lablePatch := `{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"baseline"}}}`
 		operatorNamespace := &corev1.Namespace{}
 		if err := r.Get(ctx, client.ObjectKey{Name: operatorNS}, operatorNamespace); err != nil {
 			return err


### PR DESCRIPTION
- add log in pod for QE to see it is dev mode cluster 
- add two metrics: i do not think they are used in this config but they are presented in v1 config , so i add back
ref: ref: https://issues.redhat.com/browse/RHODS-12867
## new
live build:  quay.io/wenzhou/opendatahub-operator-catalog:v2.11.9-13

![Screenshot from 2023-11-12 08-28-46](https://github.com/red-hat-data-services/rhods-operator/assets/915053/32cda5ca-9fd4-45d6-9538-5a57a0a8d6f9)
matches


![Screenshot from 2023-11-12 08-28-38](https://github.com/red-hat-data-services/rhods-operator/assets/915053/30486c6b-2776-4fa0-bcce-7ea40c279be7)

fixed duplicated dashboard alerts
![Screenshot from 2023-11-12 09-50-43](https://github.com/red-hat-data-services/rhods-operator/assets/915053/36b1d725-5f3e-4444-9bd0-4bc6b8890ebf)

## old
local build:  quay.io/wenzhou/opendatahub-operator-catalog:v2.11.9-0

![Screenshot from 2023-11-09 08-50-16](https://github.com/red-hat-data-services/rhods-operator/assets/915053/5f8c10c2-a5c8-4352-90af-75fd47295b26)
![Screenshot from 2023-11-09 08-50-00](https://github.com/red-hat-data-services/rhods-operator/assets/915053/4271acdd-55d5-48b7-8455-aacd893d9d78)
![Screenshot from 2023-11-09 12-18-58](https://github.com/red-hat-data-services/rhods-operator/assets/915053/d733becb-4942-4820-a49f-e9497e1a2a99)

![Screenshot from 2023-11-09 14-34-45](https://github.com/red-hat-data-services/rhods-operator/assets/915053/ce2dfa96-3c0f-47a8-b6c2-ddc85427c5e4)
