### PR TITLE
test: fix test for rhoai to be used for e2e weekly

### DIFF
--- a/tests/e2e/controller_setup_test.go
+++ b/tests/e2e/controller_setup_test.go
@@ -77,9 +77,9 @@ func NewTestContext() (*testContext, error) { //nolint:golint,revive // Only use
 	}
 
 	// setup DSCI CR since we do not create automatically by operator
-	testDSCI := setupDSCICR()
+	testDSCI := setupDSCICR("e2e-test-dsci")
 	// Setup DataScienceCluster CR
-	testDSC := setupDSCInstance()
+	testDSC := setupDSCInstance("e2e-test")
 
 	return &testContext{
 		cfg:                     config,
@@ -87,7 +87,7 @@ func NewTestContext() (*testContext, error) { //nolint:golint,revive // Only use
 		customClient:            custClient,
 		operatorNamespace:       opNamespace,
 		applicationsNamespace:   testDSCI.Spec.ApplicationsNamespace,
-		resourceCreationTimeout: time.Minute * 2,
+		resourceCreationTimeout: time.Minute * 3, // 5 pods of dashboard will take longer time than ODH
 		resourceRetryInterval:   time.Second * 10,
 		ctx:                     context.TODO(),
 		testDsc:                 testDSC,

--- a/tests/e2e/dsc_deletion_test.go
+++ b/tests/e2e/dsc_deletion_test.go
@@ -33,7 +33,7 @@ func deletionTestSuite(t *testing.T) {
 			require.NoError(t, err, "Error to delete DSC instance")
 		})
 		t.Run("Deletion: Application Resource", func(t *testing.T) {
-			err = testCtx.testAllApplicationDeletion()
+			err = testCtx.testAllApplicationDeletion(t)
 			require.NoError(t, err, "Error to delete component")
 		})
 		t.Run("Deletion: DSCI instance", func(t *testing.T) {
@@ -83,7 +83,7 @@ func (tc *testContext) testApplicationDeletion(component components.ComponentInt
 	return nil
 }
 
-func (tc *testContext) testAllApplicationDeletion() error {
+func (tc *testContext) testAllApplicationDeletion(t *testing.T) error { //nolint:thelper
 	// Deletion all listed components' deployments
 
 	components, err := tc.testDsc.GetComponents()
@@ -92,9 +92,12 @@ func (tc *testContext) testAllApplicationDeletion() error {
 	}
 
 	for _, c := range components {
-		if err = tc.testApplicationDeletion(c); err != nil {
-			return err
-		}
+		c := c
+		t.Run("Delete "+c.GetComponentName(), func(t *testing.T) {
+			t.Parallel()
+			err = tc.testApplicationDeletion(c)
+			require.NoError(t, err)
+		})
 	}
 
 	return nil
@@ -119,5 +122,5 @@ func (tc *testContext) testDeletionExistDSCI() error {
 			return fmt.Errorf("error getting DSCI instance :%w", err)
 		}
 	}
-	return err
+	return nil
 }

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -37,9 +37,9 @@ import (
 )
 
 const (
-	servicemeshNamespace = "openshift-operators"
-	servicemeshOpName    = "servicemeshoperator"
-	serverlessOpName     = "serverless-operator"
+	depedentOperatorNamespace = "openshift-operators"
+	servicemeshOpName         = "servicemeshoperator"
+	serverlessOpName          = "serverless-operator"
 )
 
 func (tc *testContext) waitForControllerDeployment(name string, replicas int32) error {
@@ -67,16 +67,16 @@ func (tc *testContext) waitForControllerDeployment(name string, replicas int32) 
 	return err
 }
 
-func setupDSCICR() *dsci.DSCInitialization {
+func setupDSCICR(name string) *dsci.DSCInitialization {
 	dsciTest := &dsci.DSCInitialization{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "e2e-test-dsci",
+			Name: name,
 		},
 		Spec: dsci.DSCInitializationSpec{
-			ApplicationsNamespace: "opendatahub",
+			ApplicationsNamespace: "redhat-ods-applications",
 			Monitoring: dsci.Monitoring{
 				ManagementState: "Managed",
-				Namespace:       "opendatahub",
+				Namespace:       "redhat-ods-monitoring",
 			},
 			TrustedCABundle: dsci.TrustedCABundleSpec{
 				ManagementState: "Managed",
@@ -90,10 +90,10 @@ func setupDSCICR() *dsci.DSCInitialization {
 	return dsciTest
 }
 
-func setupDSCInstance() *dsc.DataScienceCluster {
+func setupDSCInstance(name string) *dsc.DataScienceCluster {
 	dscTest := &dsc.DataScienceCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "e2e-test-dsc",
+			Name: name,
 		},
 		Spec: dsc.DataScienceClusterSpec{
 			Components: dsc.Components{
@@ -110,7 +110,7 @@ func setupDSCInstance() *dsc.DataScienceCluster {
 				},
 				ModelMeshServing: modelmeshserving.ModelMeshServing{
 					Component: components.Component{
-						ManagementState: operatorv1.Removed,
+						ManagementState: operatorv1.Managed,
 					},
 				},
 				DataSciencePipelines: datasciencepipelines.DataSciencePipelines{
@@ -143,12 +143,12 @@ func setupDSCInstance() *dsc.DataScienceCluster {
 				},
 				TrustyAI: trustyai.TrustyAI{
 					Component: components.Component{
-						ManagementState: operatorv1.Managed,
+						ManagementState: operatorv1.Removed,
 					},
 				},
 				TrainingOperator: trainingoperator.TrainingOperator{
 					Component: components.Component{
-						ManagementState: operatorv1.Managed,
+						ManagementState: operatorv1.Removed,
 					},
 				},
 			},
@@ -373,7 +373,7 @@ func ensureOperator(tc *testContext, name string, ns string) error {
 	return waitCSV(tc, name, ns)
 }
 
-func ensureServicemeshOperators(t *testing.T, tc *testContext) error { //nolint: thelper
+func ensureDepedentOperators(t *testing.T, tc *testContext) error { //nolint: thelper
 	ops := []string{
 		serverlessOpName,
 		servicemeshOpName,
@@ -385,7 +385,7 @@ func ensureServicemeshOperators(t *testing.T, tc *testContext) error { //nolint:
 		op := op // to avoid loop variable in the closures
 		t.Logf("Ensuring %s is installed", op)
 		go func(op string) {
-			err := ensureOperator(tc, op, servicemeshNamespace)
+			err := ensureOperator(tc, op, depedentOperatorNamespace)
 			c <- err
 		}(op)
 	}
@@ -399,5 +399,5 @@ func ensureServicemeshOperators(t *testing.T, tc *testContext) error { //nolint:
 }
 
 func (tc *testContext) setUp(t *testing.T) error { //nolint: thelper
-	return ensureServicemeshOperators(t, tc)
+	return ensureDepedentOperators(t, tc)
 }

--- a/tests/e2e/odh_manager_test.go
+++ b/tests/e2e/odh_manager_test.go
@@ -10,14 +10,14 @@ func testODHOperatorValidation(t *testing.T) {
 	testCtx, err := NewTestContext()
 	require.NoError(t, err)
 
-	t.Run("validate ODH Operator pod", testCtx.testODHDeployment)
+	t.Run("validate RHOAI Operator pod", testCtx.testRHOAIDeployment)
 	t.Run("validate CRDs owned by the operator", testCtx.validateOwnedCRDs)
 }
 
-func (tc *testContext) testODHDeployment(t *testing.T) {
+func (tc *testContext) testRHOAIDeployment(t *testing.T) {
 	// Verify if the operator deployment is created
-	require.NoErrorf(t, tc.waitForControllerDeployment("opendatahub-operator-controller-manager", 1),
-		"error in validating odh operator deployment")
+	require.NoErrorf(t, tc.waitForControllerDeployment("redhat-ods-operator-controller-manager", 1),
+		"error in validating rhoai operator deployment")
 }
 
 func (tc *testContext) validateOwnedCRDs(t *testing.T) {


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/RHOAIENG-8550

local test:
```
=== RUN   TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_DSCInitialization_instance
=== RUN   TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_DataScienceCluster_instance
=== RUN   TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_Ownerrefrences_exist
=== RUN   TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_Controller_reconcile
=== RUN   TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_Component_Enabled_field
--- PASS: TestOdhOperator (424.84s)
    --- PASS: TestOdhOperator/validate_operator_pod_is_running (31.17s)
        --- PASS: TestOdhOperator/validate_operator_pod_is_running/validate_RHOAI_Operator_pod (10.22s)
        --- PASS: TestOdhOperator/validate_operator_pod_is_running/validate_CRDs_owned_by_the_operator (20.43s)
    --- PASS: TestOdhOperator/create_Opendatahub_components (393.67s)
        --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test (382.66s)
            --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Creation_of_DSCI_CR (10.33s)
            --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Creation_of_DataScienceCluster_instance (40.66s)
            --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components (60.13s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_kueue (10.12s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_ray (10.22s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_kserve (10.32s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_data-science-pipelines-operator (10.33s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_model-mesh (10.33s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_dashboard (10.43s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_workbenches (10.43s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_codeflare (10.11s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_trustyai (180.12s)
                --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_all_deployed_components/Validate_trainingoperator (180.11s)
            --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_DSCInitialization_instance (0.00s)
            --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_DataScienceCluster_instance (0.00s)
            --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_Ownerrefrences_exist (0.11s)
            --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_Controller_reconcile (40.58s)
            --- PASS: TestOdhOperator/create_Opendatahub_components/e2e-test/Validate_Component_Enabled_field (40.51s)
PASS
ok      github.com/opendatahub-io/opendatahub-operator/v2/tests/e2e     424.852s
```