### PR TITLE
Update Defaults for Servicemesh and Kserve

### DIFF
--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -115,7 +115,7 @@ spec:
                         type: string
                     type: object
                   managementState:
-                    default: Managed
+                    default: Removed
                     enum:
                     - Managed
                     - Removed

--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
                 "managementState": "Managed"
               },
               "modelmeshserving": {
-                "managementState": "Removed"
+                "managementState": "Managed"
               },
               "ray": {
                 "managementState": "Removed"
@@ -64,6 +64,14 @@ metadata:
             "monitoring": {
               "managementState": "Managed",
               "namespace": "redhat-ods-monitoring"
+            },
+            "serviceMesh": {
+              "controlPlane": {
+                "metricsCollection": "Istio",
+                "name": "data-science-smcp",
+                "namespace": "istio-system"
+              },
+              "managementState": "Managed"
             }
           }
         },

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -116,7 +116,7 @@ spec:
                         type: string
                     type: object
                   managementState:
-                    default: Managed
+                    default: Removed
                     enum:
                     - Managed
                     - Removed

--- a/config/samples/datasciencecluster_v1_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v1_datasciencecluster.yaml
@@ -19,7 +19,7 @@ spec:
     kserve:
       managementState: "Managed"
     modelmeshserving:
-      managementState: "Removed"
+      managementState: "Managed"
     ray:
       managementState: "Removed"
     workbenches:

--- a/config/samples/dscinitialization_v1_dscinitialization.yaml
+++ b/config/samples/dscinitialization_v1_dscinitialization.yaml
@@ -13,4 +13,10 @@ spec:
     managementState: "Managed"
     namespace: 'redhat-ods-monitoring'
   applicationsNamespace: 'redhat-ods-applications'
+  serviceMesh:
+    controlPlane:
+      metricsCollection: Istio
+      name: data-science-smcp
+      namespace: istio-system
+    managementState: Managed
 

--- a/infrastructure/v1/servicemesh_types.go
+++ b/infrastructure/v1/servicemesh_types.go
@@ -5,7 +5,7 @@ import operatorv1 "github.com/openshift/api/operator/v1"
 // ServiceMeshSpec configures Service Mesh.
 type ServiceMeshSpec struct {
 	// +kubebuilder:validation:Enum=Managed;Removed
-	// +kubebuilder:default=Managed
+	// +kubebuilder:default=Removed
 	ManagementState operatorv1.ManagementState `json:"managementState,omitempty"`
 	// ControlPlane holds configuration of Service Mesh used by Opendatahub.
 	ControlPlane ControlPlaneSpec `json:"controlPlane,omitempty"`

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -163,7 +163,7 @@ func CreateDefaultDSC(cli client.Client, platform deploy.Platform) error {
 					Component: components.Component{ManagementState: operatorv1.Managed},
 				},
 				ModelMeshServing: modelmeshserving.ModelMeshServing{
-					Component: components.Component{ManagementState: operatorv1.Removed},
+					Component: components.Component{ManagementState: operatorv1.Managed},
 				},
 				DataSciencePipelines: datasciencepipelines.DataSciencePipelines{
 					Component: components.Component{ManagementState: operatorv1.Managed},

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -35,6 +35,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/ray"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/trustyai"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components/workbenches"
+	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
@@ -206,6 +207,14 @@ func CreateDefaultDSCI(cli client.Client, platform deploy.Platform, appNamespace
 		Monitoring: dsci.Monitoring{
 			ManagementState: operatorv1.Managed,
 			Namespace:       monNamespace,
+		},
+		ServiceMesh: infrav1.ServiceMeshSpec{
+			ManagementState: "Managed",
+			ControlPlane: infrav1.ControlPlaneSpec{
+				Name:              "data-science-smcp",
+				Namespace:         "istio-system",
+				MetricsCollection: "Istio",
+			},
 		},
 	}
 


### PR DESCRIPTION
Ref: https://issues.redhat.com/browse/RHOAIENG-126

This PR changes will result in following usecases:

**Self-Managed**

- **New Installs** : Kserve - `Managed` , Modelmesh: `Managed`, Servicemesh(dsci) : `Managed`
- **Upgrade**: Kserve - `same as 2.4`,  Modelmesh: `same as 2.4` , Servicemesh(dsci): `Removed`

Note: If kserve is set to `Managed` in 2.4, users will explicitly need to update `Servicemesh` to `Managed` in DSCI.