### PR TITLE
[rhoai-2.19] Old conditions remain on DSC after upgrade from 2.16

### DIFF
--- a/pkg/controller/conditions/conditions.go
+++ b/pkg/controller/conditions/conditions.go
@@ -312,6 +312,14 @@ func (r *Manager) findUnhappyDependent() *common.Condition {
 	return nil
 }
 
+// Reset clears all conditions managed by the Manager.
+//
+// It achieves this by setting an empty slice of common.Condition
+// in the underlying accessor.
+func (r *Manager) Reset() {
+	r.accessor.SetConditions([]common.Condition{})
+}
+
 // Sort arranges the conditions retrieved from the accessor based on the following rules:
 // 1. `happy` condition is assigned the highest priority.
 // 2. `dependents` are prioritized in the order they are defined.

--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -253,6 +253,12 @@ func (r *Reconciler) apply(ctx context.Context, res common.PlatformObject) error
 		Manifests:  make([]types.ManifestInfo, 0),
 	}
 
+	// reset conditions so any unknown condition eventually set on
+	// the owned resource get cleaned up. This is the case when a
+	// condition is replaced/removed.
+
+	rr.Conditions.Reset()
+
 	var provisionErr error
 
 	dsci, dscilErr := cluster.GetDSCI(ctx, r.Client)

--- a/pkg/controller/reconciler/reconciler_test.go
+++ b/pkg/controller/reconciler/reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -128,7 +129,9 @@ func TestConditions(t *testing.T) {
 		{
 			name: "ready",
 			err:  nil,
+
 			matcher: And(
+				jq.Match(`all(.status.conditions[]?.type; . != "foo")`),
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionTrue),
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionTrue),
 			),
@@ -137,6 +140,7 @@ func TestConditions(t *testing.T) {
 			name: "stop",
 			err:  odherrors.NewStopError("stop"),
 			matcher: And(
+				jq.Match(`all(.status.conditions[]?.type; . != "foo")`),
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionFalse),
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionFalse),
 			),
@@ -145,6 +149,7 @@ func TestConditions(t *testing.T) {
 			name: "failure",
 			err:  errors.New("failure"),
 			matcher: And(
+				jq.Match(`all(.status.conditions[]?.type; . != "foo")`),
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeReady, metav1.ConditionFalse),
 				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionTypeProvisioningSucceeded, metav1.ConditionFalse),
 			),
@@ -159,6 +164,26 @@ func TestConditions(t *testing.T) {
 
 			err = cli.Create(ctx, dash)
 			g.Expect(err).NotTo(HaveOccurred())
+
+			st, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&common.Status{
+				Conditions: []common.Condition{{
+					Type:               "foo",
+					Status:             metav1.ConditionFalse,
+					LastTransitionTime: metav1.NewTime(time.Now()),
+				}},
+			})
+
+			g.Expect(err).NotTo(HaveOccurred())
+
+			err = unstructured.SetNestedField(dash.Object, st, "status")
+			g.Expect(err).NotTo(HaveOccurred())
+
+			err = cli.Status().Update(ctx, dash)
+			g.Expect(err).NotTo(HaveOccurred())
+
+			g.Expect(dash).Should(
+				jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, "foo", metav1.ConditionFalse),
+			)
 
 			req := ctrl.Request{
 				NamespacedName: types.NamespacedName{
@@ -180,7 +205,9 @@ func TestConditions(t *testing.T) {
 
 			g.Expect(result.Requeue).Should(BeFalse())
 
-			di := dash.DeepCopy()
+			di := resources.GvkToUnstructured(gvk.Dashboard)
+			di.SetName(dash.GetName())
+
 			err = cli.Get(ctx, client.ObjectKeyFromObject(di), di)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(di).Should(tt.matcher)


### PR DESCRIPTION
## Description
JIRA: [RHOAIENG-25990](https://issues.redhat.com/browse/RHOAIENG-25990)
Backport of [RHOAIENG-222481](https://issues.redhat.com/browse/RHOAIENG-22481) to 2.19.1.


## How Has This Been Tested?
Will be tested as a part of 2.19.1 testing.

## Screenshot or short clip
N/A

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
