### PR TITLE
RHOAIENG-8518: Implement unit tests for kubeflow training and kserve alerts

### DIFF
--- a/tests/prometheus_unit_tests/kserve_alerts_unit_tests.yaml
+++ b/tests/prometheus_unit_tests/kserve_alerts_unit_tests.yaml
@@ -1,0 +1,83 @@
+rule_files:
+  - "kserve_alerts.yaml"
+
+evaluation_interval: 1m
+
+tests:
+  # burn rate
+  - interval: 1m
+    input_series:
+      - series: probe_success:burnrate5m{instance="kserve-controller-manager"}
+        values: "0x60"
+      - series: probe_success:burnrate30m{instance="kserve-controller-manager"}
+        values: "0x60"
+      - series: probe_success:burnrate1h{instance="kserve-controller-manager"}
+        values: "0x60"
+      - series: probe_success:burnrate2hm{instance="kserve-controller-manager"}
+        values: "0x60"
+      - series: probe_success:burnrate6h{instance="kserve-controller-manager"}
+        values: "0x60"
+      - series: probe_success:burnrate1d{instance="kserve-controller-manager"}
+        values: "0x60"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: Kserve Controller Probe Success Burn Rate
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: probe_success:burnrate5m{instance="kserve-controller-manager"}
+        values: "1+1x60"
+      - series: probe_success:burnrate1h{instance="kserve-controller-manager"}
+        values: "1+1x60"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: Kserve Controller Probe Success Burn Rate
+        exp_alerts:
+          - exp_labels:
+              alertname: Kserve Controller Probe Success Burn Rate
+              instance: "kserve-controller-manager"
+              severity: critical
+            exp_annotations:
+              message: "High error budget burn for kserve-controller-manager (current value: 3)."
+              summary: Kserve Controller Probe Success Burn Rate
+              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-kserve-controller-probe-success-burn-rate.md"
+
+  - interval: 1m
+    input_series:
+      - series: probe_success:burnrate30m{instance="kserve-controller-manager"}
+        values: "1+1x60"
+      - series: probe_success:burnrate6h{instance="kserve-controller-manager"}
+        values: "1+1x60"
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: Kserve Controller Probe Success Burn Rate
+        exp_alerts:
+          - exp_labels:
+              alertname: Kserve Controller Probe Success Burn Rate
+              instance: "kserve-controller-manager"
+              severity: critical
+            exp_annotations:
+              message: "High error budget burn for kserve-controller-manager (current value: 16)."
+              summary: Kserve Controller Probe Success Burn Rate
+              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-kserve-controller-probe-success-burn-rate.md"
+
+  - interval: 1m
+    input_series:
+      - series: probe_success:burnrate2h{instance="kserve-controller-manager"}
+        values: "1+1x60"
+      - series: probe_success:burnrate1d{instance="kserve-controller-manager"}
+        values: "1+1x60"
+    alert_rule_test:
+      - eval_time: 1h
+        alertname: Kserve Controller Probe Success Burn Rate
+        exp_alerts:
+          - exp_labels:
+              alertname: Kserve Controller Probe Success Burn Rate
+              instance: "kserve-controller-manager"
+              severity: warning
+            exp_annotations:
+              message: "High error budget burn for kserve-controller-manager (current value: 61)."
+              summary: Kserve Controller Probe Success Burn Rate
+              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Model-Serving/rhods-kserve-controller-probe-success-burn-rate.md"
+

--- a/tests/prometheus_unit_tests/training_operator_unit_tests.yaml
+++ b/tests/prometheus_unit_tests/training_operator_unit_tests.yaml
@@ -1,0 +1,46 @@
+rule_files:
+  - "training_operator_alerts.yaml"
+
+evaluation_interval: 1m
+
+tests:
+  # Operator running
+  - interval: 1m
+    input_series:
+      - series: up{job="KubeFlow Training Operator"}
+        values: "1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KubeFlow Training Operator is not running
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KubeFlow Training Operator is not running
+        exp_alerts:
+          - exp_labels:
+              alertname: KubeFlow Training Operator is not running
+              severity: warning
+            exp_annotations:
+              description: "This alert fires when the KubeFlow Training Operator is not running."
+              summary: Alerting for KubeFlow Training Operator
+              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/training-operator-availability.md"
+  
+  - interval: 1m
+    input_series:
+      - series: up{job="KubeFlow Training Operator"}
+        values: "0" 
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KubeFlow Training Operator is not running
+        exp_alerts:
+          - exp_labels:
+              alertname: KubeFlow Training Operator is not running
+              severity: warning
+              job: "KubeFlow Training Operator"
+            exp_annotations:
+              description: "This alert fires when the KubeFlow Training Operator is not running."
+              summary: Alerting for KubeFlow Training Operator
+              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/training-operator-availability.md"


### PR DESCRIPTION
## Description
[Jira ticket](https://issues.redhat.com/browse/RHOAIENG-8518)

This pr adds support for unit tests for the kserve and kubeflow alerts

## How Has This Been Tested?
```
cd tests/prometheus_unit_tests

# Use yq to pull the alert definitions out of the larger config file
yq '.data."rhods-dashboard-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > dashboard_alerts.yaml && yq '.data."model-mesh-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > model_mesh_alerts.yaml && yq '.data."trustyai-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > trustyai_alerts.yaml && yq '.data."odh-model-controller-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > model_controller_alerts.yaml && yq '.data."workbenches-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > workbenches_alerts.yaml && yq '.data."data-science-pipelines-operator-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > data_science_pipelines_operator_alerts.yaml && yq '.data."kserve-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > kserve_alerts.yaml && yq '.data."trainingoperator-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > training_operator_alerts.yaml

# Run the unit tests
promtool test rules *_unit_tests.yaml
```

## Screenshot or short clip
<img width="1320" alt="image" src="https://github.com/user-attachments/assets/99a13037-808e-4213-a686-1a48d317af3a">

## Merge criteria
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
