### PR TITLE
RHOAIENG-8512: Implement unit tests for codeflare alerts

### DIFF
--- a/tests/prometheus_unit_tests/codeflare_alerts_unit_tests.yaml
+++ b/tests/prometheus_unit_tests/codeflare_alerts_unit_tests.yaml
@@ -1,0 +1,129 @@
+rule_files:
+  - "codeflare_alerts.yaml"
+
+evaluation_interval: 1m
+
+tests:
+  # burn rate
+  - interval: 1m
+    input_series:
+      - series: probe_success:burnrate5m{instance="codeflare-operator"}
+        values: "0x60"
+      - series: probe_success:burnrate30m{instance="codeflare-operator"}
+        values: "0x60"
+      - series: probe_success:burnrate1h{instance="codeflare-operator"}
+        values: "0x60"
+      - series: probe_success:burnrate2h{instance="codeflare-operator"}
+        values: "0x60"
+      - series: probe_success:burnrate6h{instance="codeflare-operator"}
+        values: "0x60"
+      - series: probe_success:burnrate1d{instance="codeflare-operator"}
+        values: "0x60"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: CodeFlare Operator Probe Success Burn Rate
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: probe_success:burnrate5m{instance="codeflare-operator"}
+        values: "1+1x60"
+      - series: probe_success:burnrate1h{instance="codeflare-operator"}
+        values: "1+1x60"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: CodeFlare Operator Probe Success Burn Rate
+        exp_alerts:
+          - exp_labels:
+              alertname: CodeFlare Operator Probe Success Burn Rate
+              instance: "codeflare-operator"
+              namespace: "redhat-ods-applications"
+              severity: info
+            exp_annotations:
+              message: "High error budget burn for codeflare-operator (current value: 3)."
+              summary: CodeFlare Operator Probe Success Burn Rate
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-availability.md'
+
+  - interval: 1m
+    input_series:
+      - series: probe_success:burnrate30m{instance="codeflare-operator"}
+        values: "1+1x60"
+      - series: probe_success:burnrate6h{instance="codeflare-operator"}
+        values: "1+1x60"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: CodeFlare Operator Probe Success Burn Rate
+        exp_alerts:
+          - exp_labels:
+              alertname: CodeFlare Operator Probe Success Burn Rate
+              instance: "codeflare-operator"
+              namespace: "redhat-ods-applications"
+              severity: info
+            exp_annotations:
+              message: "High error budget burn for codeflare-operator (current value: 16)."
+              summary: CodeFlare Operator Probe Success Burn Rate
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-probe-success-burn-rate.md'
+
+  - interval: 1m
+    input_series:
+      - series: probe_success:burnrate2h{instance="codeflare-operator"}
+        values: "1+1x60"
+      - series: probe_success:burnrate1d{instance="codeflare-operator"}
+        values: "1+1x60"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: CodeFlare Operator Probe Success Burn Rate
+        exp_alerts:
+          - exp_labels:
+              alertname: CodeFlare Operator Probe Success Burn Rate
+              instance: "codeflare-operator"
+              namespace: "redhat-ods-applications"
+              severity: info
+            exp_annotations:
+              message: "High error budget burn for codeflare-operator (current value: 61)."
+              summary: CodeFlare Operator Probe Success Burn Rate
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-probe-success-burn-rate.md'
+
+  # operator running
+  - interval: 1m
+    input_series:
+      - series: up{job="CodeFlare Operator"}
+        values: 1
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: CodeFlare Operator is not running
+        exp_alerts: []
+  
+  - interval: 1m
+    input_series:
+      - series: up{job="CodeFlare Operator"}
+        values: 0
+    alert_rule_test:
+      - eval_time: 1m
+        alertname: CodeFlare Operator is not running
+        exp_alerts:
+          - exp_labels:
+              alertname: CodeFlare Operator is not running
+              job: "CodeFlare Operator"
+              namespace: "redhat-ods-applications"
+              severity: info
+            exp_annotations:
+              description: This alert fires when the CodeFlare Operator is not running.
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-availability.md'
+              summary: Alerting for CodeFlare Operator
+  
+  - interval: 1m
+    input_series:
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: CodeFlare Operator taking too long to be up
+        exp_alerts:
+          - exp_labels:
+              alertname: CodeFlare Operator taking too long to be up
+              namespace: "redhat-ods-applications"
+              job: "CodeFlare Operator"
+              severity: info
+            exp_annotations:
+              description: This alert fires when the CodeFlare Operator takes over 2 min. to come back online. Either CodeFlare Operator is not running and failing to become ready, is misconfigured, or the metrics endpoint is not responding.
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/codeflare-operator-absent-over-time.md'
+              summary: Alerting for CodeFlare Operator


### PR DESCRIPTION
## Description
This pr adds support for unit tests for the codeflare alerts

[Jira ticket](https://issues.redhat.com/browse/RHOAIENG-8512)

## How Has This Been Tested?
```
cd tests/prometheus_unit_tests

# Use yq to pull the alert definitions out of the larger config file
yq '.data."rhods-dashboard-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > dashboard_alerts.yaml && yq '.data."model-mesh-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > model_mesh_alerts.yaml && yq '.data."trustyai-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > trustyai_alerts.yaml && yq '.data."odh-model-controller-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > model_controller_alerts.yaml && yq '.data."workbenches-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > workbenches_alerts.yaml && yq '.data."data-science-pipelines-operator-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > data_science_pipelines_operator_alerts.yaml && yq '.data."codeflare-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > codeflare_alerts.yaml

# Run the unit tests
promtool test rules *_unit_tests.yaml
```

## Screenshot or short clip
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/1a93e07b-d470-4e44-a18c-99677df6b5cc">

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
