### PR TITLE
fix(monitoring): do not set odh monitoring namespace when apply for  manifests in "monitoring/base"

### DIFF
--- a/config/monitoring/base/cluster-monitor-rolebinding.yaml
+++ b/config/monitoring/base/cluster-monitor-rolebinding.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cluster-monitor-rhods-reader
+  namespace: redhat-ods-monitoring
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/monitoring/base/rhods-prometheusrules.yaml
+++ b/config/monitoring/base/rhods-prometheusrules.yaml
@@ -11,6 +11,7 @@ metadata:
     role: recording-rules
     app: rhods
   name: rhods-rules
+  namespace: redhat-ods-monitoring
 spec:
   groups:
   - name: rhods-usage.rules

--- a/config/monitoring/base/rhods-servicemonitor.yaml
+++ b/config/monitoring/base/rhods-servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: rhods-monitor-federation
+  namespace: redhat-ods-monitoring
   labels:
     monitor-component: rhods-resources
     team: rhods
@@ -68,6 +69,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: rhods-monitor-federation2
+  namespace: redhat-ods-monitoring
   labels:
     monitor-component: rhods-resources
     team: rhods

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -454,7 +454,7 @@ func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsci.D
 		r.Client,
 		dsciInit,
 		monitoringBasePath,
-		dsciInit.Spec.Monitoring.Namespace,
+		"",
 		"monitoring-base",
 		dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed); err != nil {
 		r.Log.Error(err, "error to deploy manifests under "+monitoringBasePath)

--- a/pkg/plugins/namespacePlugin.go
+++ b/pkg/plugins/namespacePlugin.go
@@ -30,6 +30,14 @@ func ApplyNamespacePlugin(manifestNamespace string, resMap resmap.ResMap) error 
 			},
 			{
 				Gvk: resid.Gvk{
+					Group: "rbac.authorization.k8s.io",
+					Kind:  "RoleBinding",
+				},
+				Path:               "subjects/namespace",
+				CreateIfNotPresent: true,
+			},
+			{
+				Gvk: resid.Gvk{
 					Group: "admissionregistration.k8s.io",
 					Kind:  "ValidatingWebhookConfiguration",
 				},

--- a/pkg/plugins/namespacePlugin.go
+++ b/pkg/plugins/namespacePlugin.go
@@ -30,14 +30,6 @@ func ApplyNamespacePlugin(manifestNamespace string, resMap resmap.ResMap) error 
 			},
 			{
 				Gvk: resid.Gvk{
-					Group: "rbac.authorization.k8s.io",
-					Kind:  "RoleBinding",
-				},
-				Path:               "subjects/namespace",
-				CreateIfNotPresent: true,
-			},
-			{
-				Gvk: resid.Gvk{
 					Group: "admissionregistration.k8s.io",
 					Kind:  "ValidatingWebhookConfiguration",
 				},


### PR DESCRIPTION
- this is the reason why our rolebinding it set to `openshift-monitorig` but got replaced with our `monitoring namespace` which causes monitoring not working
- to not cause any side effect: will keep plugin as-is for this release,
- only to hardcoded our monitoring namespace in monitoring/base folder manifests
P.S:  seems only with removing plugin part is not helping, might need to check `SetRoleBindingSubjects: namespace.AllServiceAccountSubjects,` later


ref: https://issues.redhat.com/browse/RHODS-12867
