### PR TITLE
update(kserve): add monitoring logic

### DIFF
--- a/components/component.go
+++ b/components/component.go
@@ -87,7 +87,6 @@ type ComponentInterface interface {
 	SetImageParamsMap(imageMap map[string]string) map[string]string
 	OverrideManifests(platform string) error
 	UpdatePrometheusConfig(cli client.Client, enable bool, component string) error
-	// WaitForDeploymentAvailable(ctx context.Context, r *rest.Config, c string, n string, i int, t int) error
 }
 
 // UpdatePrometheusConfig update prometheus-configs.yaml to include/exclude <component>.rules
@@ -120,6 +119,8 @@ func (c *Component) UpdatePrometheusConfig(cli client.Client, enable bool, compo
 			RayARules          string `yaml:"ray-alerting.rules"`
 			WorkbenchesRRules  string `yaml:"workbenches-recording.rules"`
 			WorkbenchesARules  string `yaml:"workbenches-alerting.rules"`
+			KserveRRules       string `yaml:"kserve-recording.rules"`
+			KserveARules       string `yaml:"kserve-alerting.rules"`
 		} `yaml:"data"`
 	}
 	var configMap ConfigMap
@@ -184,34 +185,3 @@ func (c *Component) UpdatePrometheusConfig(cli client.Client, enable bool, compo
 	}
 	return nil
 }
-
-// WaitForDeploymentAvailable to check if component deployment from 'namepsace' is ready within 'timeout' before apply prometheus rules for the component
-// func (c *Component) WaitForDeploymentAvailable(ctx context.Context, restConfig *rest.Config, componentName string, namespace string, interval int, timeout int) error {
-// 	resourceInterval := time.Duration(interval) * time.Second
-// 	resourceTimeout := time.Duration(timeout) * time.Minute
-// 	return wait.PollUntilContextTimeout(context.TODO(), resourceInterval, resourceTimeout, true, func(ctx context.Context) (bool, error) {
-// 		clientset, err := kubernetes.NewForConfig(restConfig)
-// 		if err != nil {
-// 			return false, fmt.Errorf("error getting client %w", err)
-// 		}
-// 		componentDeploymentList, err := clientset.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{
-// 			LabelSelector: "app.opendatahub.io/" + componentName,
-// 		})
-// 		if err != nil {
-// 			if errors.IsNotFound(err) {
-// 				return false, nil
-// 			}
-// 		}
-// 		isReady := false
-// 		if len(componentDeploymentList.Items) != 0 {
-// 			for _, deployment := range componentDeploymentList.Items {
-// 				if deployment.Status.ReadyReplicas == deployment.Status.Replicas {
-// 					isReady = true
-// 				} else {
-// 					isReady = false
-// 				}
-// 			}
-// 		}
-// 		return isReady, nil
-// 	})
-// }

--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -1395,4 +1395,3 @@ data:
           labels:
             severity: warning
             instance: notebook-spawner
-        

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -59,6 +59,7 @@ func (r *DSCInitializationReconciler) configureManagedMonitoring(ctx context.Con
 				"(.*)-(.*)model-mesh(.*).rules":                      "",
 				"(.*)-(.*)odh-model-controller(.*).rules":            "",
 				"(.*)-(.*)ray(.*).rules":                             "",
+				"(.*)-(.*)kserve(.*).rules":                          "",
 			})
 		if err != nil {
 			r.Log.Error(err, "error to remove previous enabled component rules")


### PR DESCRIPTION
![Screenshot from 2023-12-07 11-26-53](https://github.com/red-hat-data-services/rhods-operator/assets/915053/160afe31-1b84-47f0-a884-1c4e288d7246)
this need go together with https://github.com/red-hat-data-services/rhods-operator/pull/144 or after https://github.com/red-hat-data-services/rhods-operator/pull/144 merged

![Screenshot from 2023-12-07 11-58-38](https://github.com/red-hat-data-services/rhods-operator/assets/915053/09ab1cce-f021-410a-b903-252309b62c77)

live build quay.io/wenzhou/rhods-operator-catalog:v2.6.98



JIRA : https://issues.redhat.com/browse/RHOAIENG-98