### PR TITLE
fix: upgrade from v1 to v2

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -94,9 +94,11 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		// Owned objects are automatically garbage collected. For additional cleanup logic use operatorUninstall function.
 		// Return and don't requeue
 		if upgrade.HasDeleteConfigMap(r.Client) {
-			return reconcile.Result{}, fmt.Errorf("error while operator uninstall: %v",
-				upgrade.OperatorUninstall(r.Client, r.RestConfig))
+			if uninstallErr := upgrade.OperatorUninstall(r.Client, r.RestConfig); uninstallErr != nil {
+				return ctrl.Result{}, fmt.Errorf("error while operator uninstall: %v", uninstallErr)
+			}
 		}
+
 		return ctrl.Result{}, nil
 	}
 

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func main() {
 	}
 
 	// Apply update from legacy operator
-	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace); err != nil {
+	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace, dscMonitoringNamespace); err != nil {
 		setupLog.Error(err, "unable to update from legacy operator version")
 	}
 

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func main() {
 	}
 
 	// Apply update from legacy operator
-	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform); err != nil {
+	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace); err != nil {
 		setupLog.Error(err, "unable to update from legacy operator version")
 	}
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -470,7 +470,7 @@ func deleteResource(cli client.Client, namespace string, resourceType string) er
 	return err
 }
 
-func deleteDeploymentsAndCheck(ctx context.Context, cli client.Client, namespace string) (bool, error) {
+func deleteDeploymentsAndCheck(ctx context.Context, cli client.Client, namespace string) (bool, error) { //nolint
 	// Delete Deployment objects
 	var multiErr *multierror.Error
 	deployments := &appsv1.DeploymentList{}
@@ -522,7 +522,7 @@ func deleteDeploymentsAndCheck(ctx context.Context, cli client.Client, namespace
 	return true, multiErr.ErrorOrNil()
 }
 
-func deleteStatefulsetsAndCheck(ctx context.Context, cli client.Client, namespace string) (bool, error) {
+func deleteStatefulsetsAndCheck(ctx context.Context, cli client.Client, namespace string) (bool, error) { //nolint
 	// Delete statefulset objects
 	var multiErr *multierror.Error
 	statefulsets := &appsv1.StatefulSetList{}


### PR DESCRIPTION
live build: [quay.io/wenzhou/rhods-operator-catalog:v2.4.0](http://quay.io/wenzhou/rhods-operator-catalog:v2.4.0) 
including rhods 1.33 v1 as FROM in this build

 
  - include edson's rhods-12939 from odh
     - fix the logic of adding deployment into markdeletionlist
     - add the missing steps in the backoff call=> this is the tricky one, blame bad documentation 
     -  ^ creds from @bartoszmajsak
  - add cleanup for the monitoring NS for the modelmesh monitoring deployment
  -  fix reconcile when we have deletion CM but no error return from operatorunistall
