### PR TITLE
chore: update check interval from 2s to 10s, just way to much in the log

### DIFF
--- a/pkg/feature/conditions.go
+++ b/pkg/feature/conditions.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	interval = 2 * time.Second
+	interval = 10 * time.Second
 	duration = 5 * time.Minute
 )
 

--- a/pkg/feature/servicemesh/conditions.go
+++ b/pkg/feature/servicemesh/conditions.go
@@ -19,7 +19,7 @@ import (
 var log = ctrlLog.Log.WithName("features")
 
 const (
-	interval = 2 * time.Second
+	interval = 10 * time.Second
 	duration = 5 * time.Minute
 )
 


### PR DESCRIPTION
just way to much print out of this 
`2023-11-24T09:27:54Z	INFO	features	waiting for pods to become ready	{"feature": "mesh-control-plane-creation", "namespace": "istio-system", "duration (s)": 300}`
then the logs are useless

esp. in the case i did not config SMCP for ROSA so FT CR wont get created and the check will never work.
