### PR TITLE
Fix conflicting files that are blocking automerge

### DIFF
--- a/.github/workflows/operator-insta-merge.yaml
+++ b/.github/workflows/operator-insta-merge.yaml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     branches:
       - 'rhoai-2.1[6-9]+'  # Trigger the workflow on pushes to any rhoai-* branch
-      - 'rhoai-2.2[0-9]+' # Trigger the workflow on pushes to any rhoai-2.20 and above branch
+      - 'rhoai-2.2[0-9]+'  # Trigger the workflow on pushes to any rhoai-2.20 branch and above
     types:
       - opened
       - reopened

--- a/.github/workflows/operator-processor.yaml
+++ b/.github/workflows/operator-processor.yaml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - 'rhoai-2.1[6-9]+'
-      - 'rhoai-2.2[0-9]+' # Trigger the workflow on pushes to any rhoai-2.20 branch
+      - 'rhoai-2.2[0-9]+'  # Trigger the workflow on pushes to any rhoai-2.20 branch and above
     paths:
       - build/operator-nudging.yaml
 


### PR DESCRIPTION
For some reason these were changed on 2.20 in a slightly different way than on main, but the diff is just comments.