### PR TITLE
Only deploy kserve SM resources with Authorino

### DIFF
--- a/controllers/components/kserve/kserve.go
+++ b/controllers/components/kserve/kserve.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	componentName            = componentApi.KserveComponentName
+	authorinoOperator        = "authorino-operator"
 	serviceMeshOperator      = "servicemeshoperator"
 	serverlessOperator       = "serverless-operator"
 	kserveConfigMapName      = "inferenceservice-config"

--- a/controllers/components/kserve/kserve_controller_actions_test.go
+++ b/controllers/components/kserve/kserve_controller_actions_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/onsi/gomega/gstruct"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	ofapiv2 "github.com/operator-framework/api/pkg/operators/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -13,6 +15,8 @@ import (
 	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/dscinitialization/v1"
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/apis/infrastructure/v1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/controllers/status"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/render/template"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
@@ -281,5 +285,128 @@ func TestCheckPreConditions_RawServiceConfig(t *testing.T) {
 		WithTransform(resources.ToUnstructured, And(
 			jq.Match(`.status.conditions[] | select(.type == "%s") | .status == "%s"`, status.ConditionServingAvailable, metav1.ConditionFalse),
 		)),
+	)
+}
+
+func TestCleanUpTemplatedResources_withAuthorino(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	cli, err := fakeclient.New(
+		&ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
+			Name: serviceMeshOperator,
+		}},
+		&ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
+			Name: serverlessOperator,
+		}},
+		&ofapiv1alpha1.Subscription{ObjectMeta: metav1.ObjectMeta{
+			Name: authorinoOperator,
+		}},
+	)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	ksHeaded := componentApi.Kserve{}
+	ksHeaded.Spec.DefaultDeploymentMode = componentApi.Serverless
+	ksHeaded.Spec.Serving.ManagementState = operatorv1.Managed
+
+	dsci := dsciv1.DSCInitialization{}
+	dsci.Spec.ServiceMesh = &infrav1.ServiceMeshSpec{
+		ManagementState: operatorv1.Managed,
+	}
+
+	rrHeaded := types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   &ksHeaded,
+		DSCI:       &dsci,
+		Conditions: conditions.NewManager(&ksHeaded, status.ConditionTypeReady),
+	}
+
+	err = addTemplateFiles(ctx, &rrHeaded)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = template.NewAction(
+		template.WithCache(),
+		template.WithDataFn(getTemplateData),
+	)(ctx, &rrHeaded)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cleanUpTemplatedResources(ctx, &rrHeaded)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(rrHeaded.Resources).Should(
+		And(
+			HaveLen(11),
+			ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Object": And(
+					HaveKeyWithValue("kind", gvk.AuthorizationPolicy.Kind),
+				),
+			})),
+			ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Object": And(
+					HaveKeyWithValue("kind", gvk.EnvoyFilter.Kind),
+				),
+			})),
+		),
+	)
+}
+
+func TestCleanUpTemplatedResources_withoutAuthorino(t *testing.T) {
+	ctx := context.Background()
+	g := NewWithT(t)
+
+	cli, err := fakeclient.New(
+		&ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
+			Name: serviceMeshOperator,
+		}},
+		&ofapiv2.OperatorCondition{ObjectMeta: metav1.ObjectMeta{
+			Name: serverlessOperator,
+		}},
+	)
+
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	ksHeaded := componentApi.Kserve{}
+	ksHeaded.Spec.DefaultDeploymentMode = componentApi.Serverless
+	ksHeaded.Spec.Serving.ManagementState = operatorv1.Managed
+
+	dsci := dsciv1.DSCInitialization{}
+	dsci.Spec.ServiceMesh = &infrav1.ServiceMeshSpec{
+		ManagementState: operatorv1.Managed,
+	}
+
+	rrHeaded := types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   &ksHeaded,
+		DSCI:       &dsci,
+		Conditions: conditions.NewManager(&ksHeaded, status.ConditionTypeReady),
+	}
+
+	err = addTemplateFiles(ctx, &rrHeaded)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = template.NewAction(
+		template.WithCache(),
+		template.WithDataFn(getTemplateData),
+	)(ctx, &rrHeaded)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = cleanUpTemplatedResources(ctx, &rrHeaded)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(rrHeaded.Resources).Should(
+		And(
+			HaveLen(7),
+			Not(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Object": And(
+					HaveKeyWithValue("kind", gvk.AuthorizationPolicy.Kind),
+				),
+			}))),
+			Not(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Object": And(
+					HaveKeyWithValue("kind", gvk.EnvoyFilter.Kind),
+				),
+			}))),
+		),
 	)
 }


### PR DESCRIPTION
This is a backport of a65c3fb9e10725fa6211adfb61f046769568f499 to the rhoai-2.19 branch, to address the following issue in 2.19.1:
https://issues.redhat.com/browse/RHOAIENG-24151

This fixes a bug where previously the AuthorizationPolicy and EnvoyFilter resources were only deployed when Authorino was installed, but it was refactored in 2.19 which caused those to be deployed even when Authorino not installed, which is incorrect.

Old code where it only deployed if authorino installed: https://github.com/red-hat-data-services/rhods-operator/blob/rhoai-2.16/components/kserve/servicemesh_setup.go#L46

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
