### PR TITLE
RHODS-12956: removing CR update from the reconciliation loop to avoid infinite loop

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -21,11 +21,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+	"time"
+
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/rest"
-	"reflect"
-	"time"
 
 	"github.com/go-logr/logr"
 	v1 "github.com/openshift/api/operator/v1"
@@ -168,13 +169,6 @@ func (r *DataScienceClusterReconciler) Reconcile(ctx context.Context, req ctrl.R
 		return ctrl.Result{}, errors.New("only one instance of DSCInitialization object is allowed")
 	}
 
-	// Ensure all omitted components show up as explicitly disabled
-	instance, err = r.updateComponents(ctx, instance)
-	if err != nil {
-		_ = r.reportError(err, instance, "error updating list of components in the CR")
-		return ctrl.Result{}, err
-	}
-
 	// Initialize error list, instead of returning errors after every component is deployed
 	var componentErrors *multierror.Error
 
@@ -247,6 +241,7 @@ func (r *DataScienceClusterReconciler) reconcileSubComponent(ctx context.Context
 	component components.ComponentInterface,
 ) (*dsc.DataScienceCluster, error) {
 	componentName := component.GetComponentName()
+
 	enabled := component.GetManagementState() == v1.Managed
 	// First set conditions to reflect a component is about to be reconciled
 	instance, err := r.updateStatus(ctx, instance, func(saved *dsc.DataScienceCluster) {
@@ -347,23 +342,6 @@ func (r *DataScienceClusterReconciler) updateStatus(ctx context.Context, origina
 		// Try to update
 		err = r.Client.Status().Update(context.TODO(), saved)
 
-		// Return err itself here (not wrapped inside another error)
-		// so that RetryOnConflict can identify it correctly.
-		return err
-	})
-	return saved, err
-}
-
-func (r *DataScienceClusterReconciler) updateComponents(ctx context.Context, original *dsc.DataScienceCluster) (*dsc.DataScienceCluster, error) {
-	saved := &dsc.DataScienceCluster{}
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		err := r.Client.Get(ctx, client.ObjectKeyFromObject(original), saved)
-		if err != nil {
-			return err
-		}
-
-		// Try to update
-		err = r.Client.Update(context.TODO(), saved)
 		// Return err itself here (not wrapped inside another error)
 		// so that RetryOnConflict can identify it correctly.
 		return err


### PR DESCRIPTION
## Description
RHODS-12956 : the operator was updating the DSC CR from within the reconciliation loop code, causing an infinite loop.
This fix was discussed with James.

## How Has This Been Tested?
Manually tested in dev cluster

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] JIRA link(s): https://issues.redhat.com/browse/RHODS-12956
- [X] The developer has manually tested the changes and verified that the changes work
