### PR TITLE
Update Dockerfile.konflux to use Go 1.22 builder

### DIFF
--- a/Dockerfiles/Dockerfile.konflux
+++ b/Dockerfiles/Dockerfile.konflux
@@ -1,7 +1,7 @@
 # Build the manager binary
 ################################################################################
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.21@sha256:742ae6ec1aef3e7faae488c47695fb64964d342aefecf52d23bd9d5e6731d0b6 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22@sha256:1cfdf0c57886426cfd322b438f2c87612d034a7121a3e70bf897162415b42216 as builder
 
 USER root
 WORKDIR /opt


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
The UBI8 go-toolset is a single-stream image repository, and therefore won't receive any further updates to the 1.22 tag now that 1.22 is out.
<!--- Link your JIRA and related links here for reference. -->
Jira: https://issues.redhat.com/browse/RHOAIENG-16819