### PR TITLE
update(nwp): rhoai open application ns with ingress from all ns

### DIFF
--- a/config/monitoring/networkpolicy/applications/applications.yaml
+++ b/config/monitoring/networkpolicy/applications/applications.yaml
@@ -22,13 +22,15 @@ spec:
           port: 8099
         - protocol: TCP
           port: 8181
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: redhat-ods-monitoring
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: openshift-monitoring
+        - protocol: TCP
+          port: 9443    # default webhook of components
+    # - from:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: redhat-ods-monitoring
+    # - from:
+    #     - namespaceSelector:
+    #         matchLabels:
+    #           kubernetes.io/metadata.name: openshift-monitoring
   policyTypes:
     - Ingress


### PR DESCRIPTION
- add 9443 to list which is default for component's controller

to lose NWP:  not only limit for monitoring => application, but all others, since we have traffic might be from DSproject to applications as well. 


this can related to the fix kueue made for https://issues.redhat.com/browse/RHOAIENG-3914 to create their own NWP.
we might have other components need 9443 open as well, if we should have operator finally controller NWP instead of component to create their own, then we need to move this into rhoai operator 