### PR TITLE
Redefine Kserve Controller Manager scrape config

### DIFF
--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -210,12 +210,15 @@ data:
       metrics_path: /metrics
       scheme: http
       kubernetes_sd_configs:
-        - role: endpoints
+        - role: pod
           namespaces:
             names:
               - <odh_application_namespace>
+          selectors: 
+          - role: pod 
+            label: 'app.kubernetes.io/part-of=kserve'
       relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
+        - source_labels: [__meta_kubernetes_pod_label_control_plane]
           regex: ^(kserve-controller-manager)$
           target_label: kubernetes_name
           action: keep


### PR DESCRIPTION
Fixes :  https://issues.redhat.com/browse/RHOAIENG-2189 

Context: 
The service created for the Kserve Controller Manager is badly configured and hence cannot be used to define the scrape config for controller metrics as the existing config results in an invalid scrape target for the SRE prometheus in `redhat-ods-monitoring`. We need to use the controller pod directly as the defined scrape target for these metrics. 
(Thanks @israel-hdez for the solution) 

Changes : 
Changed the scrape config job for Kserve Controller to use the pod directly instead of the service. 

Results: 
The Kserve Controller Manager shows up in the list of Prometheus Targets. 
![Screenshot 2023-07-11 104622](https://github.com/red-hat-data-services/rhods-operator/assets/20891020/b7c3f148-4670-47b0-a4bb-4b622c32725b)

The previously firing alert is now gone 
![image](https://github.com/red-hat-data-services/rhods-operator/assets/20891020/92ac8ea8-b0de-44eb-b9b3-4cb3e11a23f2)

Testing Steps: 
- Install the RHOAI 2.6.0 RC1 build using OLM install, specifically as an addon. 
   - `./setup.sh -t addon -u fast -i brew.registry.redhat.io/rh-osbs/iib:655647`
- After the DSC is `Ready`, scale the operator deployment in `redhat-ods-operator` to 0 to prevent reconciliation of the prometheus scrape configs. 
- In the namespace `redhat-ods-monitoring`, apply the changes in this PR in the `ConfigMap` named `prometheus`. 
- Delete the prometheus pod in `redhat-ods-monitoring` and allow the deployment to re-create it. 
- Access the Prometheus UI in `redhat-ods-monitoring` and verify results similar to the screenshots attached earlier in the PR. 