### PR TITLE
Fix missing llama-stack-k8s-operator manifest copy in pre-fetch script

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -50,3 +50,6 @@ map:
   odh-feast-operator:
     src: infra/feast-operator/config
     dest: feastoperator
+  llama-stack-k8s-operator:
+    src: config
+    dest: llamastackoperator


### PR DESCRIPTION
This PR updates the pre-fetch script to include the missing configuration needed to copy the llama-stack-k8s-operator manifests into the RHODS operator.