### PR TITLE
Exclude component-codegen from syft SBOMs

### DIFF
--- a/.syft.yaml
+++ b/.syft.yaml
@@ -1,0 +1,8 @@
+# This excludes the dependencies that are only used for the
+# component-codegen tool from being included in any source SBOM
+# generated from the root of the main project. We use these SBOMs
+# downstream to determine if any vulnerable versions of dependencies
+# are being used, so excluding this subproject may reduce toil in
+# fixing CVEs that don't actually affect the operator.
+exclude:
+  - ./cmd/component-codegen/*


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

This excludes the dependencies that are only used for the component-codegen tool from being included in any source SBOM generated from the root of the main project. We use these SBOMs downstream to determine if any vulnerable versions of dependencies are being used, so excluding this subproject may reduce toil in fixing CVEs that don't actually affect the operator.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Generated an SBOM before and after this change, and noticed the entries for the component-codegen sub-project were excluded from the file after this change.

Before:

```
syft dir:$(pwd) --output cyclonedx-json=sbom-source-before.json
```

After:
```
syft dir:$(pwd) --output cyclonedx-json=sbom-source-after.json
```

Compare:

```
diff -u <(jq "." sbom-source-before.json) <(jq "." sbom-source-after.json)
```

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work