### PR TITLE
[sync] It takes more than 10 minutes for kserve-controller to be created during 2.17 installation (#1564)

### DIFF
--- a/controllers/components/kserve/kserve_controller.go
+++ b/controllers/components/kserve/kserve_controller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	featuresv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/features/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/deploy"
@@ -43,6 +44,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/clusterrole"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/component"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/generation"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/hash"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/predicates/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
@@ -113,7 +115,12 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 				},
 			)),
 		).
-
+		// resource
+		Watches(
+			&dsciv1.DSCInitialization{},
+			reconciler.WithEventHandler(handlers.ToNamed(componentApi.KserveInstanceName)),
+			reconciler.WithPredicates(predicate.Or(generation.New(), resources.DSCIReadiness)),
+		).
 		// operands - dynamically watched
 		//
 		// A watch will be created dynamically for these kinds, if they exist on the cluster

--- a/pkg/controller/predicates/resources/resources.go
+++ b/pkg/controller/predicates/resources/resources.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 )
 
 var _ predicate.Predicate = DeploymentPredicate{}
@@ -114,6 +115,30 @@ var DSCComponentUpdatePredicate = predicate.Funcs{
 				}
 			}
 		}
+		return false
+	},
+}
+
+var DSCIReadiness = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldObj, ok := e.ObjectOld.(*dsciv1.DSCInitialization)
+		if !ok {
+			return false
+		}
+		newObj, ok := e.ObjectNew.(*dsciv1.DSCInitialization)
+		if !ok {
+			return false
+		}
+
+		return oldObj.Status.Phase != newObj.Status.Phase
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		return false
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
 		return false
 	},
 }

--- a/pkg/feature/servicemesh/conditions.go
+++ b/pkg/feature/servicemesh/conditions.go
@@ -90,12 +90,15 @@ func WaitForControlPlaneToBeReady(ctx context.Context, cli client.Client, f *fea
 
 	return wait.PollUntilContextTimeout(ctx, interval, duration, false, func(ctx context.Context) (bool, error) {
 		ready, err := CheckControlPlaneComponentReadiness(ctx, cli, smcp, smcpNs)
+		if err != nil {
+			return false, err
+		}
 
 		if ready {
 			f.Log.Info("done waiting for control plane components to be ready", "control-plane", smcp, "namespace", smcpNs)
 		}
 
-		return ready, err
+		return ready, nil
 	})
 }
 
@@ -107,13 +110,19 @@ func CheckControlPlaneComponentReadiness(ctx context.Context, c client.Client, s
 		Name:      smcpName,
 	}, smcpObj)
 
-	if err != nil {
+	switch {
+	case k8serr.IsNotFound(err):
+		return false, nil
+	case err != nil:
 		return false, fmt.Errorf("failed to find Service Mesh Control Plane: %w", err)
 	}
 
 	components, found, err := unstructured.NestedMap(smcpObj.Object, "status", "readiness", "components")
-	if err != nil || !found {
+	if err != nil {
 		return false, fmt.Errorf("status conditions not found or error in parsing of Service Mesh Control Plane: %w", err)
+	}
+	if !found {
+		return false, nil
 	}
 
 	readyComponents := len(components["ready"].([]interface{}))     //nolint:forcetypeassert,errcheck


### PR DESCRIPTION


* It takes more than 10 minutes for kserve-controller to be created during 2.17 installation

* cleanup

(cherry picked from commit 48341ffdc20606a517f65502662d39515716737e)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-18425

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
