### PR TITLE
Fix metadata.managedFields must be nil error in DSC (#1018)

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -35,6 +34,7 @@ import (
 	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	"golang.org/x/exp/maps"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
@@ -227,7 +227,7 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 	}
 
 	// If resource already exists, update it.
-	return updateResource(ctx, cli, obj, found, owner, componentName)
+	return updateResource(ctx, cli, obj, found, owner)
 }
 
 /*
@@ -445,7 +445,7 @@ func performPatch(ctx context.Context, cli client.Client, obj, found *unstructur
 	return cli.Patch(ctx, found, client.RawPatch(types.ApplyPatchType, data), client.ForceOwnership, client.FieldOwner(owner.GetName()))
 }
 
-func updateResource(ctx context.Context, cli client.Client, obj, found *unstructured.Unstructured, owner metav1.Object, componentName string) error {
+func updateResource(ctx context.Context, cli client.Client, obj, found *unstructured.Unstructured, owner metav1.Object) error {
 	// Skip ODHDashboardConfig Update
 	if found.GetKind() == "OdhDashboardConfig" {
 		return nil


### PR DESCRIPTION
* Fix metadata.managedFields must be nil error in DSC

* Address comments

This commit also updates how we fetch resources from cluster

* Fix getResource function

* addressed comments

* fix linters

* Update resource deletion

Patching resources is not required before deletion. Updated delete function

* Fix linters

(cherry picked from commit f4e66f0972823364b2d8b21ad81c58f07379cf92)