### PR TITLE
Add watch to deleted ns

### DIFF
--- a/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
+++ b/controllers/certconfigmapgenerator/certconfigmapgenerator_controller.go
@@ -53,6 +53,9 @@ func (r *CertConfigmapGeneratorReconciler) Reconcile(ctx context.Context, req ct
 	// Get namespace instance
 	userNamespace := &corev1.Namespace{}
 	if err := r.Client.Get(ctx, client.ObjectKey{Name: req.Namespace}, userNamespace); err != nil {
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
 		return ctrl.Result{}, errors.WithMessage(err, "error getting namespace to inject trustedCA bundle ")
 	}
 
@@ -138,6 +141,10 @@ var NamespaceCreatedPredicate = predicate.Funcs{
 			return true
 		}
 		return false
+	},
+
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return trustedcabundle.ShouldInjectTrustedBundle(e.Object)
 	},
 }
 


### PR DESCRIPTION
This is part of https://issues.redhat.com/browse/RHOAIENG-5514

Triggers automatic reconcile when namespace is deleted, instead of waiting on eventual reconciliation