### PR TITLE
[WIP] RHOAIENG-2020: Rename TrustyAI API group

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -1621,7 +1621,7 @@ spec:
           verbs:
           - '*'
         - apiGroups:
-          - trustyai.opendatahub.io.trustyai.opendatahub.io
+          - trustyai.opendatahub.io
           resources:
           - trustyaiservices
           verbs:
@@ -1633,13 +1633,13 @@ spec:
           - update
           - watch
         - apiGroups:
-          - trustyai.opendatahub.io.trustyai.opendatahub.io
+          - trustyai.opendatahub.io
           resources:
           - trustyaiservices/finalizers
           verbs:
           - update
         - apiGroups:
-          - trustyai.opendatahub.io.trustyai.opendatahub.io
+          - trustyai.opendatahub.io
           resources:
           - trustyaiservices/status
           verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1388,7 +1388,7 @@ rules:
   verbs:
   - '*'
 - apiGroups:
-  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  - trustyai.opendatahub.io
   resources:
   - trustyaiservices
   verbs:
@@ -1400,13 +1400,13 @@ rules:
   - update
   - watch
 - apiGroups:
-  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  - trustyai.opendatahub.io
   resources:
   - trustyaiservices/finalizers
   verbs:
   - update
 - apiGroups:
-  - trustyai.opendatahub.io.trustyai.opendatahub.io
+  - trustyai.opendatahub.io
   resources:
   - trustyaiservices/status
   verbs:

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -114,9 +114,9 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=probes,verbs=get;create;patch;delete;deletecollection
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheusrules,verbs=get;create;patch;delete;deletecollection
 
-//+kubebuilder:rbac:groups=trustyai.opendatahub.io.trustyai.opendatahub.io,resources=trustyaiservices,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=trustyai.opendatahub.io.trustyai.opendatahub.io,resources=trustyaiservices/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=trustyai.opendatahub.io.trustyai.opendatahub.io,resources=trustyaiservices/finalizers,verbs=update
+//+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=trustyaiservices,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=trustyaiservices/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=trustyai.opendatahub.io,resources=trustyaiservices/finalizers,verbs=update
 
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheuses/finalizers,verbs=get;create;patch;delete;deletecollection
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=prometheuses/status,verbs=get;create;patch;delete;deletecollection


### PR DESCRIPTION
Rename TrustyAI API group in accordance to https://github.com/trustyai-explainability/trustyai-service-operator/pull/169

- https://issues.redhat.com/browse/RHOAIENG-2020
- https://issues.redhat.com/browse/RHOAIENG-342
- https://github.com/trustyai-explainability/trustyai-service-operator/pull/169