### PR TITLE
fix(monitoring): when DSC is removed entry in rule_files should be cleanup without panic

### DIFF
--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -7,8 +7,8 @@ metadata:
 data:
   prometheus.yml: |
     rule_files:
-      - 'operator-recording.rules'
-      - 'deadmanssnitch-alerting.rules'
+      - operator-recording.rules
+      - deadmanssnitch-alerting.rules
 
     global:
       scrape_interval:     10s
@@ -333,14 +333,14 @@ data:
       - name: DeadManSnitch
         interval: 1m
         rules:
-          - alert: DeadManSnitch
-            expr: vector(1)
-            labels:
-              severity: critical
-              namespace: redhat-ods-monitoring
-            annotations:
-              description: This is a DeadManSnitch to ensure RHODS monitoring and alerting pipeline is online.
-              summary: Alerting DeadManSnitch
+        - alert: DeadManSnitch
+          expr: vector(1)
+          labels:
+            severity: critical
+            namespace: redhat-ods-monitoring
+          annotations:
+            description: This is a DeadManSnitch to ensure RHODS monitoring and alerting pipeline is online.
+            summary: Alerting DeadManSnitch
 
   codeflare-recording.rules: |
     groups:

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -50,9 +50,18 @@ func (r *DSCInitializationReconciler) configureManagedMonitoring(ctx context.Con
 		}
 	}
 	if initial == "revertbackup" {
+		// TODO: implement with a better solution
+		// to have - before component name is to filter out the real rules file line
+		// e.g line of "workbenches-recording.rules: |"
 		err := common.MatchLineInFile(filepath.Join(prometheusConfigPath, "prometheus-configs.yaml"),
 			map[string]string{
-				"*.rules: ": "",
+				"(.*)-(.*)workbenches(.*).rules":                     "",
+				"(.*)-(.*)rhods-dashboard(.*).rules":                 "",
+				"(.*)-(.*)codeflare(.*).rules":                       "",
+				"(.*)-(.*)data-science-pipelines-operator(.*).rules": "",
+				"(.*)-(.*)model-mesh(.*).rules":                      "",
+				"(.*)-(.*)odh-model-controller(.*).rules":            "",
+				"(.*)-(.*)ray(.*).rules":                             "",
 			})
 		if err != nil {
 			r.Log.Error(err, "error to remove previous enabled component rules")


### PR DESCRIPTION
- match does not work with * in the string need to use (.*)

ref:  https://issues.redhat.com/browse/RHODS-12867

report by https://redhat-internal.slack.com/archives/C064Z5S84F3/p1700382245612159

live-build to test: quay.io/wenzhou/opendatahub-operator-catalog:v2.11.19


test:
- install operator
- default GA components all up and prometheus has them in the config
-
![Screenshot from 2023-11-19 15-49-17](https://github.com/red-hat-data-services/rhods-operator/assets/915053/833af61f-ea1b-4d48-ad3d-4d88abc59292)

- delete DSC
- wait about 2 mins
- check prometheus config again, only find 2 default rules
-
![Screenshot from 2023-11-19 16-52-16](https://github.com/red-hat-data-services/rhods-operator/assets/915053/4ca0d618-7a7c-4124-9075-ee8ad489104b)
