### PR TITLE
update: to keep SMCP CR even servicemesh state is set to Removed

### DIFF
--- a/controllers/dscinitialization/servicemesh_setup.go
+++ b/controllers/dscinitialization/servicemesh_setup.go
@@ -32,7 +32,7 @@ func (r *DSCInitializationReconciler) configureServiceMesh(instance *dsciv1.DSCI
 	case operatorv1.Unmanaged:
 		r.Log.Info("ServiceMesh CR is not configured by the operator, we won't do anything")
 	case operatorv1.Removed:
-		r.Log.Info("existing ServiceMesh CR (owned by operator) will be removed")
+		r.Log.Info("existing ServiceMesh CR (owned by operator) will not be removed")
 		if err := r.removeServiceMesh(instance); err != nil {
 			return err
 		}


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/RHOAIENG-2209

offline converstaion: https://redhat-internal.slack.com/archives/C067G701YP6/p1706255091619629
in short: 
we keep the same behavior as in 2.5 for the deletion
we updates the message to user that Removed will not delete SMCP

follow up logic change will be introduced in 2.7
