### PR TITLE
RHOAIENG-12537: Improve Searchability of RHOAI in Operator Catalog

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -1777,8 +1777,15 @@ spec:
   keywords:
   - OpenShift
   - Open Data Hub
+  - ODH
   - opendatahub
   - Red Hat OpenShift AI
+  - RHOAI
+  - OAI
+  - AI
+  - ML
+  - Machine Learning
+  - Data Science
   - notebooks
   - serving
   - training


### PR DESCRIPTION
## Description
Added missing RHOAI-related keywords to the RHOAI operator bundle's CSV, to improve searchability of RHOAI operator

JIRA reference: [RHOAIENG-12537](https://issues.redhat.com/browse/RHOAIENG-12537)

## How Has This Been Tested?
Manually tested on dev OpenShift cluster in the OperatorHub UI

Testing steps:
1. build and push bundle image
2. build and push index/catalog image
3. deploy a CatalogSource that references the index/catalog image into openshift-marketplace namespace
4. search for RHOAI operator in OperatorHub UI using the added keywords

## Screenshot or short clip
![image](https://github.com/user-attachments/assets/644f0d6c-73dd-4e04-a69a-119fa62c70bc)
![image](https://github.com/user-attachments/assets/fdb82bfb-b70e-4a4c-9298-62a932b62f1a)

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
