### PR TITLE
fix: add missing rbac rule to scrape metrics endpoints protected by rbac, fixes RHOAIENG-13957

### DIFF
--- a/config/monitoring/prometheus/base/prometheus-roles.yaml
+++ b/config/monitoring/prometheus/base/prometheus-roles.yaml
@@ -46,3 +46,7 @@ rules:
   - list
   - get
   - watch
+- nonResourceURLs:
+  - "/metrics"
+  verbs:
+  - get


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Add missing rbac rule to scrape metrics endpoints protected by rbac
See [RHOAIENG-13957](https://issues.redhat.com/browse/RHOAIENG-13957) for more details. 

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by adding this rule to the prometheus-scraper role manually in a test QE cluster. 

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [X] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [X] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work