### PR TITLE
Restore trustyAI manifest references in 2.8

### DIFF
--- a/components/trustyai/trustyai.go
+++ b/components/trustyai/trustyai.go
@@ -3,6 +3,7 @@ package trustyai
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -13,6 +14,7 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/monitoring"
 )
 
 var (
@@ -53,12 +55,13 @@ func (t *TrustyAI) GetComponentName() string {
 	return ComponentName
 }
 
-func (t *TrustyAI) ReconcileComponent(_ context.Context, cli client.Client, _ *rest.Config, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
+func (t *TrustyAI) ReconcileComponent(ctx context.Context, cli client.Client, resConf *rest.Config, owner metav1.Object, dscispec *dsciv1.DSCInitializationSpec, _ bool) error {
 	var imageParamMap = map[string]string{
 		"trustyaiServiceImage":  "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
 		"trustyaiOperatorImage": "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
 	}
 	enabled := t.GetManagementState() == operatorv1.Managed
+	monitoringEnabled := dscispec.Monitoring.ManagementState == operatorv1.Managed
 
 	platform, err := deploy.GetPlatform(cli)
 	if err != nil {
@@ -67,7 +70,7 @@ func (t *TrustyAI) ReconcileComponent(_ context.Context, cli client.Client, _ *r
 
 	// Return when platform is RHOAI
 	if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods {
-		return nil
+		enabled = false
 	}
 
 	if enabled {
@@ -84,6 +87,27 @@ func (t *TrustyAI) ReconcileComponent(_ context.Context, cli client.Client, _ *r
 		}
 	}
 	// Deploy TrustyAI Operator
+	if err := deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, t.GetComponentName(), enabled); err != nil {
+		return err
+	}
 
-	return deploy.DeployManifestsFromPath(cli, owner, Path, dscispec.ApplicationsNamespace, t.GetComponentName(), enabled)
+	// CloudService Monitoring handling
+	if platform == deploy.ManagedRhods {
+		if enabled {
+			if err := monitoring.WaitForDeploymentAvailable(ctx, resConf, ComponentName, dscispec.ApplicationsNamespace, 10, 1); err != nil {
+				return fmt.Errorf("deployment for %s is not ready to server: %w", ComponentName, err)
+			}
+			fmt.Printf("deployment for %s is done, updating monitoring rules\n", ComponentName)
+		}
+		if err := t.UpdatePrometheusConfig(cli, enabled && monitoringEnabled, ComponentName); err != nil {
+			return err
+		}
+		if err = deploy.DeployManifestsFromPath(cli, owner,
+			filepath.Join(deploy.DefaultManifestPath, "monitoring", "prometheus", "apps"),
+			dscispec.Monitoring.Namespace,
+			"prometheus", true); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -309,6 +309,28 @@ data:
           target_label: __address__
           replacement: ${1}:8080
 
+    - job_name: 'TrustyAI Controller Manager'
+      honor_labels: true
+      metrics_path: /metrics
+      scheme: http
+      kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+              - <odh_application_namespace>
+          selectors:
+            - role: pod
+              label: 'app.opendatahub.io/trustyai=true'
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_part_of]
+          regex: ^(trustyai)$
+          target_label: kubernetes_name
+          action: keep
+        - source_labels: [__address__]
+          regex: (.*)
+          target_label: __address__
+          replacement: ${1}:8080
+
     - job_name: 'RHOAI Metrics'
       honor_labels: true
       scheme: http
@@ -1398,3 +1420,91 @@ data:
           labels:
             severity: warning
             instance: notebook-spawner
+
+  trustyai-recording.rules: |
+    groups:
+      - name: SLOs - TrustyAI Controller Manager
+        rules:
+        - expr: |
+            absent(up{job=~'TrustyAI Controller Manager'}) * 0 or vector(1)
+          labels:
+            instance: trustyai-service-operator-controller-manager
+          record: probe_success
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[1d]))
+          labels:
+            instance: trustyai-service-operator-controller-manager
+          record: probe_success:burnrate1d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[1h]))
+          labels:
+            instance: trustyai-service-operator-controller-manager
+          record: probe_success:burnrate1h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[2h]))
+          labels:
+            instance: trustyai-service-operator-controller-manager
+          record: probe_success:burnrate2h
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[30m]))
+          labels:
+            instance: trustyai-service-operator-controller-manager
+          record: probe_success:burnrate30m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[3d]))
+          labels:
+            instance: trustyai-service-operator-controller-manager
+          record: probe_success:burnrate3d
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[5m]))
+          labels:
+            instance: trustyai-service-operator-controller-manager
+          record: probe_success:burnrate5m
+        - expr: |
+            1 - min(avg_over_time(probe_success{instance="trustyai-service-operator-controller-manager"}[6h]))
+          labels:
+            instance: trustyai-service-operator-controller-manager
+          record: probe_success:burnrate6h
+  trustyai-alerting.rules: |
+    groups:
+      - name: SLOs-probe_success_trustyai
+        rules:
+        - alert: TrustyAI Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-trustyai-controller-probe-success-burn-rate.md"
+            summary: TrustyAI Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate5m{instance=~"trustyai-service-operator-controller-manager"}) by (instance) > (14.40 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1h{instance=~"trustyai-service-operator-controller-manager"}) by (instance) > (14.40 * (1-0.98000))
+          for: 2m
+          labels:
+            severity: critical
+            instance: trustyai-service-operator-controller-manager
+        - alert: TrustyAI Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-trustyai-controller-probe-success-burn-rate.md"
+            summary: TrustyAI Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate30m{instance=~"trustyai-service-operator-controller-manager"}) by (instance) > (6.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate6h{instance=~"trustyai-service-operator-controller-manager"}) by (instance) > (6.00 * (1-0.98000))
+          for: 15m
+          labels:
+            severity: critical
+            instance: trustyai-service-operator-controller-manager
+        - alert: TrustyAI Controller Probe Success Burn Rate
+          annotations:
+            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhoai-trustyai-controller-probe-success-burn-rate.md"
+            summary: TrustyAI Controller Probe Success Burn Rate
+          expr: |
+            sum(probe_success:burnrate2h{instance=~"trustyai-service-operator-controller-manager"}) by (instance) > (3.00 * (1-0.98000))
+            and
+            sum(probe_success:burnrate1d{instance=~"trustyai-service-operator-controller-manager"}) by (instance) > (3.00 * (1-0.98000))
+          for: 1h
+          labels:
+            severity: warning
+            instance: trustyai-service-operator-controller-manager

--- a/main.go
+++ b/main.go
@@ -213,6 +213,12 @@ func main() {
 		setupLog.Error(err, "unable to update from legacy operator version")
 	}
 
+	// Remove TrustyAI forRHOAI
+	// TODO: Remove below check in 2.9 version
+	if err = upgrade.RemoveDeprecatedTrustyAI(setupClient, platform); err != nil {
+		setupLog.Error(err, "unable to remove trustyai from DSC")
+	}
+
 	if err = upgrade.CleanupExistingResource(setupClient, platform); err != nil {
 		setupLog.Error(err, "unable to perform cleanup")
 	}


### PR DESCRIPTION
We cannot remove manifest references and cleanup logic for 2.8. This is to support upgrade path 2.6 --> 2.8
Ref: https://issues.redhat.com/browse/RHOAIENG-4332