### PR TITLE
sync: fix for managed cluster upgrade with DSC already exists (#305)

### DIFF
--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -206,7 +206,7 @@ func CreateWithRetry(ctx context.Context, cli client.Client, obj client.Object, 
 	return wait.PollUntilContextTimeout(ctx, interval, timeout, true, func(ctx context.Context) (bool, error) {
 		err := cli.Create(ctx, obj)
 		if err != nil {
-			return false, nil //nolint:nilerr
+			return false, err
 		}
 		return true, nil
 	})


### PR DESCRIPTION
Signed-off-by: Wen Zhou <wenzhou@redhat.com>
(cherry picked from commit ca3c6e24946faf782fcc779e0013fc118b1d8b94)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
missing fix which was on 2.11 but not on main branch which is leading to not on 2.12

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-11135


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build quay.io/wenzhou/rhods-operator-catalog:v2.12.0-2


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
