### PR TITLE
fix(oauth-dashboard): force to delete OAuthClient CR as well when delete secrete for dashboard

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -83,9 +83,9 @@ metadata:
           "labels": {
             "app.kubernetes.io/name": "datasciencecluster",
             "app.kubernetes.io/instance": "default-dsc",
-            "app.kubernetes.io/part-of": "opendatahub-operator",
+            "app.kubernetes.io/part-of": "rhods-operator",
             "app.kubernetes.io/managed-by": "kustomize",
-            "app.kubernetes.io/created-by": "opendatahub-operator"
+            "app.kubernetes.io/created-by": "rhods-operator"
           }
         },
         "spec": {

--- a/components/component.go
+++ b/components/component.go
@@ -68,7 +68,7 @@ type ManifestsConfig struct {
 }
 
 type ComponentInterface interface {
-	ReconcileComponent(cli client.Client, owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec, currentComponentStatus bool) error
+	ReconcileComponent(cli client.Client, owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec, currentComponentExist bool) error
 	GetComponentName() string
 	GetManagementState() operatorv1.ManagementState
 	SetImageParamsMap(imageMap map[string]string) map[string]string

--- a/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -18,9 +18,9 @@ metadata:
           "labels": {
             "app.kubernetes.io/name": "datasciencecluster",
             "app.kubernetes.io/instance": "default-dsc",
-            "app.kubernetes.io/part-of": "opendatahub-operator",
+            "app.kubernetes.io/part-of": "rhods-operator",
             "app.kubernetes.io/managed-by": "kustomize",
-            "app.kubernetes.io/created-by": "opendatahub-operator"
+            "app.kubernetes.io/created-by": "rhods-operator"
           }
         },
         "spec": {

--- a/config/samples/dscinitialization_v1_dscinitialization.yaml
+++ b/config/samples/dscinitialization_v1_dscinitialization.yaml
@@ -6,7 +6,7 @@ metadata:
     app.kubernetes.io/instance: default-dsci
     app.kubernetes.io/part-of: rhods-operator
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: opendatahub-operator
+    app.kubernetes.io/created-by: rhods-operator
   name: default-dsci
 spec:
   monitoring:

--- a/controllers/secretgenerator/secretgenerator_controller.go
+++ b/controllers/secretgenerator/secretgenerator_controller.go
@@ -75,6 +75,8 @@ func (r *SecretGeneratorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false
 		},
+		// this only watch for secret deletion if has with annotation
+		// e.g dashboard-oauth-client but not dashboard-oauth-client-generated
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			if _, found := e.Object.GetAnnotations()[SECRET_NAME_ANNOTATION]; found {
 				return true
@@ -106,7 +108,7 @@ func (r *SecretGeneratorReconciler) Reconcile(ctx context.Context, request ctrl.
 	err := r.Client.Get(ctx, request.NamespacedName, foundSecret)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			// If Secret is deleted, delete OAuthClient if exists
+			// if no secrect exists in namespace, delete OAuthClient if CR exists
 			err = r.deleteOAuthClient(ctx, request.Name)
 		}
 		return ctrl.Result{}, err
@@ -137,7 +139,7 @@ func (r *SecretGeneratorReconciler) Reconcile(ctx context.Context, request ctrl.
 
 			secret, err := newSecret(foundSecret.GetAnnotations())
 			if err != nil {
-				secGenLog.Error(err, "error creating secret")
+				secGenLog.Error(err, "error creating secret %s in %s", generatedSecret.Name, generatedSecret.Namespace)
 				return ctrl.Result{}, err
 			}
 
@@ -149,15 +151,18 @@ func (r *SecretGeneratorReconciler) Reconcile(ctx context.Context, request ctrl.
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+			secGenLog.Info("Done generating secret in namespace",
+				"secret", generatedSecret.Name, "namespace", generatedSecret.Namespace)
+			// check if annotation oauth-client-route exists
 			if secret.OAuthClientRoute != "" {
 				// Get OauthClient Route
 				oauthClientRoute, err := r.getRoute(ctx, secret.OAuthClientRoute, request.Namespace)
 				if err != nil {
-					secGenLog.Error(err, "Unable to retrieve route", "route-name", secret.OAuthClientRoute)
+					secGenLog.Error(err, "Unable to retrieve route from OAuthClient", "route-name", secret.OAuthClientRoute)
 					return ctrl.Result{}, err
 				}
 				// Generate OAuthClient for the generated secret
-				secGenLog.Info("Generating an oauth client resource for route", "route-name", oauthClientRoute.Name)
+				secGenLog.Info("Generating an OAuthClient CR for route", "route-name", oauthClientRoute.Name)
 				err = r.createOAuthClient(ctx, foundSecret.Name, secret.Value, oauthClientRoute.Spec.Host)
 				if err != nil {
 					secGenLog.Error(err, "error creating oauth client resource. Recreate the Secret", "secret-name",
@@ -206,7 +211,7 @@ func (r *SecretGeneratorReconciler) createOAuthClient(ctx context.Context, name 
 	oauthClient := &ocv1.OAuthClient{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "OAuthClient",
-			APIVersion: "v1",
+			APIVersion: "oauth.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -222,12 +227,11 @@ func (r *SecretGeneratorReconciler) createOAuthClient(ctx context.Context, name 
 			secGenLog.Info("OAuth client resource already exists, patch it", "name", oauthClient.Name)
 			data, err := json.Marshal(oauthClient)
 			if err != nil {
-				return fmt.Errorf("failed to get DataScienceCluster custom resource data: %v", err)
+				return fmt.Errorf("failed to get DataScienceCluster CR data: %w", err)
 			}
-			err = r.Client.Patch(context.TODO(), oauthClient, client.RawPatch(types.ApplyPatchType, data),
-				client.ForceOwnership, client.FieldOwner("opendatahub-operator"))
-			if err != nil {
-				return err
+			if err = r.Client.Patch(context.TODO(), oauthClient, client.RawPatch(types.ApplyPatchType, data),
+				client.ForceOwnership, client.FieldOwner("rhods-operator")); err != nil {
+				return fmt.Errorf("failed to patch existing OAuthClient CR: %w", err)
 			}
 			return nil
 		}
@@ -248,9 +252,8 @@ func (r *SecretGeneratorReconciler) deleteOAuthClient(ctx context.Context, secre
 		return err
 	}
 
-	err = r.Client.Delete(ctx, oauthClient)
-	if err != nil {
-		return fmt.Errorf("error deleting OAuthClient %v", oauthClient.Name)
+	if err = r.Client.Delete(ctx, oauthClient); err != nil {
+		return fmt.Errorf("error deleting OAuthClient %s: %w", oauthClient.Name, err)
 	}
 
 	return nil

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -245,7 +245,7 @@ func CreateDefaultDSCI(cli client.Client, platform deploy.Platform, appNamespace
 			}
 			existingDSCI := &instances.Items[0]
 			err = cli.Patch(context.TODO(), existingDSCI, client.RawPatch(types.ApplyPatchType, data),
-				client.ForceOwnership, client.FieldOwner("opendatahub-operator"))
+				client.ForceOwnership, client.FieldOwner("rhods-operator"))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- do force OAuthClient deletion along with secret deletion
- update owner to rhods-operator
- update APIVersion for the patch, this is to fix error when we only want to patch OAuthClient from secrectgenerator_contorller:
`ERROR	Reconciler error	{"controller": "secret-generator-controller", "controllerGroup": "", "controllerKind": "Secret", "Secret": {"name":"dashboard-oauth-client","namespace":"odh"}, "namespace": "odh", "name": "dashboard-oauth-client", "reconcileID": "067a9ca5-89c8-4353-b0c5-ef241b8946ab", "error": "Incorrect version specified in apply patch. Specified patch version: v1, expected: oauth.openshift.io/v1"}`
- rename function name
-  add more comments and debug info message
fix: https://github.com/opendatahub-io/opendatahub-operator/issues/712

**new:** without force deletion oauthclient
live build quay.io/wenzhou/rhods-operator-catalog:v2.4.122-1

**old:**
live buid to be tested quay.io/wenzhou/opendatahub-operator-catalog:v2.4.122-0
