### PR TITLE
[sync] fix: do not fail during Operator upgrade check error if it is VAPB not have same API version (#2249)

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -748,7 +748,8 @@ func cleanupDeprecatedKueueVAPB(ctx context.Context, cli client.Client) error {
 
 	// Attempt to delete the resource
 	err := cli.Delete(ctx, vapb)
-	if client.IgnoreNotFound(err) != nil {
+	// VAPB is not a CRD but a core type from k8s, we wanna ensure API version is correct
+	if client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 		return fmt.Errorf("failed to delete deprecated ValidatingAdmissionPolicyBinding: %w", err)
 	}
 


### PR DESCRIPTION
* fix: do not fail during Operator upgrade check error if it is VAPB not have same API version

---------



(cherry picked from commit 033cc3cff2b4b06a4d8ffeb3dd9a7ecd5799799c)

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->
ref: [https://issues.redhat.com/browse/RHOAIENG-31978](https://issues.redhat.com/browse/RHOAIENG-31978)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
