### PR TITLE
Fetch kserve manifests using git commit

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -5,12 +5,9 @@ map:
     src: manifests
     dest: workbenches/notebooks
     ref_type: branch
-  kserve:
-    git.url: https://github.com/red-hat-data-services/kserve
-    git.commit: github.ref_name
+  odh-kserve-controller:
     src: config
     dest: kserve
-    ref_type: branch
   odh-kf-notebook-controller:
     src: components/notebook-controller/config
     dest: workbenches/kf-notebook-controller


### PR DESCRIPTION
ref: https://issues.redhat.com/browse/RHOAIENG-29725

Now that kserve images are built in internal konflux and will be published to the catalog, we can fetch the controller manifest precisely using the source git commit 