### PR TITLE
fix: need apply application NWP for self-managed

### DIFF
--- a/controllers/dscinitialization/utils.go
+++ b/controllers/dscinitialization/utils.go
@@ -176,7 +176,7 @@ func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(
 ) error {
 	log := logf.FromContext(ctx)
 	name := dscInit.Spec.ApplicationsNamespace
-	if platform == cluster.ManagedRhoai {
+	if platform == cluster.ManagedRhoai || platform == cluster.SelfManagedRhoai {
 		// Get operator namepsace
 		operatorNs, err := cluster.GetOperatorNamespace()
 		if err != nil {
@@ -189,8 +189,8 @@ func (r *DSCInitializationReconciler) reconcileDefaultNetworkPolicy(
 			log.Error(err, "error to set networkpolicy in operator namespace", "path", networkpolicyPath)
 			return err
 		}
-		// Deploy networkpolicy for monitoring namespace
-		if dscInit.Spec.Monitoring.ManagementState == operatorv1.Managed {
+		// Deploy networkpolicy for monitoring namespace only for managed cluster.
+		if dscInit.Spec.Monitoring.ManagementState == operatorv1.Managed && platform == cluster.ManagedRhoai {
 			err = deploy.DeployManifestsFromPath(ctx, r.Client, dscInit, networkpolicyPath+"/monitoring", dscInit.Spec.Monitoring.Namespace, "networkpolicy", true)
 			if err != nil {
 				log.Error(err, "error to set networkpolicy in monitroing namespace", "path", networkpolicyPath)


### PR DESCRIPTION
- monitoring NWP can be only for managed cluster
- components might require certain ports e.g 9443 to be open

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
waiting Jira to be open and decide if need backport to 2.19

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
