### PR TITLE
[sync]: from main to 2.7 release

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -148,6 +148,9 @@ metadata:
             "modelmeshserving": {
               "managementState": "Managed"
             },
+            "kueue": {
+              "managementState": "Removed"
+            },
             "ray": {
               "managementState": "Removed"
             },
@@ -1773,7 +1776,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: REPLACE_IMAGE:latest 
+                image: REPLACE_IMAGE:latest
                 imagePullPolicy: Always
                 livenessProbe:
                   httpGet:

--- a/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -49,6 +49,9 @@ metadata:
             "modelmeshserving": {
               "managementState": "Managed"
             },
+            "kueue": {
+              "managementState": "Removed"
+            },
             "ray": {
               "managementState": "Removed"
             },


### PR DESCRIPTION
ref: https://github.com/red-hat-data-services/rhods-operator/pull/185

see internal converstation: https://redhat-internal.slack.com/archives/C06E98JP45Q/p1707286321280849 