### PR TITLE
backport:  https://github.com/red-hat-data-services/rhods-operator/pull/154

### DIFF
--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -265,6 +265,7 @@ spec:
                             default: Managed
                             enum:
                             - Managed
+                            - Unmanaged
                             - Removed
                             pattern: ^(Managed|Unmanaged|Force|Removed)$
                             type: string

--- a/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/bundle/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -115,9 +115,10 @@ spec:
                         type: string
                     type: object
                   managementState:
-                    default: Managed
+                    default: Removed
                     enum:
                     - Managed
+                    - Unmanaged
                     - Removed
                     pattern: ^(Managed|Unmanaged|Force|Removed)$
                     type: string

--- a/components/kserve/kserve.go
+++ b/components/kserve/kserve.go
@@ -159,7 +159,7 @@ func (k *Kserve) Cleanup(_ client.Client, instance *dsciv1.DSCInitializationSpec
 func (k *Kserve) configureServerless(instance *dsciv1.DSCInitializationSpec) error {
 	if k.Serving.ManagementState == operatorv1.Managed {
 		if instance.ServiceMesh.ManagementState != operatorv1.Managed {
-			return fmt.Errorf("serviceMesh is not configured as Managaed in DSCI instance but required by KServe serving")
+			fmt.Println("ServiceMesh is not configured as Managed in DSCI instance")
 		}
 
 		serverlessInitializer := feature.NewFeaturesInitializer(instance, k.configureServerlessFeatures)

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -266,6 +266,7 @@ spec:
                             default: Managed
                             enum:
                             - Managed
+                            - Unmanaged
                             - Removed
                             pattern: ^(Managed|Unmanaged|Force|Removed)$
                             type: string

--- a/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
+++ b/config/crd/bases/dscinitialization.opendatahub.io_dscinitializations.yaml
@@ -116,9 +116,10 @@ spec:
                         type: string
                     type: object
                   managementState:
-                    default: Managed
+                    default: Removed
                     enum:
                     - Managed
+                    - Unmanaged
                     - Removed
                     pattern: ^(Managed|Unmanaged|Force|Removed)$
                     type: string

--- a/infrastructure/v1/serverless_types.go
+++ b/infrastructure/v1/serverless_types.go
@@ -7,7 +7,7 @@ import (
 // ServingSpec specifies the configuration for the KNative Serving components and their
 // bindings with the Service Mesh.
 type ServingSpec struct {
-	// +kubebuilder:validation:Enum=Managed;Removed
+	// +kubebuilder:validation:Enum=Managed;Unmanaged;Removed
 	// +kubebuilder:default=Managed
 	ManagementState operatorv1.ManagementState `json:"managementState,omitempty"`
 	// Name specifies the name of the KNativeServing resource that is going to be

--- a/infrastructure/v1/servicemesh_types.go
+++ b/infrastructure/v1/servicemesh_types.go
@@ -4,8 +4,8 @@ import operatorv1 "github.com/openshift/api/operator/v1"
 
 // ServiceMeshSpec configures Service Mesh.
 type ServiceMeshSpec struct {
-	// +kubebuilder:validation:Enum=Managed;Removed
-	// +kubebuilder:default=Managed
+	// +kubebuilder:validation:Enum=Managed;Unmanaged;Removed
+	// +kubebuilder:default=Removed
 	ManagementState operatorv1.ManagementState `json:"managementState,omitempty"`
 	// ControlPlane holds configuration of Service Mesh used by Opendatahub.
 	ControlPlane ControlPlaneSpec `json:"controlPlane,omitempty"`

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -234,7 +234,9 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 		}
 
 		existingOwnerReferences := obj.GetOwnerReferences()
-		if existingOwnerReferences == nil {
+		selector := "app.opendatahub.io/" + componentName
+		// only removed the resource with our label applied, not the same name resource maually created by user
+		if existingOwnerReferences == nil && resourceLabels[selector] == "true" {
 			return cli.Delete(ctx, found)
 		} else if len(existingOwnerReferences) > 0 {
 			for _, owner := range existingOwnerReferences {

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -241,6 +241,7 @@ func CreateDefaultDSCI(cli client.Client, platform deploy.Platform, appNamespace
 		fmt.Printf("DSCInitialization resource already exists. It will not be updated with default DSCI.")
 		return nil
 	case len(instances.Items) == 0:
+		fmt.Printf("create default DSCI CR.")
 		err := cli.Create(context.TODO(), defaultDsci)
 		if err != nil {
 			return err


### PR DESCRIPTION
* fix: do not force check if servicemesh is set to managed in DSCI

* update: add supported value for serverless and servicemesh

- currently removed and unmanaged are the same logic

* update: do not remove resources if it has label

