### PR TITLE
[sync]Remove legacy ModelController deployment on upgrade (#1591)

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -284,6 +284,8 @@ func CleanupExistingResource(ctx context.Context,
 
 	// cleanup nvidia nim integration
 	multiErr = multierror.Append(multiErr, cleanupNimIntegration(ctx, cli, oldReleaseVersion, dscApplicationsNamespace))
+	// cleanup model controller legacy deployment
+	multiErr = multierror.Append(multiErr, cleanupModelControllerLegacyDeployment(ctx, cli, dscApplicationsNamespace))
 
 	return multiErr.ErrorOrNil()
 }
@@ -668,4 +670,53 @@ func cleanupNimIntegration(ctx context.Context, cli client.Client, oldRelease cl
 	}
 
 	return errs.ErrorOrNil()
+}
+
+// When upgrading from version 2.16 to 2.17, the odh-model-controller
+// fails to be provisioned due to the immutability of the deployment's
+// label selectors. In RHOAI ≤ 2.16, the model controller was deployed
+// independently by both kserve and modelmesh, leading to variations
+// in label assignments depending on the deployment order. During a
+// redeployment or upgrade, this error was ignored, and the model
+// controller would eventually be reconciled by the appropriate component.
+//
+// However, in version 2.17, the model controller is now a defined
+// dependency with its own fixed labels and selectors. This change
+// causes issues during upgrades, as existing deployments cannot be
+// modified accordingly.
+//
+// This function as to stay as long as there is any long term support
+// release based on the old logic.
+func cleanupModelControllerLegacyDeployment(ctx context.Context, cli client.Client, applicationNS string) error {
+	l := logf.FromContext(ctx)
+
+	d := appsv1.Deployment{}
+	d.Name = "odh-model-controller"
+	d.Namespace = applicationNS
+
+	err := cli.Get(ctx, client.ObjectKeyFromObject(&d), &d)
+	switch {
+	case k8serr.IsNotFound(err):
+		return nil
+	case err != nil:
+		return fmt.Errorf("failure getting %s deployment in namespace %s: %w", d.Name, d.Namespace, err)
+	}
+
+	if d.Labels[labels.PlatformPartOf] == componentApi.ModelControllerComponentName {
+		return nil
+	}
+
+	l.Info("deleting legacy deployment", "name", d.Name, "namespace", d.Namespace)
+
+	err = cli.Delete(ctx, &d, client.PropagationPolicy(metav1.DeletePropagationForeground))
+	switch {
+	case k8serr.IsNotFound(err):
+		return nil
+	case err != nil:
+		return fmt.Errorf("failure deleting %s deployment in namespace %s: %w", d.Name, d.Namespace, err)
+	}
+
+	l.Info("legacy deployment deleted", "name", d.Name, "namespace", d.Namespace)
+
+	return nil
 }


### PR DESCRIPTION
* Remove legacy ModelController deployment on upgrade

When upgrading from version 2.16 to 2.17, the odh-model-controller fails to be provisioned due to the immutability of the deployment's label selectors. In RHOAI ≤ 2.16, the model controller was deployed independently by both kserve and modelmesh, leading to variations in label assignments depending on the deployment order. During a redeployment or upgrade, this error was ignored, and the model controller would eventually be reconciled by the appropriate component.

However, in version 2.17, the model controller is now a defined dependency with its own fixed labels and selectors. This change causes issues during upgrades, as existing deployments cannot be modified accordingly.

* Add comment

* Fix linter findings

(cherry picked from commit cb2baa92ceb41b32a6bfb821b4db5e1d07029883)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
**a bit change from original one,due to the cleanup upgrade logic was only in ODH has not been sync to RHOAI**

<!--- Link your JIRA and related links here for reference. -->

https://issues.redhat.com/browse/RHOAIENG-18937

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
