### PR TITLE
[backport] fix: dashboard image not get set in downstream due to devFlags conf (#1224)

### DIFF
--- a/components/dashboard/dashboard.go
+++ b/components/dashboard/dashboard.go
@@ -92,7 +92,7 @@ func (d *Dashboard) ReconcileComponent(ctx context.Context,
 		if err := d.cleanOauthClient(ctx, cli, dscispec, currentComponentExist, l); err != nil {
 			return err
 		}
-		if d.DevFlags != nil {
+		if d.DevFlags != nil && len(d.DevFlags.Manifests) != 0 {
 			// Download manifests and update paths
 			if err := d.OverrideManifests(ctx, platform); err != nil {
 				return err


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- if DSC CR has old format with empty devFlag:{}, it can cause downstream image not replace but run with quay.io one

Signed-off-by: Wen Zhou <wenzhou@redhat.com>
(cherry picked from commit 1dbe26966fcdddaa5a9d1e7f858ecf958037f7b3)



<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-12300


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
