### PR TITLE
add permissions to access prometheuses/api

### DIFF
--- a/config/monitoring/prometheus/base/prometheus-rolebinding-viewer.yaml
+++ b/config/monitoring/prometheus/base/prometheus-rolebinding-viewer.yaml
@@ -9,4 +9,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: view
+  name: cluster-monitoring-view


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Openshift 4.16 seems to have made a change to require more permissions for the prometheus instance to federate metrics from the cluster prometheus. Previously view permission for the namespace was all that was required but now permissions to get, create and update `prometheuses/api` is required. These permissions are already encompassed in the `cluster-monitoring-view` role.
<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-12824
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Confirm that the openshift federation target in prometheus is reporting `down` .
- Change made on local cluster.
- Confirm that the openshift federation target in prometheus is reporting `up`.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
