### PR TITLE
fix: adding logic to apply trustyai prometheus 

### DIFF
--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -3,6 +3,7 @@ package trustyai
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -13,6 +14,7 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/monitoring"
 )
 
 var (
@@ -50,12 +52,13 @@ func (t *TrustyAI) GetComponentName() string {
 	return ComponentName
 }
 
-func (t *TrustyAI) ReconcileComponent(_ context.Context, cli client.Client, _ *rest.Config, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
+func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
 	var imageParamMap = map[string]string{
 		"trustyaiServiceImage":  "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
 		"trustyaiOperatorImage": "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
 	}
 	enabled := t.GetManagementState() == operatorv1.Managed
+	monitoringEnabled := dscispec.Monitoring.ManagementState == operatorv1.Managed
 
 	platform, err := deploy.GetPlatform(cli)
 	if err != nil {
@@ -76,6 +79,27 @@ func (t *TrustyAI) ReconcileComponent(_ context.Context, cli client.Client, _ *r
 		}
 	}
 	// Deploy TrustyAI Operator
-	err = deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, t.GetComponentName(), enabled)
-	return err
+	if err := deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, t.GetComponentName(), enabled); err != nil {
+		return err
+	}
+
+	// CloudService Monitoring handling
+	if platform == deploy.ManagedRhods {
+		if enabled {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 10, 1); err != nil {
+				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
+			}
+			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)
+		}
+		if err := t.UpdatePrometheusConfig(cli, enabled && monitoringEnabled, ComponentName); err != nil {
+			return err
+		}
+		if err = deploy.DeployManifestsFromPath(cli, owner,
+			filepath.Join(deploy.DefaultManifestPath, "monitoring", "prometheus", "apps"),
+			dscispec.Monitoring.Namespace,
+			"prometheus", true); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -129,29 +129,6 @@ data:
       - target_label: __address__
         replacement: blackbox-exporter.<odh_monitoring_project>.svc.cluster.local:9114
 
-
-    - job_name: 'user_facing_endpoints_status_trustyai'
-      scrape_interval: 10s
-      metrics_path: /probe
-      scheme: https
-      tls_config:
-        insecure_skip_verify: true
-      params:
-        module: [http_2xx]
-      authorization:
-        credentials_file: /run/secrets/kubernetes.io/serviceaccount/token
-      static_configs:
-      - targets: [trustyai-service-operator-controller-manager-metrics-service.<odh_application_namespace>.svc:8443/metrics]
-        labels:
-          name: trustyai-service-operator-controller-manager
-      relabel_configs:
-      - source_labels: [__address__]
-        target_label: __param_target
-      - source_labels: [__param_target]
-        target_label: instance
-      - target_label: __address__
-        replacement: blackbox-exporter.<odh_monitoring_project>.svc.cluster.local:9114
-
     - job_name: 'Kubeflow Notebook Controller Service Metrics'
       honor_labels: true
       metrics_path: /metrics
@@ -337,19 +314,22 @@ data:
       metrics_path: /metrics
       scheme: http
       kubernetes_sd_configs:
-        - role: endpoints
+        - role: pod
           namespaces:
             names:
               - <odh_application_namespace>
+          selectors:
+            - role: pod
+              label: 'app.opendatahub.io/trustyai=true'
       relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          regex: ^(trustyai-service-operator-controller-manager-metrics-service)$
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_part_of]
+          regex: ^(trustyai)$
           target_label: kubernetes_name
           action: keep
         - source_labels: [__address__]
           regex: (.+):(\d+)
           target_label: __address__
-          replacement: ${1}:8080          
+          replacement: ${1}:8080
 
     - job_name: 'RHODS Metrics'
       honor_labels: true
@@ -1207,7 +1187,7 @@ data:
 
   kserve-alerting.rules: |
     groups:
-      - name: SLOs-probe_success
+      - name: SLOs-probe_success_kserve
         rules:
         - alert: Kserve Controller Probe Success Burn Rate
           annotations:
@@ -1451,43 +1431,43 @@ data:
             instance: trustyai-service-operator-controller-manager
           record: probe_success
         - expr: |
-            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[1d]))
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[1d]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate1d
         - expr: |
-            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[1h]))
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[1h]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate1h
         - expr: |
-            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[2h]))
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[2h]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate2h
         - expr: |
-            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[30m]))
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[30m]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate30m
         - expr: |
-            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[3d]))
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[3d]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate3d
         - expr: |
-            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[5m]))
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[5m]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate5m
         - expr: |
-            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[6h]))
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[6h]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate6h
   trustyai-alerting.rules: |
     groups:
-      - name: SLOs-probe_success
+      - name: SLOs-probe_success_trustyai
         rules:
         - alert: TrustyAI Controller Probe Success Burn Rate
           annotations:
@@ -1501,6 +1481,7 @@ data:
           for: 2m
           labels:
             severity: critical
+            instance: trustyai-service-operator-controller-manager
         - alert: TrustyAI Controller Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
@@ -1513,6 +1494,7 @@ data:
           for: 15m
           labels:
             severity: critical
+            instance: trustyai-service-operator-controller-manager
         - alert: TrustyAI Controller Probe Success Burn Rate
           annotations:
             message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
@@ -1525,3 +1507,4 @@ data:
           for: 1h
           labels:
             severity: warning
+            instance: trustyai-service-operator-controller-manager

--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -129,6 +129,29 @@ data:
       - target_label: __address__
         replacement: blackbox-exporter.<odh_monitoring_project>.svc.cluster.local:9114
 
+
+    - job_name: 'user_facing_endpoints_status_trustyai'
+      scrape_interval: 10s
+      metrics_path: /probe
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+      params:
+        module: [http_2xx]
+      authorization:
+        credentials_file: /run/secrets/kubernetes.io/serviceaccount/token
+      static_configs:
+      - targets: [trustyai-service-operator-controller-manager-metrics-service.<odh_application_namespace>.svc:8443/metrics]
+        labels:
+          name: trustyai-service-operator-controller-manager
+      relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter.<odh_monitoring_project>.svc.cluster.local:9114
+
     - job_name: 'Kubeflow Notebook Controller Service Metrics'
       honor_labels: true
       metrics_path: /metrics
@@ -320,7 +343,7 @@ data:
               - <odh_application_namespace>
       relabel_configs:
         - source_labels: [__meta_kubernetes_service_name]
-          regex: ^(trustyai-service-operator-controller-manager)$
+          regex: ^(trustyai-service-operator-controller-manager-metrics-service)$
           target_label: kubernetes_name
           action: keep
         - source_labels: [__address__]
@@ -1428,37 +1451,37 @@ data:
             instance: trustyai-service-operator-controller-manager
           record: probe_success
         - expr: |
-            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[1d]))
+            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[1d]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate1d
         - expr: |
-            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[1h]))
+            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[1h]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate1h
         - expr: |
-            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[2h]))
+            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[2h]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate2h
         - expr: |
-            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[30m]))
+            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[30m]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate30m
         - expr: |
-            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[3d]))
+            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[3d]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate3d
         - expr: |
-            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[5m]))
+            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[5m]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate5m
         - expr: |
-            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[6h]))
+            1 - min(avg_over_time(probe_success{instance=~"trustyai-service-operator-controller-manager", job="user_facing_endpoints_status_trustyai"}[6h]))
           labels:
             instance: trustyai-service-operator-controller-manager
           record: probe_success:burnrate6h


### PR DESCRIPTION
as part of https://issues.redhat.com/browse/RHOAIENG-99
we have rules defined in commit https://github.com/red-hat-data-services/rhods-operator/pull/161
but still need the logic in operator to apply such

also tuning these rules from original commit

new:  (live build quay.io/wenzhou/rhods-operator-catalog:v2.6.173) 
update tests:

![Screenshot from 2024-01-24 13-48-44](https://github.com/red-hat-data-services/rhods-operator/assets/915053/edae1144-8754-4da6-b190-d6c5bc1d8d3d)


old: 
test on live build: can confirm config has been applied for trustyai
![Screenshot from 2024-01-24 10-36-38](https://github.com/red-hat-data-services/rhods-operator/assets/915053/816d2bcf-c732-422a-8532-86b82062680a)

