### PR TITLE
fix(monitoring): add missing role and rolebinding for prometheus

### DIFF
--- a/config/monitoring/base/rhods-prometheus-role.yaml
+++ b/config/monitoring/base/rhods-prometheus-role.yaml
@@ -1,0 +1,17 @@
+# this is role for cluster-monitoring to read rhods prometheus service by cluster-monitoring service account
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rhods-prometheus-cluster-monitoring-viewer
+  namespace: redhat-ods-monitoring
+rules:
+  - verbs:
+      - get
+      - watch
+      - list
+    apiGroups:
+      - ''
+    resources:
+      - pods
+      - services
+      - endpoints

--- a/config/monitoring/base/rhods-prometheus-rolebinding.yaml
+++ b/config/monitoring/base/rhods-prometheus-rolebinding.yaml
@@ -1,0 +1,14 @@
+# this is rolebingding to rhods-prometheus-cluster-monitoring-viewer for cluster-monitoring to read rhods prometheus service
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rhods-prometheus-cluster-monitoring-viewer-binding
+  namespace: redhat-ods-monitoring
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-k8s
+    namespace: openshift-monitoring
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rhods-prometheus-cluster-monitoring-viewer


### PR DESCRIPTION
for error: `failed to list *v1.Service: services is forbidden: User \"system:serviceaccount:openshift-monitoring:prometheus-k8s\" cannot list resource \"services\" in API group \"\" in the namespace \"redhat-ods-monitoring\"`


the decision is to keep using cluster-monitoring for this release


ref: https://issues.redhat.com/browse/RHODS-12867