### PR TITLE
fix(secret): do not delete secret if cannot find

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -295,9 +295,10 @@ func (d *Dashboard) cleanOauthClient(cli client.Client, dscispec *dsciv1.DSCInit
 			if !apierrs.IsNotFound(err) {
 				return fmt.Errorf("error getting secret %s: %w", name, err)
 			}
-		}
-		if err := cli.Delete(context.TODO(), oauthClientSecret); err != nil {
-			return fmt.Errorf("error deleting secret %s in namespace %s : %w", name, dscispec.ApplicationsNamespace, err)
+		} else {
+			if err := cli.Delete(context.TODO(), oauthClientSecret); err != nil {
+				return fmt.Errorf("error deleting secret %s in namespace %s : %w", name, dscispec.ApplicationsNamespace, err)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
fix error:
`2023-11-27T08:41:04Z ERROR controllers.DataScienceCluster failed to reconcile dashboard on DataScienceCluster {"instance.Name": "default-dsc", "error": "error deleting secret dashboard-oauth-client in namespace redhat-ods-applications : resource name may not be empty"}`

ref: https://issues.redhat.com/browse/RHODS-12948