### PR TITLE
[backport]: missing get verbs on MWC and secrets

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -289,6 +289,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -685,6 +686,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,6 +56,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -452,6 +453,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -164,7 +164,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 
-// +kubebuilder:rbac:groups="core",resources=secrets,verbs=create;delete;list;update;watch;patch
+// +kubebuilder:rbac:groups="core",resources=secrets,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="core",resources=secrets/finalizers,verbs=get;create;watch;update;patch;list;delete
 
 // +kubebuilder:rbac:groups="core",resources=rhmis,verbs=watch;list
@@ -233,7 +233,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch;create;patch;delete
 
 // +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=validatingwebhookconfigurations,verbs=get;list;watch;create;update;delete;patch
-// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=create;delete;list;update;watch;patch
+// +kubebuilder:rbac:groups="admissionregistration.k8s.io",resources=mutatingwebhookconfigurations,verbs=create;delete;list;update;watch;patch;get
 
 /* This is needed to derterminiate cluster type */
 // +kubebuilder:rbac:groups="addons.managed.openshift.io",resources=addons,verbs=get


### PR DESCRIPTION
- this is causing MWC CR from kserve did not get cleaned up when kserve is Removed

backport https://github.com/red-hat-data-services/rhods-operator/pull/174