### PR TITLE
fix(monitoring): only set prometheus as part-of label from component

### DIFF
--- a/components/codeflare/codeflare.go
+++ b/components/codeflare/codeflare.go
@@ -108,7 +108,7 @@ func (c *CodeFlare) ReconcileComponent(cli client.Client, owner metav1.Object, d
 		if err = deploy.DeployManifestsFromPath(cli, owner,
 			filepath.Join(deploy.DefaultManifestPath, "monitoring", "prometheus", "apps"),
 			dscispec.Monitoring.Namespace,
-			ComponentName+"prometheus", true); err != nil {
+			"prometheus", true); err != nil {
 			return err
 		}
 	}

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -167,7 +167,7 @@ func (d *Dashboard) ReconcileComponent(cli client.Client, owner metav1.Object, d
 			if err = deploy.DeployManifestsFromPath(cli, owner,
 				filepath.Join(deploy.DefaultManifestPath, "monitoring", "prometheus", "apps"),
 				dscispec.Monitoring.Namespace,
-				ComponentName+"prometheus", true); err != nil {
+				"prometheus", true); err != nil {
 				return err
 			}
 		}

--- a/components/datasciencepipelines/datasciencepipelines.go
+++ b/components/datasciencepipelines/datasciencepipelines.go
@@ -93,7 +93,7 @@ func (d *DataSciencePipelines) ReconcileComponent(cli client.Client, owner metav
 		if err = deploy.DeployManifestsFromPath(cli, owner,
 			filepath.Join(deploy.DefaultManifestPath, "monitoring", "prometheus", "apps"),
 			dscispec.Monitoring.Namespace,
-			ComponentName+"prometheus", true); err != nil {
+			"prometheus", true); err != nil {
 			return err
 		}
 	}

--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -150,7 +150,7 @@ func (m *ModelMeshServing) ReconcileComponent(cli client.Client, owner metav1.Ob
 		if err = deploy.DeployManifestsFromPath(cli, owner,
 			filepath.Join(deploy.DefaultManifestPath, "monitoring", "prometheus", "apps"),
 			dscispec.Monitoring.Namespace,
-			ComponentName+"prometheus", true); err != nil {
+			"prometheus", true); err != nil {
 			return err
 		}
 	}

--- a/components/ray/ray.go
+++ b/components/ray/ray.go
@@ -86,7 +86,7 @@ func (r *Ray) ReconcileComponent(cli client.Client, owner metav1.Object, dscispe
 		if err = deploy.DeployManifestsFromPath(cli, owner,
 			filepath.Join(deploy.DefaultManifestPath, "monitoring", "prometheus", "apps"),
 			dscispec.Monitoring.Namespace,
-			ComponentName+"prometheus", true); err != nil {
+			"prometheus", true); err != nil {
 			return err
 		}
 	}

--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -175,7 +175,7 @@ func (w *Workbenches) ReconcileComponent(cli client.Client, owner metav1.Object,
 		if err = deploy.DeployManifestsFromPath(cli, owner,
 			filepath.Join(deploy.DefaultManifestPath, "monitoring", "prometheus", "apps"),
 			dscispec.Monitoring.Namespace,
-			ComponentName+"prometheus", true); err != nil {
+			"prometheus", true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
this will reduced necessary updates on prometheus configmap



live build: quay.io/wenzhou/rhods-operator:dev-2.5.12966  