### PR TITLE
[cherry-pick]: remove label on operator namespace

### DIFF
--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -122,7 +122,6 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 		if platform == deploy.SelfManagedRhods || platform == deploy.ManagedRhods {
 			_, err := cluster.CreateNamespace(cli, "rhods-notebooks", cluster.WithLabels(cluster.ODHGeneratedNamespaceLabel, "true"))
 			if err != nil {
-				// no need to log error as it was already logged in createOdhNamespace
 				return err
 			}
 		}

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -22,7 +22,6 @@ import (
 	dsci "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 )
 
 var (
@@ -37,10 +36,6 @@ var (
 // - Network Policies 'opendatahub' that allow traffic between the ODH namespaces
 // - RoleBinding 'opendatahub'.
 func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, dscInit *dsci.DSCInitialization, name string) error {
-	platform, err := deploy.GetPlatform(r.Client)
-	if err != nil {
-		return err
-	}
 	// Expected namespace for the given name
 	desiredNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
@@ -54,7 +49,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 
 	// Create Namespace if it doesn't exist
 	foundNamespace := &corev1.Namespace{}
-	err = r.Get(ctx, client.ObjectKey{Name: name}, foundNamespace)
+	err := r.Get(ctx, client.ObjectKey{Name: name}, foundNamespace)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
 			r.Log.Info("Creating namespace", "name", name)
@@ -114,27 +109,6 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 			labelPatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true", "pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}`
 
 			err = r.Patch(ctx, foundMonitoringNamespace, client.RawPatch(types.MergePatchType, []byte(labelPatch)))
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	// Patch downstream Operator Namespace if it is monitoring enabled
-	if dscInit.Spec.Monitoring.ManagementState == operatorv1.Managed {
-		if platform == deploy.ManagedRhods || platform == deploy.SelfManagedRhods {
-			operatorNs, err := upgrade.GetOperatorNamespace()
-			if err != nil {
-				r.Log.Error(err, "error getting operator namespace")
-				return err
-			}
-			r.Log.Info("Patching operator namespace", "name", operatorNs)
-			labelPatch := `{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"baseline"}}}`
-			operatorNamespace := &corev1.Namespace{}
-			if err := r.Get(ctx, client.ObjectKey{Name: operatorNs}, operatorNamespace); err != nil {
-				return err
-			}
-			err = r.Patch(ctx, operatorNamespace, client.RawPatch(types.MergePatchType, []byte(labelPatch)))
 			if err != nil {
 				return err
 			}

--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -36,7 +36,7 @@ var (
 // - Network Policies 'opendatahub' that allow traffic between the ODH namespaces
 // - RoleBinding 'opendatahub'.
 func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, dscInit *dsci.DSCInitialization, name string) error {
-	// Expected namespace for the given name
+	// Expected application namespace for the given name
 	desiredNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -47,7 +47,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 		},
 	}
 
-	// Create Namespace if it doesn't exist
+	// Create Application Namespace if it doesn't exist
 	foundNamespace := &corev1.Namespace{}
 	err := r.Get(ctx, client.ObjectKey{Name: name}, foundNamespace)
 	if err != nil {
@@ -68,6 +68,7 @@ func (r *DSCInitializationReconciler) createOdhNamespace(ctx context.Context, ds
 			r.Log.Error(err, "Unable to fetch namespace", "name", name)
 			return err
 		}
+		// Patch Application Namespace if it exists
 	} else if dscInit.Spec.Monitoring.ManagementState == operatorv1.Managed {
 		r.Log.Info("Patching application namespace for Managed cluster", "name", name)
 		labelPatch := `{"metadata":{"labels":{"openshift.io/cluster-monitoring":"true","pod-security.kubernetes.io/enforce":"baseline","opendatahub.io/generated-namespace": "true"}}}`


### PR DESCRIPTION
ref: https://github.com/opendatahub-io/opendatahub-operator/pull/883
jira https://issues.redhat.com/browse/RHOAIENG-3889

**live build quay.io/wenzhou/rhods-operator-catalog:v2.9.3889-10**
1. test on new installation:
no  label `pod-security.kubernetes.io/enforce `created on redhat-ods-operator namespace

2. test on cleanup:
based on above case, add label `pod-security.kubernetes.io/enforce:baseline`on the redhat-ods-oeprator namespace
![Screenshot from 2024-03-14 13-56-12](https://github.com/red-hat-data-services/rhods-operator/assets/915053/567e0a98-49e6-45e3-b580-0567527528e3)

then restart operator pod
then check nemspace, label `pod-security.kubernetes.io/enforce` is gone
![Screenshot from 2024-03-14 16-42-46](https://github.com/red-hat-data-services/rhods-operator/assets/915053/6059e526-01e4-497f-906d-afacbcb71dd1)


