### PR TITLE
fix(monitoring): do not create rhods-monitor-federation2

### DIFF
--- a/config/monitoring/base/rhods-servicemonitor.yaml
+++ b/config/monitoring/base/rhods-servicemonitor.yaml
@@ -65,49 +65,49 @@ spec:
 # move from modelmesh-monitoring
 # this one is duplicated as the old modelmesh-federated-metrics
 # in order to keep metrics there if user set modelmesh to Removed
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: rhods-monitor-federation2
-  namespace: redhat-ods-monitoring
-  labels:
-    monitor-component: rhods-resources
-    team: rhods
-spec:
-  endpoints:
-    - interval: 30s
-      params:
-        'match[]':
-          - '{__name__= "haproxy_backend_http_average_response_latency_milliseconds"}'
-          - '{__name__= "haproxy_backend_http_responses_total"}'
-          - '{__name__= "container_cpu_usage_seconds_total"}'
-          - '{__name__= "container_memory_working_set_bytes"}'
-          - '{__name__= "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate"}'
-          - '{__name__= "cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits"}'
-          - '{__name__= "cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests"}'
-          - '{__name__= "cluster:namespace:pod_memory:active:kube_pod_container_resource_requests"}'
-          - '{__name__= "cluster:namespace:pod_memory:active:kube_pod_container_resource_limits"}'
-          - '{__name__= "kube_persistentvolumeclaim_resource_requests_storage_bytes"}'
-          - '{__name__= "kubelet_volume_stats_used_bytes"}'
-          - '{__name__= "kubelet_volume_stats_capacity_bytes"}'
-      honorLabels: true
-      scrapeTimeout: 10s
-      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      bearerTokenSecret:
-        key: ""
-      path: /federate
-      port: web
-      scheme: https
-      tlsConfig:
-        ca: {}
-        cert: {}
-        insecureSkipVerify: true
-  namespaceSelector:
-    matchNames:
-      - openshift-monitoring
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: prometheus
-      app.kubernetes.io/instance: k8s
-      app.kubernetes.io/name: prometheus
-      app.kubernetes.io/part-of: openshift-monitoring
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   name: rhods-monitor-federation2
+#   namespace: redhat-ods-monitoring
+#   labels:
+#     monitor-component: rhods-resources
+#     team: rhods
+# spec:
+#   endpoints:
+#     - interval: 30s
+#       params:
+#         'match[]':
+#           - '{__name__= "haproxy_backend_http_average_response_latency_milliseconds"}'
+#           - '{__name__= "haproxy_backend_http_responses_total"}'
+#           - '{__name__= "container_cpu_usage_seconds_total"}'
+#           - '{__name__= "container_memory_working_set_bytes"}'
+#           - '{__name__= "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate"}'
+#           - '{__name__= "cluster:namespace:pod_cpu:active:kube_pod_container_resource_limits"}'
+#           - '{__name__= "cluster:namespace:pod_cpu:active:kube_pod_container_resource_requests"}'
+#           - '{__name__= "cluster:namespace:pod_memory:active:kube_pod_container_resource_requests"}'
+#           - '{__name__= "cluster:namespace:pod_memory:active:kube_pod_container_resource_limits"}'
+#           - '{__name__= "kube_persistentvolumeclaim_resource_requests_storage_bytes"}'
+#           - '{__name__= "kubelet_volume_stats_used_bytes"}'
+#           - '{__name__= "kubelet_volume_stats_capacity_bytes"}'
+#       honorLabels: true
+#       scrapeTimeout: 10s
+#       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+#       bearerTokenSecret:
+#         key: ""
+#       path: /federate
+#       port: web
+#       scheme: https
+#       tlsConfig:
+#         ca: {}
+#         cert: {}
+#         insecureSkipVerify: true
+#   namespaceSelector:
+#     matchNames:
+#       - openshift-monitoring
+#   selector:
+#     matchLabels:
+#       app.kubernetes.io/component: prometheus
+#       app.kubernetes.io/instance: k8s
+#       app.kubernetes.io/name: prometheus
+#       app.kubernetes.io/part-of: openshift-monitoring


### PR DESCRIPTION
- it is not in use and was previously imported from modelmesh
https://redhat-internal.slack.com/archives/C03UGJY6Z1A/p1707320748074229?thread_ts=1704193152.827009&cid=C03UGJY6Z1A


related to https://issues.redhat.com/browse/RHOAIENG-2479