### PR TITLE
fix incorrect label in dashboard SLO probe alerts

### DIFF
--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -734,7 +734,7 @@ data:
         rules:
         - alert: RHODS Dashboard Probe Success Burn Rate
           annotations:
-            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            message: 'High error budget burn for {{ $labels.name }} (current value: {{ $value }}).'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
             summary: RHODS Dashboard Probe Success Burn Rate
           expr: |
@@ -747,7 +747,7 @@ data:
             namespace: redhat-ods-applications
         - alert: RHODS Dashboard Probe Success Burn Rate
           annotations:
-            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            message: 'High error budget burn for {{ $labels.name }} (current value: {{ $value }}).'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
             summary: RHODS Dashboard Probe Success Burn Rate
           expr: |
@@ -760,7 +760,7 @@ data:
             namespace: redhat-ods-applications
         - alert: RHODS Dashboard Probe Success Burn Rate
           annotations:
-            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            message: 'High error budget burn for {{ $labels.name }} (current value: {{ $value }}).'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
             summary: RHODS Dashboard Probe Success Burn Rate
           expr: |
@@ -773,7 +773,7 @@ data:
             namespace: redhat-ods-applications
         - alert: RHODS Dashboard Probe Success Burn Rate
           annotations:
-            message: 'High error budget burn for {{ $labels.instance }} (current value: {{ $value }}).'
+            message: 'High error budget burn for {{ $labels.name }} (current value: {{ $value }}).'
             triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/RHODS-Dashboard/rhods-dashboard-probe-success-burn-rate.md"
             summary: RHODS Dashboard Probe Success Burn Rate
           expr: |


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
The dashboard SLO probe alerts reference an incorrect label so when the alert fires the message will have an empty space. This happens because while the metric probe_success contains the instance label.

![image](https://github.com/user-attachments/assets/6b95d5da-9e69-4256-a702-ca4e762a53ac)


The alert sums the metric by (name) so it groups away the instance label.

![image](https://github.com/user-attachments/assets/47fa37f3-a07e-4c37-bc6c-7ac69a16e646)



The message should reference the name label not the instance label.
<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-11746
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Deployed RHOAI with managed monitoring setup.
- Confirm the alert references the wrong label.
- Click show annotations in alertmanager.
- Repeatedly scale down the dashboard pods so the alert fires and confirm the empty space where the label should be in the message.
- Confirm the output of the metric the alert is based on `sum by(name) (probe_success:burnrate5m{name=~"rhods-dashboard"})` outputs the name label.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
