### PR TITLE
[sync]fix: do not redeploy segment-io's if it has been deployed previously

### DIFF
--- a/controllers/dscinitialization/dscinitialization_controller.go
+++ b/controllers/dscinitialization/dscinitialization_controller.go
@@ -245,8 +245,8 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				return reconcile.Result{}, err
 			}
 			if instance.Spec.Monitoring.ManagementState == operatorv1.Managed {
-				r.Log.Info("Monitoring enabled, won't apply changes", "cluster", "Self-Managed RHOAI Mode")
-				err = r.configureCommonMonitoring(instance)
+				r.Log.Info("Monitoring enabled, won't apply changes", "cluster", "Self-Managed RHODS Mode")
+				err = r.configureCommonMonitoring(ctx, instance)
 				if err != nil {
 					return reconcile.Result{}, err
 				}
@@ -265,7 +265,7 @@ func (r *DSCInitializationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				if err != nil {
 					return reconcile.Result{}, err
 				}
-				err = r.configureCommonMonitoring(instance)
+				err = r.configureCommonMonitoring(ctx, instance)
 				if err != nil {
 					return reconcile.Result{}, err
 				}

--- a/controllers/dscinitialization/monitoring.go
+++ b/controllers/dscinitialization/monitoring.go
@@ -434,19 +434,38 @@ func createMonitoringProxySecret(ctx context.Context, cli client.Client, name st
 	return nil
 }
 
-func (r *DSCInitializationReconciler) configureCommonMonitoring(dsciInit *dsciv1.DSCInitialization) error {
-	// configure segment.io
-	segmentPath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "segment")
-	if err := deploy.DeployManifestsFromPath(
-		r.Client,
-		dsciInit,
-		segmentPath,
-		dsciInit.Spec.ApplicationsNamespace,
-		"segment-io",
-		dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed); err != nil {
-		r.Log.Error(err, "error to deploy manifests under "+segmentPath)
+func (r *DSCInitializationReconciler) configureSegmentIO(ctx context.Context, dsciInit *dsciv1.DSCInitialization) error {
+	// create segment.io only when configmap does not exist in the cluster
+	segmentioConfigMap := &corev1.ConfigMap{}
+	if err := r.Client.Get(ctx, client.ObjectKey{
+		Namespace: dsciInit.Spec.ApplicationsNamespace,
+		Name:      "odh-segment-key-config",
+	}, segmentioConfigMap); err != nil {
+		if !k8serr.IsNotFound(err) {
+			r.Log.Error(err, "error to get configmap 'odh-segment-key-config'")
+			return err
+		} else {
+			segmentPath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "segment")
+			if err := deploy.DeployManifestsFromPath(
+				r.Client,
+				dsciInit,
+				segmentPath,
+				dsciInit.Spec.ApplicationsNamespace,
+				"segment-io",
+				dsciInit.Spec.Monitoring.ManagementState == operatorv1.Managed); err != nil {
+				r.Log.Error(err, "error to deploy manifests under "+segmentPath)
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (r *DSCInitializationReconciler) configureCommonMonitoring(ctx context.Context, dsciInit *dsciv1.DSCInitialization) error {
+	if err := r.configureSegmentIO(ctx, dsciInit); err != nil {
 		return err
 	}
+
 	// configure monitoring base
 	monitoringBasePath := filepath.Join(deploy.DefaultManifestPath, "monitoring", "base")
 	err := common.ReplaceStringsInFile(filepath.Join(monitoringBasePath, "rhods-servicemonitor.yaml"),


### PR DESCRIPTION
- dashboard is using segment-io's configmap to flip monitoring settings
- upon upgrade, Operator redploy the same configmap to set data to "true"

<!--- Provide a general summary of your changes in the Title above -->

Many thanks for submitting your Pull Request ❤️!

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md)
- [ ] Pull Request contains description of the issue
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains link to any dependent or related Pull Request

## Description
<!--- Describe your changes in detail -->

## JIRA issue:
<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-1205
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip:
<!--- Attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Have a meaningful commit messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
