### PR TITLE
RHOAIENG-18097: 2.16 backport of RHOAIENG-18095: Deprecation of kube-rbac-proxy

### DIFF
--- a/config/monitoring/prometheus/apps/prometheus-configs.yaml
+++ b/config/monitoring/prometheus/apps/prometheus-configs.yaml
@@ -334,7 +334,11 @@ data:
     - job_name: 'Kueue Operator'
       honor_labels: true
       metrics_path: /metrics
-      scheme: http
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
+      authorization:
+        credentials_file: /run/secrets/kubernetes.io/serviceaccount/token
       kubernetes_sd_configs:
         - role: endpoints
           namespaces:
@@ -348,7 +352,7 @@ data:
         - source_labels: [__address__]
           regex: (.+):(\d+)
           target_label: __address__
-          replacement: ${1}:8080
+          replacement: ${1}:8443
 
     - job_name: 'TrustyAI Controller Manager'
       honor_labels: true


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

https://issues.redhat.com/browse/RHOAIENG-18097

This backports the change from https://github.com/opendatahub-io/opendatahub-operator/pull/1500 (for https://issues.redhat.com/browse/RHOAIENG-18097), to the 2.16 branch.


<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
