### PR TITLE
RHOAIENG-24688: Use go-toolset 1.23 to pick up security fixes

### DIFF
--- a/Dockerfiles/Dockerfile.konflux
+++ b/Dockerfiles/Dockerfile.konflux
@@ -1,7 +1,7 @@
 # Build the manager binary
 ################################################################################
 
-FROM registry.redhat.io/ubi8/go-toolset:1.22@sha256:a1a37882bbcf1c0f1115d478d5ea9f74b496b8c753d5e4e431a70786e2dbcbfc as builder
+FROM registry.redhat.io/ubi8/go-toolset:1.23@sha256:655e5a3a907f29f9ea69ec070247ec9cdb2e0e227a0fbe5f0b41e3259bf31715 as builder
 
 # These built-in args are defined in the global scope, and are not automatically accessible within build stages or RUN commands.
 # To expose these arguments inside the build stage, we need to redefine it without a value.


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
JIRA: https://issues.redhat.com/browse/RHOAIENG-24688

The UBI8 go-toolset image is single-stream, so it needs to be updated to the new tag to pick up the latest security vulnerability fixes in the Go standard library. The manifest list digest will be kept up-to-date by the konflux/renovate/mintmaker automation, but only to the latest of a particular tag, and since the old tag doesn't receive any updates once the new tag is release, it's necessary to update the tag at least when there are security fixes that need to be picked up.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
