### PR TITLE
Don't restrict the nbc image update to downstream only (#1170)

### DIFF
--- a/components/workbenches/workbenches.go
+++ b/components/workbenches/workbenches.go
@@ -136,18 +136,16 @@ func (w *Workbenches) ReconcileComponent(ctx context.Context, cli client.Client,
 	}
 	l.WithValues("Path", notebookControllerPath).Info("apply manifests done NBC")
 
-	// Update image parameters for nbc in downstream
+	// Update image parameters for nbc
 	if enabled {
 		if (dscispec.DevFlags == nil || dscispec.DevFlags.ManifestsUri == "") && (w.DevFlags == nil || len(w.DevFlags.Manifests) == 0) {
-			if platform == cluster.ManagedRhods || platform == cluster.SelfManagedRhods {
-				// for kf-notebook-controller image
-				if err := deploy.ApplyParams(notebookControllerPath, imageParamMap); err != nil {
-					return fmt.Errorf("failed to update image %s: %w", notebookControllerPath, err)
-				}
-				// for odh-notebook-controller image
-				if err := deploy.ApplyParams(kfnotebookControllerPath, imageParamMap); err != nil {
-					return fmt.Errorf("failed to update image %s: %w", kfnotebookControllerPath, err)
-				}
+			// for kf-notebook-controller image
+			if err := deploy.ApplyParams(notebookControllerPath, imageParamMap); err != nil {
+				return fmt.Errorf("failed to update image %s: %w", notebookControllerPath, err)
+			}
+			// for odh-notebook-controller image
+			if err := deploy.ApplyParams(kfnotebookControllerPath, imageParamMap); err != nil {
+				return fmt.Errorf("failed to update image %s: %w", kfnotebookControllerPath, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This should address the [1]. With current code it wasn't possible to override the images used for the notebook controllers via env property, now it should be possible.



(cherry picked from commit 39b7232af026cd6a4c9540aed1a9b07577c2a205)




<!--- Link your JIRA and related links here for reference. -->
[1] https://issues.redhat.com/browse/RHOAIENG-11134

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
