### PR TITLE
feat(modelserving): skip reconcile on deployment resources

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -305,6 +305,13 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 		}
 	}
 
+	// JIRA 6889.  odh-model-controller will be covered by either kserve or model-mesh case
+	if componentName == "model-mesh" {
+		if err := removeResourcesFromDeployment(obj); err != nil {
+			return err
+		}
+	}
+
 	// Preserve app.opendatahub.io/<component> labels of previous versions of existing objects
 	foundLabels := make(map[string]string)
 	for k, v := range found.GetLabels() {


### PR DESCRIPTION
ref https://issues.redhat.com/browse/RHOAIENG-6989

it is similar request but on model servering.
we no need to opt on odh-model-controller since it uses the same component name either by kserve or model servering.

As: if we only enabled Kserve but not modelmesh in 2.9.0, we can config odh-model-controller resource already.


local build quay.io/wenzhou/rhods-operator-catalog:v2.9.6989 
manually updated deployment of 

modelmesh-controller to
![Screenshot from 2024-05-09 16-05-36](https://github.com/red-hat-data-services/rhods-operator/assets/915053/5c849ac2-ae83-4f82-9da6-b4a7a471b889)

odh-model-controller to
![Screenshot from 2024-05-09 16-10-02](https://github.com/red-hat-data-services/rhods-operator/assets/915053/64bdbf8c-f414-4dc2-acac-acf49806e133)

pods get recreated and stay the same value , not reverted back to original one

