### PR TITLE
fix: workbench deployment + change path for its manifests in build

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -8,19 +8,19 @@ MANIFEST_ORG="red-hat-data-services"
 # component: notebook, dsp, kserve, dashbaord, cf/ray/kueue/trainingoperator, trustyai, modelmesh.
 # in the format of "repo-org:repo-name:ref-name:source-folder:target-folder".
 declare -A COMPONENT_MANIFESTS=(
-    ["codeflare"]="red-hat-data-services:codeflare-operator:rhoai-2.12:config:codeflare"
-    ["ray"]="red-hat-data-services:kuberay:rhoai-2.12:ray-operator/config:ray"
-    ["kueue"]="red-hat-data-services:kueue:rhoai-2.12:config:kueue"
-    ["data-science-pipelines-operator"]="red-hat-data-services:data-science-pipelines-operator:rhoai-2.12:config:data-science-pipelines-operator"
-    ["kf-notebook-controller"]="red-hat-data-services:kubeflow:rhoai-2.12:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
-    ["odh-notebook-controller"]="red-hat-data-services:kubeflow:rhoai-2.12:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
-    ["notebooks"]="red-hat-data-services:notebooks:rhoai-2.12:manifests:/jupyterhub/notebooks"
-    ["trustyai"]="red-hat-data-services:trustyai-service-operator:rhoai-2.12:config:trustyai-service-operator"
-    ["model-mesh"]="red-hat-data-services:modelmesh-serving:rhoai-2.12:config:model-mesh"
-    ["odh-model-controller"]="red-hat-data-services:odh-model-controller:rhoai-2.12:config:odh-model-controller"
-    ["kserve"]="red-hat-data-services:kserve:rhoai-2.12:config:kserve"
-    ["odh-dashboard"]="red-hat-data-services:odh-dashboard:rhoai-2.12:manifests:dashboard"
-    ["trainingoperator"]="red-hat-data-services:training-operator:rhoai-2.12:manifests:trainingoperator"
+    ["codeflare"]="red-hat-data-services:codeflare-operator:rhoai-2.13:config:codeflare"
+    ["ray"]="red-hat-data-services:kuberay:rhoai-2.13:ray-operator/config:ray"
+    ["kueue"]="red-hat-data-services:kueue:rhoai-2.13:config:kueue"
+    ["data-science-pipelines-operator"]="red-hat-data-services:data-science-pipelines-operator:rhoai-2.13:config:data-science-pipelines-operator"
+    ["kf-notebook-controller"]="red-hat-data-services:kubeflow:rhoai-2.13:components/notebook-controller/config:odh-notebook-controller/kf-notebook-controller"
+    ["odh-notebook-controller"]="red-hat-data-services:kubeflow:rhoai-2.13:components/odh-notebook-controller/config:odh-notebook-controller/odh-notebook-controller"
+    ["notebooks"]="red-hat-data-services:notebooks:rhoai-2.13:manifests:notebooks"
+    ["trustyai"]="red-hat-data-services:trustyai-service-operator:rhoai-2.13:config:trustyai-service-operator"
+    ["model-mesh"]="red-hat-data-services:modelmesh-serving:rhoai-2.13:config:model-mesh"
+    ["odh-model-controller"]="red-hat-data-services:odh-model-controller:rhoai-2.13:config:odh-model-controller"
+    ["kserve"]="red-hat-data-services:kserve:rhoai-2.13:config:kserve"
+    ["odh-dashboard"]="red-hat-data-services:odh-dashboard:rhoai-2.13:manifests:dashboard"
+    ["trainingoperator"]="red-hat-data-services:training-operator:rhoai-2.13:manifests:trainingoperator"
 )
 
 # Allow overwriting repo using flags component=repo

--- a/pkg/cluster/const.go
+++ b/pkg/cluster/const.go
@@ -9,4 +9,7 @@ const (
 	OpenDataHub Platform = "Open Data Hub"
 	// Unknown indicates that operator is not deployed using OLM.
 	Unknown Platform = ""
+
+	// DefaultNotebooksNamespace defines default namespace for notebooks.
+	DefaultNotebooksNamespace = "rhods-notebooks"
 )


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
- sync to changes in ODH on workbench: to fix the problem of we did not apply correct workbench image before params.env gets updated
- also uplift branch to 2.13 to get new manifests
- refer to https://github.com/opendatahub-io/opendatahub-operator/pull/1226 but since it has the path change, cannot just sync from ODH to rhoai

<!--- Link your JIRA and related links here for reference. -->
ref: https://issues.redhat.com/browse/RHOAIENG-12732


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- local build with PR: quay.io/wenzhou/rhoai-operator-catalog:v2.14.910-0
  result similar to ODH PR
- mock build with passing env for workbenchimages: quay.io/wenzhou/rhoai-operator-catalog:v2.14.910-2
  enable workbench
  2 CM created + imagestream created: quay.io/modh/.... are used 
  see both notebook-controller and kf-notebook-controller have issue to pull image which passed from Operator => expected, params.env is working to use these images instead of one from quay.io
  


## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
