### PR TITLE
fix(prometheus): mapping for trustyai and rhods operator

### DIFF
--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -328,7 +328,7 @@ data:
           target_label: __address__
           replacement: ${1}:8080          
 
-    - job_name: 'RHODS Metrics'
+    - job_name: 'RHOAI Metrics'
       honor_labels: true
       scheme: http
       kubernetes_sd_configs:
@@ -359,12 +359,12 @@ data:
         interval: 15m
         rules:
         - expr: |
-            rate(controller_runtime_reconcile_total{controller="dscinitialization-controller", job="RHODS Metrics", result!="success"}[15m])
+            rate(controller_runtime_reconcile_total{controller="dscinitialization-controller", job="RHOAI Metrics", result!="success"}[15m])
           labels:
             instance: dscinitialization-controller
           record: controller_runtime_reconcile_total:rate15m
         - expr: |
-            rate(controller_runtime_reconcile_total{controller="datasciencecluster-controller", job="RHODS Metrics", result!="success"}[15m])
+            rate(controller_runtime_reconcile_total{controller="datasciencecluster-controller", job="RHOAI Metrics", result!="success"}[15m])
           labels:
             instance: datasciencecluster-controller
           record: controller_runtime_reconcile_total:rate15m

--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -324,7 +324,7 @@ data:
           target_label: kubernetes_name
           action: keep
         - source_labels: [__address__]
-          regex: (.+):(\d+)
+          regex: (.*)
           target_label: __address__
           replacement: ${1}:8080          
 
@@ -332,17 +332,17 @@ data:
       honor_labels: true
       scheme: http
       kubernetes_sd_configs:
-        - role: endpoints
+        - role: pod
           namespaces:
             names:
               - redhat-ods-operator
       relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          regex: ^(redhat-ods-operator-controller-manager-metrics)$ 
+        - source_labels: [__meta_kubernetes_pod_labelpresent_control_plane]
+          regex: ^(true)$ 
           target_label: kubernetes_name
           action: keep
         - source_labels: [__address__]
-          regex: (.+):(\d+)
+          regex: (.*)
           target_label: __address__
           replacement: ${1}:8080
 


### PR DESCRIPTION
- wrong regex which does not replace to correct port number


ref: https://issues.redhat.com/browse/RHOAIENG-2506

test:  trusty should be up and should found rhods metrics
 (after change)
![Screenshot from 2024-02-02 09-42-39](https://github.com/red-hat-data-services/rhods-operator/assets/915053/44b86335-c95f-4996-88f7-fad273acd79d)
![Screenshot from 2024-02-02 10-04-35](https://github.com/red-hat-data-services/rhods-operator/assets/915053/da6f2825-9708-4e13-b59f-e02814228e0b)


(before change):
![Screenshot from 2024-02-02 10-08-58](https://github.com/red-hat-data-services/rhods-operator/assets/915053/f044c6c0-9296-44b1-90a3-09ff6ce56d8e)
![Screenshot from 2024-02-02 10-08-49](https://github.com/red-hat-data-services/rhods-operator/assets/915053/fecb6323-9398-4e61-9e54-b9013a9d5f10)

