### PR TITLE
update: set kserve as Managed by default DSC + fix nilpointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ spec:
       managementState: Managed
     workbenches:
       managementState: Managed
+    trustyai:
+      managementState: Managed
 ```
 
 2. Enable only Dashboard and Workbenches

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -262,7 +262,7 @@ spec:
                                 type: string
                             type: object
                           managementState:
-                            default: Removed
+                            default: Managed
                             enum:
                             - Managed
                             - Removed

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -115,7 +115,7 @@ spec:
                         type: string
                     type: object
                   managementState:
-                    default: Removed
+                    default: Managed
                     enum:
                     - Managed
                     - Removed

--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -29,10 +29,10 @@ metadata:
                 "managementState": "Managed"
               },
               "kserve": {
-                "managementState": "Removed"
+                "managementState": "Managed"
               },
               "modelmeshserving": {
-                "managementState": "Managed"
+                "managementState": "Removed"
               },
               "ray": {
                 "managementState": "Removed"
@@ -114,10 +114,10 @@ metadata:
               "managementState": "Managed"
             },
             "kserve": {
-              "managementState": "Removed"
+              "managementState": "Managed"
             },
             "modelmeshserving": {
-              "managementState": "Managed"
+              "managementState": "Removed"
             },
             "ray": {
               "managementState": "Removed"
@@ -126,7 +126,7 @@ metadata:
               "managementState": "Managed"
             },
             "trustyai": {
-              "managementState": "Managed"
+              "managementState": "Removed"
             }
           }
         }

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -263,7 +263,7 @@ spec:
                                 type: string
                             type: object
                           managementState:
-                            default: Removed
+                            default: Managed
                             enum:
                             - Managed
                             - Removed

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -116,7 +116,7 @@ spec:
                         type: string
                     type: object
                   managementState:
-                    default: Removed
+                    default: Managed
                     enum:
                     - Managed
                     - Removed

--- a/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -35,10 +35,10 @@ metadata:
               "managementState": "Managed"
             },
             "kserve": {
-              "managementState": "Removed"
+              "managementState": "Managed"
             },
             "modelmeshserving": {
-              "managementState": "Managed"
+              "managementState": "Removed"
             },
             "ray": {
               "managementState": "Removed"
@@ -47,7 +47,7 @@ metadata:
               "managementState": "Managed"
             },
             "trustyai": {
-              "managementState": "Managed"
+              "managementState": "Removed"
             }
           }
         }

--- a/config/samples/datasciencecluster_v1_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v1_datasciencecluster.yaml
@@ -17,9 +17,9 @@ spec:
     datasciencepipelines:
       managementState: "Managed"
     kserve:
-      managementState: "Removed"
-    modelmeshserving:
       managementState: "Managed"
+    modelmeshserving:
+      managementState: "Removed"
     ray:
       managementState: "Removed"
     workbenches:

--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -92,7 +92,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		instance = &instances.Items[0]
 	case len(instances.Items) > 1:
 		message := fmt.Sprintf("only one instance of DSCInitialization object is allowed. Update existing instance name %s", req.Name)
-		_, _ = r.updateStatus(ctx, instance, func(saved *dsciv1.DSCInitialization) {
+		_, _ = r.updateStatus(ctx, &instances.Items[0], func(saved *dsciv1.DSCInitialization) {
 			status.SetErrorCondition(&saved.Status.Conditions, status.DuplicateDSCInitialization, message)
 			saved.Status.Phase = status.PhaseError
 		})

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -53,13 +53,15 @@ To deploy ODH components seamlessly, ODH operator will watch two CRDs:
           datasciencepipelines:
             managementState: Managed
           kserve:
-            managementState: Removed
-          modelmeshserving:
             managementState: Managed
+          modelmeshserving:
+            managementState: Removed
           ray:
             managementState: Removed
           workbenches:
             managementState: Managed
+          trustyai:
+            managementState: Removed
     ```
 
 2. Enable only Dashboard and Workbenches(Jupyter Notebooks)

--- a/docs/Dev-Preview.md
+++ b/docs/Dev-Preview.md
@@ -86,7 +86,7 @@ metadata:
 spec:
   components:
     codeflare:
-      managementState: Managed
+      managementState: Removed
     dashboard:
       managementState: Managed
     datasciencepipelines:
@@ -94,11 +94,13 @@ spec:
     kserve:
       managementState: Managed
     modelmeshserving:
-      managementState: Managed
+      managementState: Removed
     ray:
-      managementState: Managed
+      managementState: Removed
     workbenches:
       managementState: Managed
+    trustyai:
+      managementState: Removed
 EOF
 ```
 

--- a/infrastructure/v1/serverless_types.go
+++ b/infrastructure/v1/serverless_types.go
@@ -8,7 +8,7 @@ import (
 // bindings with the Service Mesh.
 type ServingSpec struct {
 	// +kubebuilder:validation:Enum=Managed;Removed
-	// +kubebuilder:default=Removed
+	// +kubebuilder:default=Managed
 	ManagementState operatorv1.ManagementState `json:"managementState,omitempty"`
 	// Name specifies the name of the KNativeServing resource that is going to be
 	// created to instruct the KNative Operator to deploy KNative serving components.

--- a/infrastructure/v1/servicemesh_types.go
+++ b/infrastructure/v1/servicemesh_types.go
@@ -5,7 +5,7 @@ import operatorv1 "github.com/openshift/api/operator/v1"
 // ServiceMeshSpec configures Service Mesh.
 type ServiceMeshSpec struct {
 	// +kubebuilder:validation:Enum=Managed;Removed
-	// +kubebuilder:default=Removed
+	// +kubebuilder:default=Managed
 	ManagementState operatorv1.ManagementState `json:"managementState,omitempty"`
 	// ControlPlane holds configuration of Service Mesh used by Opendatahub.
 	ControlPlane ControlPlaneSpec `json:"controlPlane,omitempty"`

--- a/pkg/cluster/operations.go
+++ b/pkg/cluster/operations.go
@@ -21,9 +21,8 @@ const (
 // being used by different components.
 func UpdatePodSecurityRolebinding(cli client.Client, namespace string, serviceAccountsList ...string) error {
 	foundRoleBinding := &authv1.RoleBinding{}
-	err := cli.Get(context.TODO(), client.ObjectKey{Name: namespace, Namespace: namespace}, foundRoleBinding)
-	if err != nil {
-		return err
+	if err := cli.Get(context.TODO(), client.ObjectKey{Name: namespace, Namespace: namespace}, foundRoleBinding); err != nil {
+		return fmt.Errorf("error to get rolebinding %s from namespace %s: %w", namespace, namespace, err)
 	}
 
 	for _, sa := range serviceAccountsList {
@@ -37,7 +36,11 @@ func UpdatePodSecurityRolebinding(cli client.Client, namespace string, serviceAc
 		}
 	}
 
-	return cli.Update(context.TODO(), foundRoleBinding)
+	if err := cli.Update(context.TODO(), foundRoleBinding); err != nil {
+		return fmt.Errorf("error update rolebinding %s with serviceaccount: %w", namespace, err)
+	}
+
+	return nil
 }
 
 // Internal function used by UpdatePodSecurityRolebinding()

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -275,6 +275,7 @@ func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform, appNS 
 		if err := deleteResource(cli, montNamespace, "statefulset"); err != nil {
 			return err
 		}
+		fmt.Println("creating default DSC CR")
 		if err := CreateDefaultDSC(cli, platform); err != nil {
 			return err
 		}
@@ -323,6 +324,7 @@ func UpdateFromLegacyVersion(cli client.Client, platform deploy.Platform, appNS 
 			if err := deleteResource(cli, montNamespace, "statefulset"); err != nil {
 				return err
 			}
+			// create default DSC
 			if err = CreateDefaultDSC(cli, platform); err != nil {
 				return err
 			}


### PR DESCRIPTION
- set OSSM and serving both as default Managaed
- set kserver as default Managed too
- keep modelmesh for new installation as Removed but if it is upgrade from old verison, keep it as-was
- sync fix upstream issue 755 

**live build** quay.io/wenzhou/rhods-operator-catalog:v2.5.1

**test:**
installed 2 dependent operators 
install rhods operator
DSCI created, DSC created, 4 FT created
![Screenshot from 2023-11-21 17-47-36](https://github.com/red-hat-data-services/rhods-operator/assets/915053/de3a2fe4-8b95-44b1-bad3-6c9fe9894dd0)

kserve is managed, modelmesh is removed
![Screenshot from 2023-11-21 17-45-03](https://github.com/red-hat-data-services/rhods-operator/assets/915053/5401c2cd-9ea5-4f2d-907f-6e0e2c22ab60)
![Screenshot from 2023-11-21 17-45-11](https://github.com/red-hat-data-services/rhods-operator/assets/915053/9ee1312b-6236-4d17-a2c5-8c254afd828c)

