### PR TITLE
fix(oauth-dashboard): apiversion when patch oauthclient + add more debug info

### DIFF
--- a/components/component.go
+++ b/components/component.go
@@ -80,7 +80,7 @@ type ManifestsConfig struct {
 }
 
 type ComponentInterface interface {
-	ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec, currentComponentStatus bool) error
+	ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, DSCISpec *dsciv1.DSCInitializationSpec, currentComponentExist bool) error
 	Cleanup(cli client.Client, DSCISpec *dsciv1.DSCInitializationSpec) error
 	GetComponentName() string
 	GetManagementState() operatorv1.ManagementState

--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -84,7 +84,7 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 	resConf *rest.Config,
 	owner metav1.Object,
 	dscispec *dsciv1.DSCInitializationSpec,
-	currentComponentStatus bool,
+	currentComponentExist bool,
 ) error {
 	var imageParamMap = map[string]string{
 		"odh-dashboard-image": "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
@@ -99,9 +99,11 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 
 	// Update Default rolebinding
 	if enabled {
-		if err := d.cleanOauthClientSecrets(cli, dscispec, currentComponentStatus); err != nil {
+		// cleanup OAuth client related secret and CR if dashboard is in 'installed falas' status
+		if err := d.cleanOauthClient(cli, dscispec, currentComponentExist); err != nil {
 			return err
 		}
+
 		// Download manifests and update paths
 		if err := d.OverrideManifests(string(platform)); err != nil {
 			return err
@@ -276,26 +278,26 @@ func (d *Dashboard) deployConsoleLink(cli client.Client, owner metav1.Object, na
 	return nil
 }
 
-func (d *Dashboard) cleanOauthClientSecrets(cli client.Client, dscispec *dsciv1.DSCInitializationSpec, currentComponentStatus bool) error {
+func (d *Dashboard) cleanOauthClient(cli client.Client, dscispec *dsciv1.DSCInitializationSpec, currentComponentExist bool) error {
 	// Remove previous oauth-client secrets
 	// Check if component is going from state of `Not Installed --> Installed`
 	// Assumption: Component is currently set to enabled
-	if !currentComponentStatus {
+	name := "dashboard-oauth-client"
+	if !currentComponentExist {
+		fmt.Println("Cleanup any left secret")
 		// Delete client secrets from previous installation
 		oauthClientSecret := &v1.Secret{}
 		err := cli.Get(context.TODO(), client.ObjectKey{
 			Namespace: dscispec.ApplicationsNamespace,
-			Name:      "dashboard-oauth-client",
+			Name:      name,
 		}, oauthClientSecret)
 		if err != nil {
 			if !apierrs.IsNotFound(err) {
-				return err
+				return fmt.Errorf("error getting secret %s: %w", name, err)
 			}
-		} else {
-			err := cli.Delete(context.TODO(), oauthClientSecret)
-			if err != nil {
-				return fmt.Errorf("error deleting oauth client secret: %v", err)
-			}
+		}
+		if err := cli.Delete(context.TODO(), oauthClientSecret); err != nil {
+			return fmt.Errorf("error deleting secret %s in namespace %s : %w", name, dscispec.ApplicationsNamespace, err)
 		}
 	}
 	return nil

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -245,7 +245,7 @@ func CreateDefaultDSCI(cli client.Client, platform deploy.Platform, appNamespace
 			}
 			existingDSCI := &instances.Items[0]
 			err = cli.Patch(context.TODO(), existingDSCI, client.RawPatch(types.ApplyPatchType, data),
-				client.ForceOwnership, client.FieldOwner("opendatahub-operator"))
+				client.ForceOwnership, client.FieldOwner("rhods-operator"))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
do force OAuthClient deletion along with secret deletion
update owner to rhods-operator
update APIVersion for the patch, this is to fix error when we only want to patch OAuthClient from secrectgenerator_contorller:
ERROR	Reconciler error	{"controller": "secret-generator-controller", "controllerGroup": "", "controllerKind": "Secret", "Secret": {"name":"dashboard-oauth-client","namespace":"odh"}, "namespace": "odh", "name": "dashboard-oauth-client", "reconcileID": "067a9ca5-89c8-4353-b0c5-ef241b8946ab", "error": "Incorrect version specified in apply patch. Specified patch version: v1, expected: oauth.openshift.io/v1"}
rename function name
add more comments and debug info message
fix: https://github.com/opendatahub-io/opendatahub-operator/issues/712


ref original from https://github.com/red-hat-data-services/rhods-operator/pull/122
ref: https://issues.redhat.com/browse/RHODS-12948