### PR TITLE
RHOAIENG-8517: Implement unit tests for kuberay, kueue, notebook and kubeflow alerts

### DIFF
--- a/tests/prometheus_unit_tests/kuberay_alerts_unit_tests.yaml
+++ b/tests/prometheus_unit_tests/kuberay_alerts_unit_tests.yaml
@@ -1,0 +1,47 @@
+rule_files:
+  - "kuberay_alerts.yaml"
+
+evaluation_interval: 1m
+
+tests:
+  # Operator running
+  - interval: 1m
+    input_series:
+      - series: up{job="KubeRay Operator"}
+        values: "1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KubeRay Operator is not running
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KubeRay Operator is not running
+        exp_alerts:
+          - exp_labels:
+              alertname: KubeRay Operator is not running
+              severity: warning
+            exp_annotations:
+              description: This alert fires when the KubeRay Operator is not running.
+              summary: Alerting for KubeRay Operator
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kuberay-operator-availability.md'
+  
+  - interval: 1m
+    input_series:
+      - series: up{job="KubeRay Operator"}
+        values: "0"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: KubeRay Operator is not running
+        exp_alerts:
+          - exp_labels:
+              alertname: KubeRay Operator is not running
+              severity: warning
+              job: "KubeRay Operator"
+            exp_annotations:
+              description: This alert fires when the KubeRay Operator is not running.
+              summary: Alerting for KubeRay Operator
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kuberay-operator-availability.md'
+

--- a/tests/prometheus_unit_tests/kueue_alerts_unit_tests.yaml
+++ b/tests/prometheus_unit_tests/kueue_alerts_unit_tests.yaml
@@ -1,0 +1,46 @@
+rule_files:
+  - "kueue_alerts.yaml"
+
+evaluation_interval: 1m
+
+tests:
+  # Operator running
+  - interval: 1m
+    input_series:
+      - series: up{job="Kueue Operator"}
+        values: "1"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: Kueue Operator is not running
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: Kueue Operator is not running
+        exp_alerts:
+          - exp_labels:
+              alertname: Kueue Operator is not running
+              severity: warning
+            exp_annotations:
+              description: This alert fires when the Kueue Operator is not running.
+              summary: Alerting for Kueue Operator
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kueue-operator-availability.md'
+  
+  - interval: 1m
+    input_series:
+      - series: up{job="Kueue Operator"}
+        values: "0"
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: Kueue Operator is not running
+        exp_alerts:
+          - exp_labels:
+              alertname: Kueue Operator is not running
+              severity: warning
+              job: "Kueue Operator"
+            exp_annotations:
+              description: This alert fires when the Kueue Operator is not running.
+              summary: Alerting for Kueue Operator
+              triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Distributed-Workloads/kueue-operator-availability.md'

--- a/tests/prometheus_unit_tests/workbenches_alerts_unit_tests.yaml
+++ b/tests/prometheus_unit_tests/workbenches_alerts_unit_tests.yaml
@@ -151,3 +151,28 @@ tests:
               summary: "RHODS Jupyter Probe Success Burn Rate"
               message: "High error budget burn for notebook-spawner (current value: 181)."
               triage: 'https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-jupyter-probe-success-burn-rate.md'
+
+  # ODH notebook controllers running
+  - interval: 1m
+    input_series:
+      - series: up{job="ODH Notebook Controller Service Metrics"}
+        values: "1"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: ODH notebook controller pod is not running
+        exp_alerts: []
+  
+  - interval: 1m
+    input_series:
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: ODH notebook controller pod is not running
+        exp_alerts:
+          - exp_labels:
+              alertname: DH notebook controller pod is not running
+              severity: warning
+              namespace: redhat-ods-applications
+            exp_annotations:
+              summary: ODH notebook controller pod is not running
+              message: 'ODH notebook controller is down!'
+              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"

--- a/tests/prometheus_unit_tests/workbenches_alerts_unit_tests.yaml
+++ b/tests/prometheus_unit_tests/workbenches_alerts_unit_tests.yaml
@@ -169,10 +169,35 @@ tests:
         alertname: ODH notebook controller pod is not running
         exp_alerts:
           - exp_labels:
-              alertname: DH notebook controller pod is not running
+              alertname: ODH notebook controller pod is not running
               severity: warning
               namespace: redhat-ods-applications
             exp_annotations:
               summary: ODH notebook controller pod is not running
               message: 'ODH notebook controller is down!'
               triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-odh-notebook-controller-alert.md"
+  
+  # Kubeflow notebook controllers running
+  - interval: 1m
+    input_series:
+      - series: up{job="Kubeflow Notebook Controller Service Metrics"}
+        values: "1"
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: Kubeflow notebook controller pod is not running
+        exp_alerts: []
+  
+  - interval: 1m
+    input_series:
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: Kubeflow notebook controller pod is not running
+        exp_alerts:
+          - exp_labels:
+              alertname: Kubeflow notebook controller pod is not running
+              severity: warning
+              namespace: redhat-ods-applications
+            exp_annotations:
+              summary: Kubeflow notebook controller pod is not running
+              message: 'Kubeflow Notebook controller is down!'
+              triage: "https://gitlab.cee.redhat.com/service/managed-tenants-sops/-/blob/main/RHODS/Jupyter/rhods-kfnbc-notebook-controller-alert.md"


### PR DESCRIPTION
## Description

[Jira ticket](https://issues.redhat.com/browse/RHOAIENG-8517)

This pr adds support for unit tests for the kuberay, kueue, kubeflow controller and ODH notebook controller alerts


## How Has This Been Tested?
```
cd tests/prometheus_unit_tests

# Use yq to pull the alert definitions out of the larger config file
yq '.data."rhods-dashboard-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > dashboard_alerts.yaml && yq '.data."model-mesh-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > model_mesh_alerts.yaml && yq '.data."trustyai-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > trustyai_alerts.yaml && yq '.data."odh-model-controller-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > model_controller_alerts.yaml && yq '.data."workbenches-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > workbenches_alerts.yaml && yq '.data."data-science-pipelines-operator-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > data_science_pipelines_operator_alerts.yaml && yq '.data."kserve-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > kserve_alerts.yaml && yq '.data."kueue-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > kueue_alerts.yaml && yq '.data."ray-alerting.rules"' ../../config/monitoring/prometheus/apps/prometheus-configs.yaml > kuberay_alerts.yaml

# Run the unit tests
promtool test rules *_unit_tests.yaml
```

## Screenshot or short clip
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/2a4b45b0-dd48-4cd6-9dd5-793d5cc3a94e">

## Merge criteria
- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
