### PR TITLE
[RHOAIENG-18996] -  kserve-storage-initializer and oauth-proxy share the same SHA

### DIFF
--- a/prefetched-manifests/kserve/overlays/odh/params.env
+++ b/prefetched-manifests/kserve/overlays/odh/params.env
@@ -2,4 +2,4 @@ kserve-controller=quay.io/modh/kserve-controller@sha256:5b7a8b5665536387ded1d5e5
 kserve-agent=quay.io/modh/kserve-agent@sha256:edaad5104dcc5b1ecf1fc54d1c4c7d7becd19f7b7789462c63662e8f54e3e71d
 kserve-router=quay.io/modh/kserve-router@sha256:9302e9c3e7de8e19cec174aa1d2666bc639218dc305d05845842906e870ec3c5
 kserve-storage-initializer=quay.io/modh/kserve-storage-initializer@sha256:680fdb6d16ed7b08c3da70e41a7ee9f60b63282ad95a23a2b695985e686a2e85
-oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:680fdb6d16ed7b08c3da70e41a7ee9f60b63282ad95a23a2b695985e686a2e85
+oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:234af927030921ab8f7333f61f967b4b4dee37a1b3cf85689e9e63240dd62800


### PR DESCRIPTION

chore:	Fixes RHOAIENG-18996, the oauth-proxy sha was incorrectly updated to the same one
	than storage-initializer.

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
