### PR TITLE
[sync]Add missing predicates for Kserve dynamic watches (#1678)

### DIFF
--- a/controllers/components/kserve/kserve_controller.go
+++ b/controllers/components/kserve/kserve_controller.go
@@ -123,27 +123,27 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		// implicit predicate, so the simpler "DefaultPredicate" is also added.
 		WatchesGVK(
 			gvk.KnativeServing,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.KnativeServing)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 		WatchesGVK(
 			gvk.ServiceMeshMember,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.ServiceMeshMember)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 		WatchesGVK(
 			gvk.EnvoyFilter,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.EnvoyFilter)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 		WatchesGVK(
 			gvk.AuthorizationPolicy,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.AuthorizationPolicy)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 		WatchesGVK(
 			gvk.Gateway,
-			reconciler.Dynamic(),
+			reconciler.Dynamic(ifGVKInstalled(gvk.Gateway)),
 			reconciler.WithEventMapper(ownedViaFTMapFunc),
 			reconciler.WithPredicates(predicates.DefaultPredicate)).
 

--- a/controllers/components/kserve/kserve_support.go
+++ b/controllers/components/kserve/kserve_support.go
@@ -271,3 +271,14 @@ func ownedViaFT(cli client.Client) handler.MapFunc {
 func isLegacyOwnerRef(or metav1.OwnerReference) bool {
 	return or.APIVersion == gvk.DataScienceCluster.GroupVersion().String() && or.Kind == gvk.DataScienceCluster.Kind
 }
+
+func ifGVKInstalled(kvg schema.GroupVersionKind) func(context.Context, *odhtypes.ReconciliationRequest) bool {
+	return func(ctx context.Context, rr *odhtypes.ReconciliationRequest) bool {
+		hasCRD, err := cluster.HasCRD(ctx, rr.Client, kvg)
+		if err != nil {
+			ctrl.Log.Error(err, "error checking if CRD installed", "GVK", kvg)
+			return false
+		}
+		return hasCRD
+	}
+}

--- a/pkg/cluster/operator.go
+++ b/pkg/cluster/operator.go
@@ -100,28 +100,3 @@ func CustomResourceDefinitionExists(ctx context.Context, cli client.Client, crdG
 
 	return err
 }
-
-// return true if found, return false if not found required CRD with version
-// checks on both CRD API version also if it is under deletion.
-func HasCRDWithVersion(ctx context.Context, cli client.Client, crdGK schema.GroupKind, version string) (bool, error) {
-	crd := &apiextv1.CustomResourceDefinition{}
-	name := strings.ToLower(fmt.Sprintf("%ss.%s", crdGK.Kind, crdGK.Group))
-	err := cli.Get(ctx, client.ObjectKey{Name: name}, crd)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			return false, nil
-		}
-		return false, err
-	}
-	for _, v := range crd.Status.StoredVersions {
-		if v == version {
-			for _, condition := range crd.Status.Conditions {
-				if condition.Type == apiextv1.Terminating && condition.Status == apiextv1.ConditionTrue {
-					return false, nil
-				}
-			}
-			return true, nil
-		}
-	}
-	return false, nil
-}

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -4,15 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apihelpers"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	client2 "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
 )
 
 // UpdatePodSecurityRolebinding update default rolebinding which is created in applications namespace by manifests
@@ -177,4 +184,54 @@ func CreateWithRetry(ctx context.Context, cli client.Client, obj client.Object, 
 		// some other error
 		return false, errCreate
 	})
+}
+
+func GetCRD(ctx context.Context, cli client.Client, name string) (apiextensionsv1.CustomResourceDefinition, error) {
+	obj := apiextensionsv1.CustomResourceDefinition{}
+	err := cli.Get(ctx, client.ObjectKey{Name: name}, &obj)
+	if err != nil {
+		return obj, err
+	}
+
+	return obj, nil
+}
+
+func HasCRD(ctx context.Context, cli *client2.Client, gvk schema.GroupVersionKind) (bool, error) {
+	return HasCRDWithVersion(ctx, cli, gvk.GroupKind(), gvk.Version)
+}
+
+// HasCRDWithVersion checks if a CustomResourceDefinition (CRD) exists with the specified version.
+// It verifies the CRD's existence, ensures that the version is stored, and checks if the CRD is under deletion.
+//
+// Parameters:
+//   - ctx: The context for the request.
+//   - cli: A controller-runtime client to interact with the Kubernetes API.
+//   - gk: The GroupKind of the CRD to look up.
+//   - version: The specific version to check for within the CRD.
+//
+// Returns:
+//   - (true, nil) if the CRD with the specified version exists and is not terminating.
+//   - (false, nil) if the CRD does not exist, does not store the requested version, or is terminating.
+//   - (false, error) if there was an error fetching the CRD.
+func HasCRDWithVersion(ctx context.Context, cli *client2.Client, gk schema.GroupKind, version string) (bool, error) {
+	m, err := cli.RESTMapper().RESTMapping(gk, version)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	crd, err := GetCRD(ctx, cli, m.Resource.GroupResource().String())
+	switch {
+	case err != nil:
+		return false, client.IgnoreNotFound(err)
+	case apihelpers.IsCRDConditionTrue(&crd, apiextensionsv1.Terminating):
+		return false, nil
+	case !slices.Contains(crd.Status.StoredVersions, version):
+		return false, nil
+	default:
+		return true, nil
+	}
 }

--- a/pkg/cluster/resources_test.go
+++ b/pkg/cluster/resources_test.go
@@ -1,0 +1,92 @@
+package cluster_test
+
+import (
+	"context"
+	"testing"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestHasCRDWithVersion(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("should succeed if version is present", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		crd := apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dashboards.components.platform.opendatahub.io",
+			},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{
+				StoredVersions: []string{gvk.Dashboard.Version},
+			},
+		}
+
+		err = cli.Create(ctx, &crd)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		hasCRD, err := cluster.HasCRDWithVersion(ctx, cli, gvk.Dashboard.GroupKind(), gvk.Dashboard.Version)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(hasCRD).Should(BeTrue())
+	})
+
+	t.Run("should fails if version is not present", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		crd := apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dashboards.components.platform.opendatahub.io",
+			},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{
+				StoredVersions: []string{"v1alpha2"},
+			},
+		}
+
+		err = cli.Create(ctx, &crd)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		hasCRD, err := cluster.HasCRDWithVersion(ctx, cli, gvk.Dashboard.GroupKind(), gvk.Dashboard.Version)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(hasCRD).Should(BeFalse())
+	})
+
+	t.Run("should fails if terminating", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cli, err := fakeclient.New()
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		crd := apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dashboards.components.platform.opendatahub.io",
+			},
+			Status: apiextensionsv1.CustomResourceDefinitionStatus{
+				StoredVersions: []string{gvk.Dashboard.Version},
+				Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{{
+					Type:   apiextensionsv1.Terminating,
+					Status: apiextensionsv1.ConditionTrue,
+				}},
+			},
+		}
+
+		err = cli.Create(ctx, &crd)
+		g.Expect(err).ShouldNot(HaveOccurred())
+
+		hasCRD, err := cluster.HasCRDWithVersion(ctx, cli, gvk.Dashboard.GroupKind(), gvk.Dashboard.Version)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(hasCRD).Should(BeFalse())
+	})
+}

--- a/pkg/utils/test/fakeclient/fakeclient.go
+++ b/pkg/utils/test/fakeclient/fakeclient.go
@@ -5,6 +5,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -14,6 +15,9 @@ import (
 	clientFake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/apis/components/v1alpha1"
+	dscv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/datasciencecluster/v1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/client"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
@@ -25,10 +29,26 @@ func New(objs ...ctrlClient.Object) (*client.Client, error) {
 	utilruntime.Must(rbacv1.AddToScheme(scheme))
 	utilruntime.Must(oauthv1.AddToScheme(scheme))
 	utilruntime.Must(componentApi.AddToScheme(scheme))
+	utilruntime.Must(dsciv1.AddToScheme(scheme))
+	utilruntime.Must(dscv1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+
+	for _, o := range objs {
+		if err := resources.EnsureGroupVersionKind(scheme, o); err != nil {
+			return nil, err
+		}
+	}
 
 	fakeMapper := meta.NewDefaultRESTMapper(scheme.PreferredVersionAllGroups())
-	for gvk := range scheme.AllKnownTypes() {
-		fakeMapper.Add(gvk, meta.RESTScopeNamespace)
+	for kt := range scheme.AllKnownTypes() {
+		switch {
+		case kt == gvk.CustomResourceDefinition:
+			fakeMapper.Add(kt, meta.RESTScopeRoot)
+		case kt == gvk.ClusterRole:
+			fakeMapper.Add(kt, meta.RESTScopeRoot)
+		default:
+			fakeMapper.Add(kt, meta.RESTScopeNamespace)
+		}
 	}
 
 	ro := make([]runtime.Object, len(objs))


### PR DESCRIPTION
Before this change, these watches don't work properly, and modifying a matching resource doesn't lead to a new reconciliation request being enqueued.

To demonstrate this, once can annotate a matching resource and notice that before this change Kserve reconciliation doesn't happen. With this change, reconciliation occurs as expected.

Co-authored-by: Luca Burgazzoli <lburgazzoli@gmail.com>
(cherry picked from commit e75e4e6a4e9c652a2d22c060d16d0b054e78a705)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
this PR includes two ODH changes:
- https://github.com/opendatahub-io/opendatahub-operator/pull/1680 
- https://github.com/opendatahub-io/opendatahub-operator/pull/1678

<!--- Link your JIRA and related links here for reference. -->
https://issues.redhat.com/browse/RHOAIENG-20304

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
