### PR TITLE
multi-arch pipelines migration (rhoai-2.24)

### DIFF
--- a/build/operator-nudging.yaml
+++ b/build/operator-nudging.yaml
@@ -60,9 +60,9 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_LLAMA_STACK_K8S_OPERATOR_IMAGE
   value: quay.io/rhoai/odh-llama-stack-k8s-operator-rhel9@sha256:ac6d884049993aad20b5d3bcfdebbb211c097a04469ace88779558b457c5e3b7
 - name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
-  value: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:1bd55970c6887a18becafaf7f75fbc76f8bb6bec3f31e9740fd318b33f4ed5fd
+  value: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:86e9a381715e625e1cdc9d46953371b5fd9a6a1bb505908f95116527fc648fa8
 - name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
-  value: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:ef6807c56d5593dc7bc8aa8cfd1cc431beeda155312cb72a64d70be7a04d3dda
+  value: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:63f8d7cab8900fe3bf53ad7fa40b4754d9160ffb961a5c72f21d4b5ccf3ffaf5
 - name: RELATED_IMAGE_ODH_MUST_GATHER_IMAGE
   value: quay.io/rhoai/odh-must-gather-rhel9@sha256:4e54fab6e1930f88abff7d69a769a8d46a9a848153a740fea93937ded0f9c4d3
 - name: RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE


### PR DESCRIPTION
part of:
* https://issues.redhat.com/browse/RHOAIENG-27351
* https://issues.redhat.com/browse/RHOAIENG-28846

follows up on https://github.com/red-hat-data-services/konflux-central/pull/252

in this PR we update the nudging to be based on the manifest list image instead of the single container image.
