### PR TITLE
[rhoai-2.8.3] Fix deploy func refactor

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -381,12 +381,14 @@ spec:
           - tokenreviews
           verbs:
           - create
+          - get
         - apiGroups:
           - authorization.k8s.io
           resources:
           - subjectaccessreviews
           verbs:
           - create
+          - get
         - apiGroups:
           - authorization.openshift.io
           resources:
@@ -418,6 +420,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -428,6 +431,7 @@ spec:
           - machineautoscalers
           verbs:
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -436,6 +440,7 @@ spec:
           - machinesets
           verbs:
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -475,6 +480,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - watch
@@ -496,6 +502,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - watch
@@ -536,6 +543,7 @@ spec:
           resources:
           - clusterversions
           verbs:
+          - get
           - list
           - watch
         - apiGroups:
@@ -589,6 +597,7 @@ spec:
           resources:
           - clusterversions
           verbs:
+          - get
           - list
           - watch
         - apiGroups:
@@ -659,6 +668,7 @@ spec:
           - namespaces/finalizers
           verbs:
           - delete
+          - get
           - list
           - patch
           - update
@@ -698,6 +708,7 @@ spec:
           resources:
           - rhmis
           verbs:
+          - get
           - list
           - watch
         - apiGroups:
@@ -756,6 +767,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -840,6 +852,7 @@ spec:
           resources:
           - datasciencepipelinesapplications/finalizers
           verbs:
+          - get
           - patch
           - update
         - apiGroups:
@@ -886,6 +899,7 @@ spec:
           - events
           verbs:
           - delete
+          - get
           - list
           - patch
           - watch
@@ -962,6 +976,7 @@ spec:
           - rhmis
           verbs:
           - delete
+          - get
           - list
           - patch
           - watch
@@ -989,6 +1004,7 @@ spec:
           - machineautoscalers
           verbs:
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -997,6 +1013,7 @@ spec:
           - machinesets
           verbs:
           - delete
+          - get
           - list
           - patch
         - apiGroups:
@@ -1238,6 +1255,7 @@ spec:
           - virtualservices/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1300,6 +1318,7 @@ spec:
           - consoles
           verbs:
           - delete
+          - get
           - list
           - patch
           - watch
@@ -1458,6 +1477,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1469,6 +1489,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1479,6 +1500,7 @@ spec:
           - services/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1488,6 +1510,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1499,6 +1522,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1509,6 +1533,7 @@ spec:
           - clusterservingruntimes/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1518,6 +1543,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1528,6 +1554,7 @@ spec:
           - inferencegraphs/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1560,6 +1587,7 @@ spec:
           - inferenceservices/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1569,6 +1597,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1578,6 +1607,7 @@ spec:
           resources:
           - predictors/finalizers
           verbs:
+          - get
           - patch
           - update
         - apiGroups:
@@ -1586,6 +1616,7 @@ spec:
           - predictors/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1611,6 +1642,7 @@ spec:
           resources:
           - servingruntimes/status
           verbs:
+          - get
           - patch
           - update
         - apiGroups:
@@ -1620,6 +1652,7 @@ spec:
           verbs:
           - create
           - delete
+          - get
           - list
           - patch
           - update
@@ -1630,6 +1663,7 @@ spec:
           - trainedmodels/status
           verbs:
           - delete
+          - get
           - patch
           - update
         - apiGroups:
@@ -1696,6 +1730,7 @@ spec:
           - users
           verbs:
           - delete
+          - get
           - list
           - patch
           - watch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -132,12 +132,14 @@ rules:
   - tokenreviews
   verbs:
   - create
+  - get
 - apiGroups:
   - authorization.k8s.io
   resources:
   - subjectaccessreviews
   verbs:
   - create
+  - get
 - apiGroups:
   - authorization.openshift.io
   resources:
@@ -169,6 +171,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -179,6 +182,7 @@ rules:
   - machineautoscalers
   verbs:
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -187,6 +191,7 @@ rules:
   - machinesets
   verbs:
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -226,6 +231,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - watch
@@ -247,6 +253,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - watch
@@ -287,6 +294,7 @@ rules:
   resources:
   - clusterversions
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -340,6 +348,7 @@ rules:
   resources:
   - clusterversions
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -410,6 +419,7 @@ rules:
   - namespaces/finalizers
   verbs:
   - delete
+  - get
   - list
   - patch
   - update
@@ -449,6 +459,7 @@ rules:
   resources:
   - rhmis
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -507,6 +518,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -591,6 +603,7 @@ rules:
   resources:
   - datasciencepipelinesapplications/finalizers
   verbs:
+  - get
   - patch
   - update
 - apiGroups:
@@ -637,6 +650,7 @@ rules:
   - events
   verbs:
   - delete
+  - get
   - list
   - patch
   - watch
@@ -713,6 +727,7 @@ rules:
   - rhmis
   verbs:
   - delete
+  - get
   - list
   - patch
   - watch
@@ -740,6 +755,7 @@ rules:
   - machineautoscalers
   verbs:
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -748,6 +764,7 @@ rules:
   - machinesets
   verbs:
   - delete
+  - get
   - list
   - patch
 - apiGroups:
@@ -989,6 +1006,7 @@ rules:
   - virtualservices/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1051,6 +1069,7 @@ rules:
   - consoles
   verbs:
   - delete
+  - get
   - list
   - patch
   - watch
@@ -1209,6 +1228,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1220,6 +1240,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1230,6 +1251,7 @@ rules:
   - services/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1239,6 +1261,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1250,6 +1273,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1260,6 +1284,7 @@ rules:
   - clusterservingruntimes/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1269,6 +1294,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1279,6 +1305,7 @@ rules:
   - inferencegraphs/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1311,6 +1338,7 @@ rules:
   - inferenceservices/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1320,6 +1348,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1329,6 +1358,7 @@ rules:
   resources:
   - predictors/finalizers
   verbs:
+  - get
   - patch
   - update
 - apiGroups:
@@ -1337,6 +1367,7 @@ rules:
   - predictors/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1362,6 +1393,7 @@ rules:
   resources:
   - servingruntimes/status
   verbs:
+  - get
   - patch
   - update
 - apiGroups:
@@ -1371,6 +1403,7 @@ rules:
   verbs:
   - create
   - delete
+  - get
   - list
   - patch
   - update
@@ -1381,6 +1414,7 @@ rules:
   - trainedmodels/status
   verbs:
   - delete
+  - get
   - patch
   - update
 - apiGroups:
@@ -1447,6 +1481,7 @@ rules:
   - users
   verbs:
   - delete
+  - get
   - list
   - patch
   - watch

--- a/controllers/datasciencecluster/kubebuilder_rbac.go
+++ b/controllers/datasciencecluster/kubebuilder_rbac.go
@@ -12,13 +12,27 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="operator.knative.dev",resources=knativeservings,verbs=*
 // +kubebuilder:rbac:groups="config.openshift.io",resources=ingresses,verbs=get
 
+/* Service Mesh Integration */
+// +kubebuilder:rbac:groups="maistra.io",resources=servicemeshcontrolplanes,verbs=create;get;list;patch;update;use;watch
+// +kubebuilder:rbac:groups="maistra.io",resources=servicemeshmemberrolls,verbs=create;get;list;patch;update;use;watch
+// +kubebuilder:rbac:groups="maistra.io",resources=servicemeshmembers,verbs=create;get;list;patch;update;use;watch
+// +kubebuilder:rbac:groups="maistra.io",resources=servicemeshmembers/finalizers,verbs=create;get;list;patch;update;use;watch
+// +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices/finalizers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="networking.istio.io",resources=virtualservices,verbs=*
+// +kubebuilder:rbac:groups="networking.istio.io",resources=gateways,verbs=*
+// +kubebuilder:rbac:groups="networking.istio.io",resources=envoyfilters,verbs=*
+// +kubebuilder:rbac:groups="security.istio.io",resources=authorizationpolicies,verbs=*
+// +kubebuilder:rbac:groups="authorino.kuadrant.io",resources=authconfigs,verbs=*
+// +kubebuilder:rbac:groups="operator.authorino.kuadrant.io",resources=authorinos,verbs=*
+
 /* This is for DSP */
 //+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/status,verbs=update;patch;get
-//+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/finalizers,verbs=update;patch
+//+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications/finalizers,verbs=update;patch;get
 //+kubebuilder:rbac:groups="datasciencepipelinesapplications.opendatahub.io",resources=datasciencepipelinesapplications,verbs=create;delete;list;update;watch;patch;get
 //+kubebuilder:rbac:groups="image.openshift.io",resources=imagestreamtags,verbs=get
-//+kubebuilder:rbac:groups="authentication.k8s.io",resources=tokenreviews,verbs=create
-//+kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=create
+//+kubebuilder:rbac:groups="authentication.k8s.io",resources=tokenreviews,verbs=create;get
+//+kubebuilder:rbac:groups="authorization.k8s.io",resources=subjectaccessreviews,verbs=create;get
 
 /* This is for dashboard */
 // +kubebuilder:rbac:groups="opendatahub.io",resources=odhdashboardconfigs,verbs=create;get;patch;watch;update;delete;list
@@ -37,7 +51,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch
 
-// +kubebuilder:rbac:groups="user.openshift.io",resources=users,verbs=list;watch;patch;delete
+// +kubebuilder:rbac:groups="user.openshift.io",resources=users,verbs=list;watch;patch;delete;get
 
 // +kubebuilder:rbac:groups="template.openshift.io",resources=templates,verbs=*
 
@@ -45,26 +59,26 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="snapshot.storage.k8s.io",resources=volumesnapshots,verbs=create;delete;patch;get
 
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels,verbs=create;delete;list;update;watch;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=servingruntimes/status,verbs=update;patch
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=trainedmodels,verbs=create;delete;list;update;watch;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=servingruntimes/status,verbs=update;patch;get
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=servingruntimes/finalizers,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=servingruntimes,verbs=*
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors/finalizers,verbs=update;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors,verbs=create;delete;list;update;watch;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferenceservices/status,verbs=update;patch;delete
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors/finalizers,verbs=update;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=predictors,verbs=create;delete;list;update;watch;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferenceservices/status,verbs=update;patch;delete;get
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=inferenceservices/finalizers,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="serving.kserve.io",resources=inferenceservices,verbs=create;delete;list;update;watch;patch;get
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferencegraphs/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferencegraphs,verbs=create;delete;list;update;watch;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes/finalizers,verbs=create;delete;list;update;watch;patch
-// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes,verbs=create;delete;list;update;watch;patch
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferencegraphs/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=inferencegraphs,verbs=create;delete;list;update;watch;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes/finalizers,verbs=create;delete;list;update;watch;patch;get
+// +kubebuilder:rbac:groups="serving.kserve.io",resources=clusterservingruntimes,verbs=create;delete;list;update;watch;patch;get
 
-// +kubebuilder:rbac:groups="serving.knative.dev",resources=services/status,verbs=update;patch;delete
-// +kubebuilder:rbac:groups="serving.knative.dev",resources=services/finalizers,verbs=create;delete;list;watch;update;patch
-// +kubebuilder:rbac:groups="serving.knative.dev",resources=services,verbs=create;delete;list;watch;update;patch
+// +kubebuilder:rbac:groups="serving.knative.dev",resources=services/status,verbs=update;patch;delete;get
+// +kubebuilder:rbac:groups="serving.knative.dev",resources=services/finalizers,verbs=create;delete;list;watch;update;patch;get
+// +kubebuilder:rbac:groups="serving.knative.dev",resources=services,verbs=create;delete;list;watch;update;patch;get
 
 // +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=*,resourceNames=restricted
 // +kubebuilder:rbac:groups="security.openshift.io",resources=securitycontextconstraints,verbs=*,resourceNames=anyuid
@@ -86,7 +100,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="apiregistration.k8s.io",resources=apiservices,verbs=create;delete;list;watch;update;patch;get
 
-// +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;watch;patch;delete
+// +kubebuilder:rbac:groups="operator.openshift.io",resources=consoles,verbs=list;watch;patch;delete;get
 
 // +kubebuilder:rbac:groups="oauth.openshift.io",resources=oauthclients,verbs=create;delete;list;watch;update;patch;get
 
@@ -140,16 +154,16 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="machinelearning.seldon.io",resources=seldondeployments,verbs=*
 
-// +kubebuilder:rbac:groups="machine.openshift.io",resources=machinesets,verbs=list;patch;delete
-// +kubebuilder:rbac:groups="machine.openshift.io",resources=machineautoscalers,verbs=list;patch;delete
+// +kubebuilder:rbac:groups="machine.openshift.io",resources=machinesets,verbs=list;patch;delete;get
+// +kubebuilder:rbac:groups="machine.openshift.io",resources=machineautoscalers,verbs=list;patch;delete;get
 
 /* TODO: cleanup once kfdef is not needed*/
 // +kubebuilder:rbac:groups="kubeflow.org",resources=*,verbs=*
 // +kubebuilder:rbac:groups="kfdef.apps.kubeflow.org",resources=kfdefs,verbs=get;list;watch;patch;delete;update
 
-// +kubebuilder:rbac:groups="integreatly.org",resources=rhmis,verbs=list;watch;patch;delete
+// +kubebuilder:rbac:groups="integreatly.org",resources=rhmis,verbs=list;watch;patch;delete;get
 
-// +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=patch;create;update;delete
+// +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=patch;create;update;delete;get
 // +kubebuilder:rbac:groups="image.openshift.io",resources=imagestreams,verbs=create;list;watch;patch;delete;get
 
 // +kubebuilder:rbac:groups="extensions",resources=replicasets,verbs=*
@@ -157,7 +171,7 @@ package datasciencecluster
 
 // +kubebuilder:rbac:groups="custom.tekton.dev",resources=pipelineloops,verbs=*
 
-// +kubebuilder:rbac:groups="core",resources=services/finalizers,verbs=create;delete;list;update;watch;patch
+// +kubebuilder:rbac:groups="core",resources=services/finalizers,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="core",resources=services,verbs=get;create;watch;update;patch;list;delete
 // +kubebuilder:rbac:groups="core",resources=services,verbs=*
 // +kubebuilder:rbac:groups="*",resources=services,verbs=*
@@ -167,7 +181,7 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="core",resources=secrets,verbs=create;delete;list;update;watch;patch;get
 // +kubebuilder:rbac:groups="core",resources=secrets/finalizers,verbs=get;create;watch;update;patch;list;delete
 
-// +kubebuilder:rbac:groups="core",resources=rhmis,verbs=watch;list
+// +kubebuilder:rbac:groups="core",resources=rhmis,verbs=watch;list;get
 
 // +kubebuilder:rbac:groups="core",resources=pods/log,verbs=*
 // +kubebuilder:rbac:groups="core",resources=pods/exec,verbs=*
@@ -176,19 +190,19 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="core",resources=persistentvolumes,verbs=*
 // +kubebuilder:rbac:groups="core",resources=persistentvolumeclaims,verbs=*
 
-// +kubebuilder:rbac:groups="core",resources=namespaces/finalizers,verbs=update;list;watch;patch;delete
+// +kubebuilder:rbac:groups="core",resources=namespaces/finalizers,verbs=update;list;watch;patch;delete;get
 // +kubebuilder:rbac:groups="core",resources=namespaces,verbs=get;create;patch;delete;watch;update;list
 
 // +kubebuilder:rbac:groups="core",resources=events,verbs=get;create;watch;update;list;patch;delete
-// +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=list;watch;patch;delete
+// +kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=list;watch;patch;delete;get
 
 // +kubebuilder:rbac:groups="core",resources=endpoints,verbs=watch;list;get;create;update;delete
 
 // +kubebuilder:rbac:groups="core",resources=configmaps/status,verbs=get;update;patch;delete
 // +kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;create;watch;patch;delete;list;update
 
-// +kubebuilder:rbac:groups="core",resources=clusterversions,verbs=watch;list
-// +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=watch;list
+// +kubebuilder:rbac:groups="core",resources=clusterversions,verbs=watch;list;get
+// +kubebuilder:rbac:groups="config.openshift.io",resources=clusterversions,verbs=watch;list;get
 
 // +kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;watch;create;update;patch;delete
 
@@ -200,18 +214,18 @@ package datasciencecluster
 // +kubebuilder:rbac:groups="cert-manager.io",resources=certificates;issuers,verbs=create;patch
 
 // OpenVino still need buildconfig
-// +kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=create;patch;delete;list;watch
+// +kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=create;patch;delete;list;watch;get
 // +kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs/instantiate,verbs=create;patch;delete;get;list;watch
-// +kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs,verbs=list;watch;create;patch;delete
+// +kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs,verbs=list;watch;create;patch;delete;get
 
 // +kubebuilder:rbac:groups="batch",resources=jobs/status,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="batch",resources=jobs,verbs=*
 // +kubebuilder:rbac:groups="batch",resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="batch",resources=cronjobs,verbs=create;get;patch
 
-// +kubebuilder:rbac:groups="autoscaling",resources=horizontalpodautoscalers,verbs=watch;create;update;delete;list;patch
-// +kubebuilder:rbac:groups="autoscaling.openshift.io",resources=machinesets,verbs=list;patch;delete
-// +kubebuilder:rbac:groups="autoscaling.openshift.io",resources=machineautoscalers,verbs=list;patch;delete
+// +kubebuilder:rbac:groups="autoscaling",resources=horizontalpodautoscalers,verbs=watch;create;update;delete;list;patch;get
+// +kubebuilder:rbac:groups="autoscaling.openshift.io",resources=machinesets,verbs=list;patch;delete;get
+// +kubebuilder:rbac:groups="autoscaling.openshift.io",resources=machineautoscalers,verbs=list;patch;delete;get
 
 // +kubebuilder:rbac:groups="authorization.openshift.io",resources=roles,verbs=*
 // +kubebuilder:rbac:groups="authorization.openshift.io",resources=rolebindings,verbs=*


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/RHOAIENG-8393
 




- since we already have these resource for create, list, delete etc, no harm to add get on them

Signed-off-by: Wen Zhou <wenzhou@redhat.com>
(cherry picked from commit bd9b83cf95ddb4727575dc7dba2d7cf17dca001a)

fix: when delete resource if no CRD in the cluster (#1044)

Signed-off-by: Wen Zhou <wenzhou@redhat.com>
(cherry picked from commit c040f77a87521060becf62c2424c39dcb9551458)

deploy: refactor getResource to return NotFound for both cases (#1046)

Avoid returning (nil, nil), convert error if CRD not present to NotFound and handle them in the caller code.

Avoid checking for found == nil but handle only error code.

This is more idiomatic and less error prone.

Signed-off-by: Yauheni Kaliuta <ykaliuta@redhat.com>
(cherry picked from commit 9651b76958c6acda430e93140637fbdb8c93b1a8)

Handle Kserve exception

Fix csv

(cherry picked from commit e5f65bdf5286e033254053c2871d3e40eea34786)