### PR TITLE
revert: label changes made in upgrade PR

### DIFF
--- a/pkg/plugins/addLabelsplugin.go
+++ b/pkg/plugins/addLabelsplugin.go
@@ -11,11 +11,17 @@ func ApplyAddLabelsPlugin(componentName string, resMap resmap.ResMap) error {
 	nsplug := builtins.LabelTransformerPlugin{
 		Labels: map[string]string{
 			"app.opendatahub.io/" + componentName: "true",
+			"app.kubernetes.io/part-of":           componentName,
 		},
 		FieldSpecs: []types.FieldSpec{
 			{
 				Gvk:                resid.Gvk{Kind: "Deployment"},
 				Path:               "spec/template/metadata/labels",
+				CreateIfNotPresent: true,
+			},
+			{
+				Gvk:                resid.Gvk{Kind: "Deployment"},
+				Path:               "spec/selector/matchLabels",
 				CreateIfNotPresent: true,
 			},
 			{


### PR DESCRIPTION
see https://github.com/opendatahub-io/opendatahub-operator/pull/631

part I: https://github.com/opendatahub-io/opendatahub-operator/issues/746

this is gonna make v2.2->v2.4 back to work 