### PR TITLE
cluster_config: make GetClusterServiceVersion return NotFound error

### DIFF
--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -3,6 +3,12 @@ package gvk
 import "k8s.io/apimachinery/pkg/runtime/schema"
 
 var (
+	ClusterServiceVersion = schema.GroupVersionKind{
+		Group:   "operators.coreos.com",
+		Version: "v1alpha1",
+		Kind:    "ClusterServiceVersion",
+	}
+
 	KnativeServing = schema.GroupVersionKind{
 		Group:   "operator.knative.dev",
 		Version: "v1beta1",

--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -221,6 +221,11 @@ func manageResource(ctx context.Context, cli client.Client, obj *unstructured.Un
 		return createResource(ctx, cli, obj, owner)
 	}
 
+	// Exception to not update kserve with managed annotation
+	// do not reconcile kserve resource with annotation "opendatahub.io/managed: false"
+	if found.GetAnnotations()["opendatahub.io/managed"] == "false" && componentName == "kserve" {
+		return nil
+	}
 	// If resource already exists, update it.
 	return updateResource(ctx, cli, obj, found, owner, componentName)
 }

--- a/pkg/upgrade/uninstallation.go
+++ b/pkg/upgrade/uninstallation.go
@@ -142,24 +142,26 @@ func removeCSV(ctx context.Context, c client.Client) error {
 	}
 
 	operatorCsv, err := cluster.GetClusterServiceVersion(ctx, c, operatorNamespace)
+	if apierrs.IsNotFound(err) {
+		fmt.Printf("No clusterserviceversion for the operator found.\n")
+		return nil
+	}
+
 	if err != nil {
 		return err
 	}
 
-	if operatorCsv != nil {
-		fmt.Printf("Deleting CSV %s\n", operatorCsv.Name)
-		err = c.Delete(ctx, operatorCsv)
-		if err != nil {
-			if apierrs.IsNotFound(err) {
-				return nil
-			}
-
-			return fmt.Errorf("error deleting clusterserviceversion: %w", err)
+	fmt.Printf("Deleting CSV %s\n", operatorCsv.Name)
+	err = c.Delete(ctx, operatorCsv)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			return nil
 		}
-		fmt.Printf("Clusterserviceversion %s deleted as a part of uninstall.\n", operatorCsv.Name)
-		return nil
+
+		return fmt.Errorf("error deleting clusterserviceversion: %w", err)
 	}
-	fmt.Printf("No clusterserviceversion for the operator found.\n")
+	fmt.Printf("Clusterserviceversion %s deleted as a part of uninstall.\n", operatorCsv.Name)
+
 	return nil
 }
 


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/RHOAIENG-7938
GetClusterServiceVersion() may return nil error and nil pointer. On one hand it's ok to check object for nil in not found condition but it's a bit counter intuitive to have err nil when there is acutally "not found"

It caused a problem in GetVersion where this nil condition was not checked.

Refactor it to return the error and handle it properly.

Signed-off-by: Yauheni Kaliuta <ykaliuta@redhat.com>
(cherry picked from commit 842550dc209473a79ea7351a6458647dfab2b3c5)