### PR TITLE
fix(monitoring): only deploy role and rolebinding and servicemonitoring for Managed cluster

### DIFF
--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -432,7 +432,7 @@ func createMonitoringProxySecret(cli client.Client, name string, dsciInit *dsci.
 	return nil
 }
 
-func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsci.DSCInitialization) error {
+func (r *DSCInitializationReconciler) configureSegment(dsciInit *dsci.DSCInitialization) error {
 	// configure segment.io
 	segmentPath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "segment")
 	if err := deploy.DeployManifestsFromPath(
@@ -445,6 +445,10 @@ func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsci.D
 		r.Log.Error(err, "error to deploy manifests under "+segmentPath)
 		return err
 	}
+	return nil
+}
+
+func (r *DSCInitializationReconciler) configureMonitoring(dsciInit *dsci.DSCInitialization) error {
 	// configure monitoring base
 	monitoringBasePath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "base")
 	err := common.ReplaceStringsInFile(filepath.Join(monitoringBasePath, "rhods-servicemonitor.yaml"),


### PR DESCRIPTION
only create monitoring NS for Managed cluster
ModelMesh has moved away from SRE monitoring. no need redhat-ods-monitoring for Managed cluster.

- the change is to add a check when we craete namespace, if it is on Manage cluster then do not crate monitoring namespace
- also when calling for `configureManagedMonitoring` only for management cluster
- split `configureSegment` from old `configureCommonMonitoring` which is called by both Managed and Self-Managed cluster
- 


Did a test for upgrade 2.4 to 2.5 to 2.6 on self-managed cluster
the `CleanupExistingResource` during upgrade handles cleaning resource which was previous deployed by modelmesh so, we do not need namespace `redhat-ods-monitoring` any more, 

live build quay.io/wenzhou/rhods-operator-catalog:v2.10.2761-1

ref: https://issues.redhat.com/browse/RHOAIENG-2761