### PR TITLE
sync: mismatch between odh and rhoai

### DIFF
--- a/bundle/manifests/redhat-ods-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/redhat-ods-operator-controller-manager-metrics-service_v1_service.yaml
@@ -7,10 +7,10 @@ metadata:
   name: redhat-ods-operator-controller-manager-metrics-service
 spec:
   ports:
-  - name: metrics
+  - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8080
   selector:
     control-plane: controller-manager
 status:

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -7,9 +7,9 @@ metadata:
   namespace: system
 spec:
   ports:
-  - name: metrics
+  - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: 8080
   selector:
     control-plane: controller-manager


### PR DESCRIPTION
not sure what happened, but this is a mismatch between odh and rhoai
see:
https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/bundle/manifests/opendatahub-operator-controller-manager-metrics-service_v1_service.yaml

operator should have service on 8080 not on "https"
