### PR TITLE
update(trustyai): set component by default as Managed as GA in 2.6

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
                 "managementState": "Removed"
               },
               "trustyai": {
-                "managementState": "Removed"
+                "managementState": "Managed"
               },
               "workbenches": {
                 "managementState": "Managed"
@@ -152,7 +152,7 @@ metadata:
               "managementState": "Managed"
             },
             "trustyai": {
-              "managementState": "Removed"
+              "managementState": "Managed"
             }
           }
         }

--- a/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
               "managementState": "Managed"
             },
             "trustyai": {
-              "managementState": "Removed"
+              "managementState": "Managed"
             }
           }
         }

--- a/config/samples/datasciencecluster_v1_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v1_datasciencecluster.yaml
@@ -35,4 +35,4 @@ spec:
     workbenches:
       managementState: "Managed"
     trustyai:
-      managementState: "Removed"
+      managementState: "Managed"

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -61,7 +61,7 @@ To deploy ODH components seamlessly, ODH operator will watch two CRDs:
           workbenches:
             managementState: Managed
           trustyai:
-            managementState: Removed
+            managementState: Managed
     ```
 
 2. Enable only Dashboard and Workbenches(Jupyter Notebooks)

--- a/docs/Dev-Preview.md
+++ b/docs/Dev-Preview.md
@@ -100,7 +100,7 @@ spec:
     workbenches:
       managementState: Managed
     trustyai:
-      managementState: Removed
+      managementState: Managed
 EOF
 ```
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -170,7 +170,7 @@ func CreateDefaultDSC(cli client.Client, _ deploy.Platform) error {
 					Component: components.Component{ManagementState: operatorv1.Removed},
 				},
 				TrustyAI: trustyai.TrustyAI{
-					Component: components.Component{ManagementState: operatorv1.Removed},
+					Component: components.Component{ManagementState: operatorv1.Managed},
 				},
 			},
 		},


### PR DESCRIPTION
midstream changes https://gitlab.cee.redhat.com/data-hub/rhods-cpaas-midstream/-/merge_requests/1517

jira: https://issues.redhat.com/browse/RHOAIENG-2009