### PR TITLE
fix: remove duplicated call to the upgrade function in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -208,12 +208,7 @@ func main() {
 		}
 	}
 
-	// Apply update from legacy operator
-	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace, dscMonitoringNamespace); err != nil {
-		setupLog.Error(err, "unable to update from legacy operator version")
-	}
-
-	// Remove TrustyAI forRHOAI
+	// Remove TrustyAI for RHOAI
 	// TODO: Remove below check when trustyai manifests are removed in midstream
 	if err = upgrade.RemoveDeprecatedTrustyAI(setupClient, platform); err != nil {
 		setupLog.Error(err, "unable to remove trustyai from DSC")
@@ -230,7 +225,7 @@ func main() {
 		setupLog.Error(err, "error remove deprecated resources from previous version")
 	}
 
-	// Apply update from legacy operator
+	// Apply update from legacy operator and create default DSC for Managed platform
 	if err = upgrade.UpdateFromLegacyVersion(setupClient, platform, dscApplicationsNamespace, dscMonitoringNamespace); err != nil {
 		setupLog.Error(err, "unable to update from legacy operator version")
 	}


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/RHOAIENG-6449

this is causing double called in the startup and looks like DSC already exist in the log but actually it was create by the first call
log from Kevin's test
```
I0424 08:47:43.602533       1 request.go:682] Waited for 1.038296111s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/k8s.cni.cncf.io/v1?timeout=32s
2024-04-24T08:47:45Z	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": "0.0.0.0:8080"}
2024-04-24T08:47:45Z	INFO	secret-generator	Adding controller for Secret Generation.
2024-04-24T08:47:45Z	INFO	cert-configmap-generator	Adding controller for Configmap Generation.
starting deletion of Deployment in managed cluster
removing labels on Operator Namespace
creating default DSC CR
created DataScienceCluster resource
starting deletion of Deployment in managed cluster
removing labels on Operator Namespace
creating default DSC CR
DataScienceCluster resource already exists. It will not be updated with default DSC.
```