### PR TITLE
fix(mm-monitoring): revert the code logic but set to disable as delete

### DIFF
--- a/components/modelmeshserving/modelmeshserving.go
+++ b/components/modelmeshserving/modelmeshserving.go
@@ -22,6 +22,7 @@ import (
 var (
 	ComponentName          = "model-mesh"
 	Path                   = deploy.DefaultManifestPath + "/" + ComponentName + "/overlays/odh"
+	monitoringPath         = deploy.DefaultManifestPath + "/" + "modelmesh-monitoring/base"
 	DependentComponentName = "odh-model-controller"
 	DependentPath          = deploy.DefaultManifestPath + "/" + DependentComponentName + "/base"
 )
@@ -144,6 +145,19 @@ func (m *ModelMeshServing) ReconcileComponent(ctx context.Context,
 		} else {
 			return err
 		}
+	}
+
+	// Get monitoring namespace
+	var monitoringNamespace string
+	if dscispec.Monitoring.Namespace != "" {
+		monitoringNamespace = dscispec.Monitoring.Namespace
+	} else {
+		monitoringNamespace = dscispec.ApplicationsNamespace
+	}
+
+	// Ensure we do not deploy modelmesh-monitoring if it has been there from previous releases
+	if err = deploy.DeployManifestsFromPath(cli, owner, monitoringPath, monitoringNamespace, ComponentName, false); err != nil {
+		return err
 	}
 
 	// CloudService Monitoring handling


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/RHOAIENG-293

build 2.4 live: quay.io/wenzhou/rhods-operator-catalog:v2.4.293
build 2.5 live: quay.io/wenzhou/rhods-operator-catalog:v2.5.293 from this PR.

test:
- install 2.4 
![Screenshot from 2023-12-05 11-15-30](https://github.com/red-hat-data-services/rhods-operator/assets/915053/17113f97-4ac6-44ae-843f-c22efc4b5f24)

only have modelmesh enabled
![Screenshot from 2023-12-05 11-18-00](https://github.com/red-hat-data-services/rhods-operator/assets/915053/2152b2c2-d75a-4fa3-822f-280d47c70d5d)

check resources
![Screenshot from 2023-12-05 11-18-21](https://github.com/red-hat-data-services/rhods-operator/assets/915053/7d8ca9e9-64df-4a5c-b4f7-7f9b9bd91952)

![Screenshot from 2023-12-05 11-18-35](https://github.com/red-hat-data-services/rhods-operator/assets/915053/77cb18ef-7b96-4d61-9bb2-e77eff4d2240)

![Screenshot from 2023-12-05 11-24-15](https://github.com/red-hat-data-services/rhods-operator/assets/915053/9649365d-39f9-49b3-9e2d-ff0a16604d30)


- upgrade to 2.5
- 
![Screenshot from 2023-12-05 11-30-00](https://github.com/red-hat-data-services/rhods-operator/assets/915053/451c2015-84d0-492b-bb5e-94fef655cdd3)

check if resoruce still there
no prometheus CR
![Screenshot from 2023-12-05 11-31-46](https://github.com/red-hat-data-services/rhods-operator/assets/915053/8c97a6b5-30d0-441a-bc95-b6110c796473)
no deployment
![Screenshot from 2023-12-05 11-31-20](https://github.com/red-hat-data-services/rhods-operator/assets/915053/1ace30d5-d131-4c95-aca6-7f26e3468031)


no SA
![Screenshot from 2023-12-05 11-31-30](https://github.com/red-hat-data-services/rhods-operator/assets/915053/c958dc68-5e4d-41bb-87d0-78be31b3760a)


cannot find SerivceMonitor modelmesh-federated-metrics 