### PR TITLE
[RHOAIENG-26334] Revert notebook customized namespace for RHOAI 2.21

### DIFF
--- a/Dockerfiles/bundle.Dockerfile
+++ b/Dockerfiles/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=rhods-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha,stable,fast
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.39.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/api/components/v1alpha1/workbenches_types.go
+++ b/api/components/v1alpha1/workbenches_types.go
@@ -36,13 +36,6 @@ type WorkbenchesCommonSpec struct {
 	// workbenches spec exposed to DSC api
 	common.DevFlagsSpec `json:",inline"`
 	// workbenches spec exposed only to internal api
-
-	// Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "rhods-notebooks"
-	// +kubebuilder:default="rhods-notebooks"
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="WorkbenchNamespace is immutable"
-	// +kubebuilder:validation:Pattern="^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
-	// +kubebuilder:validation:MaxLength=63
-	WorkbenchNamespace string `json:"workbenchNamespace,omitempty"`
 }
 
 // WorkbenchesSpec defines the desired state of Workbenches
@@ -55,7 +48,6 @@ type WorkbenchesSpec struct {
 // WorkbenchesCommonStatus defines the shared observed state of Workbenches
 type WorkbenchesCommonStatus struct {
 	common.ComponentReleaseStatus `json:",inline"`
-	WorkbenchNamespace            string `json:"workbenchNamespace,omitempty"`
 }
 
 // WorkbenchesStatus defines the observed state of Workbenches

--- a/bundle/manifests/components.platform.opendatahub.io_workbenches.yaml
+++ b/bundle/manifests/components.platform.opendatahub.io_workbenches.yaml
@@ -74,16 +74,6 @@ spec:
                       type: object
                     type: array
                 type: object
-              workbenchNamespace:
-                default: rhods-notebooks
-                description: Namespace for workbenches to be installed, configurable
-                  only once when workbenches are enabled, defaults to "rhods-notebooks"
-                maxLength: 63
-                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
-                type: string
-                x-kubernetes-validations:
-                - message: WorkbenchNamespace is immutable
-                  rule: self == oldSelf
             type: object
           status:
             description: WorkbenchesStatus defines the observed state of Workbenches
@@ -168,8 +158,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
-              workbenchNamespace:
-                type: string
             type: object
         type: object
         x-kubernetes-validations:

--- a/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/bundle/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -715,16 +715,6 @@ spec:
                         - Removed
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
-                      workbenchNamespace:
-                        default: rhods-notebooks
-                        description: Namespace for workbenches to be installed, configurable
-                          only once when workbenches are enabled, defaults to "rhods-notebooks"
-                        maxLength: 63
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
-                        type: string
-                        x-kubernetes-validations:
-                        - message: WorkbenchNamespace is immutable
-                          rule: self == oldSelf
                     type: object
                 type: object
             type: object
@@ -1159,8 +1149,6 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
-                      workbenchNamespace:
-                        type: string
                     type: object
                 type: object
               conditions:

--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -109,7 +109,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: REPLACE_IMAGE:latest
-    createdAt: "2025-05-16T09:00:23Z"
+    createdAt: "2025-05-29T06:55:06Z"
     description: Operator for deployment and management of Red Hat OpenShift AI
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -189,7 +189,7 @@ metadata:
       }
     operatorframework.io/suggested-namespace: redhat-ods-operator
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.37.0
+    operators.operatorframework.io/builder: operator-sdk-v1.39.2
     operators.operatorframework.io/internal-objects: |-
       ["featuretrackers.features.opendatahub.io",
       "codeflares.components.platform.opendatahub.io", "dashboards.components.platform.opendatahub.io",
@@ -201,7 +201,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/red-hat-data-services/rhods-operator
     support: Red Hat OpenShift AI
-  name: rhods-operator.v2.20.0
+  name: rhods-operator.v2.22.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1455,7 +1455,7 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 2.20.0
+  version: 2.22.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -109,7 +109,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: REPLACE_IMAGE:latest
-    createdAt: "2025-05-29T06:55:06Z"
+    createdAt: "2025-05-29T07:18:53Z"
     description: Operator for deployment and management of Red Hat OpenShift AI
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -201,7 +201,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/red-hat-data-services/rhods-operator
     support: Red Hat OpenShift AI
-  name: rhods-operator.v2.22.0
+  name: rhods-operator.v2.21.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1455,7 +1455,7 @@ spec:
   minKubeVersion: 1.25.0
   provider:
     name: Red Hat
-  version: 2.22.0
+  version: 2.21.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: rhods-operator
   operators.operatorframework.io.bundle.channels.v1: alpha,stable,fast
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.37.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.39.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/config/crd/bases/components.platform.opendatahub.io_workbenches.yaml
+++ b/config/crd/bases/components.platform.opendatahub.io_workbenches.yaml
@@ -74,16 +74,6 @@ spec:
                       type: object
                     type: array
                 type: object
-              workbenchNamespace:
-                default: rhods-notebooks
-                description: Namespace for workbenches to be installed, configurable
-                  only once when workbenches are enabled, defaults to "rhods-notebooks"
-                maxLength: 63
-                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
-                type: string
-                x-kubernetes-validations:
-                - message: WorkbenchNamespace is immutable
-                  rule: self == oldSelf
             type: object
           status:
             description: WorkbenchesStatus defines the observed state of Workbenches
@@ -168,8 +158,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - name
                 x-kubernetes-list-type: map
-              workbenchNamespace:
-                type: string
             type: object
         type: object
         x-kubernetes-validations:

--- a/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
+++ b/config/crd/bases/datasciencecluster.opendatahub.io_datascienceclusters.yaml
@@ -715,16 +715,6 @@ spec:
                         - Removed
                         pattern: ^(Managed|Unmanaged|Force|Removed)$
                         type: string
-                      workbenchNamespace:
-                        default: rhods-notebooks
-                        description: Namespace for workbenches to be installed, configurable
-                          only once when workbenches are enabled, defaults to "rhods-notebooks"
-                        maxLength: 63
-                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$
-                        type: string
-                        x-kubernetes-validations:
-                        - message: WorkbenchNamespace is immutable
-                          rule: self == oldSelf
                     type: object
                 type: object
             type: object
@@ -1159,8 +1149,6 @@ spec:
                         x-kubernetes-list-map-keys:
                         - name
                         x-kubernetes-list-type: map
-                      workbenchNamespace:
-                        type: string
                     type: object
                 type: object
               conditions:

--- a/docs/api-overview.md
+++ b/docs/api-overview.md
@@ -535,7 +535,6 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `managementState` _[ManagementState](#managementstate)_ | Set to one of the following values:<br /><br />- "Managed" : the operator is actively managing the component and trying to keep it active.<br />              It will only upgrade the component if it is safe to do so<br /><br />- "Removed" : the operator is actively managing the component and will not install it,<br />              or if it is installed, the operator will try to remove it |  | Enum: [Managed Removed] <br /> |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
-| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "rhods-notebooks" | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 
 #### DSCWorkbenchesStatus
@@ -1905,7 +1904,6 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
-| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "rhods-notebooks" | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 
 #### WorkbenchesCommonStatus
@@ -1923,7 +1921,6 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `releases` _[ComponentRelease](#componentrelease) array_ |  |  |  |
-| `workbenchNamespace` _string_ |  |  |  |
 
 
 #### WorkbenchesList
@@ -1960,7 +1957,6 @@ _Appears in:_
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
 | `devFlags` _[DevFlags](#devflags)_ | Add developer fields |  |  |
-| `workbenchNamespace` _string_ | Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to "rhods-notebooks" | rhods-notebooks | MaxLength: 63 <br />Pattern: `^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$` <br /> |
 
 
 #### WorkbenchesStatus
@@ -1980,7 +1976,6 @@ _Appears in:_
 | `observedGeneration` _integer_ | The generation observed by the resource controller. |  |  |
 | `conditions` _[Condition](#condition) array_ |  |  |  |
 | `releases` _[ComponentRelease](#componentrelease) array_ |  |  |  |
-| `workbenchNamespace` _string_ |  |  |  |
 
 
 

--- a/internal/controller/components/workbenches/workbenches_controller_actions.go
+++ b/internal/controller/components/workbenches/workbenches_controller_actions.go
@@ -86,7 +86,7 @@ func devFlags(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
 }
 
 func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
-	workbench, ok := rr.Instance.(*componentApi.Workbenches)
+	_, ok := rr.Instance.(*componentApi.Workbenches)
 	if !ok {
 		return fmt.Errorf("resource instance %v is not a componentApi.Workbenches", rr.Instance)
 	}
@@ -96,15 +96,11 @@ func configureDependencies(ctx context.Context, rr *odhtypes.ReconciliationReque
 		labels.ODH.OwnedNamespace: "true",
 	}
 
-	if workbench.Spec.WorkbenchNamespace != "" || len(workbench.Spec.WorkbenchNamespace) > 0 {
-		wbNS.Name = workbench.Spec.WorkbenchNamespace
-	} else {
-		switch rr.Release.Name {
-		case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
-			wbNS.Name = cluster.DefaultNotebooksNamespaceRHOAI
-		case cluster.OpenDataHub:
-			wbNS.Name = cluster.DefaultNotebooksNamespaceODH
-		}
+	switch rr.Release.Name {
+	case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+		wbNS.Name = cluster.DefaultNotebooksNamespaceRHOAI
+	case cluster.OpenDataHub:
+		wbNS.Name = cluster.DefaultNotebooksNamespaceODH
 	}
 
 	err := rr.AddResources(wbNS)


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
cherry-pick https://github.com/opendatahub-io/opendatahub-operator/pull/1994
remove API for workbench namespace field
set default namespace based on platform value
+
set release to 2.21.0 in order to generate correct local build image with other components latest changes

<!--- Link your JIRA and related links here for reference. -->
ref https://issues.redhat.com/browse/RHOAIENG-26334

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local build:  quay.io/wenzhou/rhods-operator-catalog:v2.21.26334

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
