### PR TITLE
Add Predicate for Prometheus Configmap

### DIFF
--- a/controllers/datasciencecluster/datasciencecluster_controller.go
+++ b/controllers/datasciencecluster/datasciencecluster_controller.go
@@ -22,6 +22,8 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"time"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
@@ -306,13 +308,23 @@ func (r *DataScienceClusterReconciler) reportError(err error, instance *dsc.Data
 	return instance
 }
 
+var configMapPredicates = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		// Do not reconcile on prometheus configmap update, since it is handled by DSCI
+		if e.ObjectNew.GetName() == "prometheus" && e.ObjectNew.GetNamespace() == "redhat-ods-monitoring" {
+			return false
+		}
+		return true
+	},
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *DataScienceClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&dsc.DataScienceCluster{}).
 		Owns(&corev1.Namespace{}).
 		Owns(&corev1.Secret{}).
-		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.ConfigMap{}, builder.WithPredicates(configMapPredicates)).
 		Owns(&netv1.NetworkPolicy{}).
 		Owns(&authv1.Role{}).
 		Owns(&authv1.RoleBinding{}).
@@ -322,7 +334,7 @@ func (r *DataScienceClusterReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Owns(&appsv1.ReplicaSet{}).
 		Owns(&corev1.Pod{}).
 		Watches(&source.Kind{Type: &dsci.DSCInitialization{}}, handler.EnqueueRequestsFromMapFunc(r.watchDataScienceClusterResources)).
-		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, handler.EnqueueRequestsFromMapFunc(r.watchDataScienceClusterResources)).
+		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, handler.EnqueueRequestsFromMapFunc(r.watchDataScienceClusterResources), builder.WithPredicates(configMapPredicates)).
 		// this predicates prevents meaningless reconciliations from being triggered
 		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})).
 		Complete(r)
@@ -355,25 +367,30 @@ func (r *DataScienceClusterReconciler) watchDataScienceClusterResources(a client
 	if err != nil {
 		return nil
 	}
-	if len(instanceList.Items) == 1 {
-		// Trigger reconcile function when uninstall configmap is created
-		if a.GetObjectKind().GroupVersionKind().Kind == "ConfigMap" {
-			labels := a.GetLabels()
-			if val, ok := labels[upgrade.DeleteConfigMapLabel]; ok && val == "true" {
-				return []reconcile.Request{{
-					NamespacedName: types.NamespacedName{Name: instanceList.Items[0].Name},
-				}}
-			} else {
-				return nil
-			}
+	var requestName string
+	switch {
+	case len(instanceList.Items) == 1:
+		requestName = instanceList.Items[0].Name
+	case len(instanceList.Items) == 0:
+		requestName = "default-dsc"
+	default:
+		return nil
+	}
+
+	// Trigger reconcile function when uninstall configmap is created
+	operatorNs, err := upgrade.GetOperatorNamespace()
+	if err != nil {
+		return nil
+	}
+	if a.GetNamespace() == operatorNs {
+		labels := a.GetLabels()
+		if val, ok := labels[upgrade.DeleteConfigMapLabel]; ok && val == "true" {
+			return []reconcile.Request{{
+				NamespacedName: types.NamespacedName{Name: requestName},
+			}}
+		} else {
+			return nil
 		}
-		return []reconcile.Request{{
-			NamespacedName: types.NamespacedName{Name: instanceList.Items[0].Name},
-		}}
-	} else if len(instanceList.Items) == 0 {
-		return []reconcile.Request{{
-			NamespacedName: types.NamespacedName{Name: "default"},
-		}}
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds predicate/filter to prune configmap events. DSC should not reconcile on prometheus configmap changes.

Live Build : quay.io/vhire/opendatahub-operator-catalog:v2.4.0-4