### PR TITLE
Revert "add permissions to access prometheuses/api"

### DIFF
--- a/config/monitoring/prometheus/base/prometheus-rolebinding-viewer.yaml
+++ b/config/monitoring/prometheus/base/prometheus-rolebinding-viewer.yaml
@@ -9,4 +9,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cluster-monitoring-view
+  name: view


### PR DESCRIPTION
Reverts red-hat-data-services/rhods-operator#349

Need to update it to ClusterRolebinding to fix the issue