### PR TITLE
Fix Kueue webhook to support both v1 and v1alpha1 Ray resources

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -113,7 +113,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: REPLACE_IMAGE:latest
-    createdAt: "2025-07-24T06:42:59Z"
+    createdAt: "2025-08-12T15:50:45Z"
     description: Operator for deployment and management of Red Hat OpenShift AI
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -1819,6 +1819,7 @@ spec:
       - ray.io
       apiVersions:
       - v1
+      - v1alpha1
       operations:
       - CREATE
       - UPDATE

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -184,6 +184,7 @@ webhooks:
     - ray.io
     apiVersions:
     - v1
+    - v1alpha1
     operations:
     - CREATE
     - UPDATE

--- a/internal/webhook/kueue/validating.go
+++ b/internal/webhook/kueue/validating.go
@@ -29,11 +29,11 @@ import (
 
 // Webhooks for Kueue label validation:
 // - kubeflow.org/v1: pytorchjobs, notebooks
-// - ray.io/v1: rayjobs, rayclusters
+// - ray.io/v1 and v1alpha1: rayjobs, rayclusters
 // - serving.kserve.io/v1beta1: inferenceservices
 
 //+kubebuilder:webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=kubeflow.org,resources=pytorchjobs;notebooks,verbs=create;update,versions=v1,name=kubeflow-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
-//+kubebuilder:webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs;rayclusters,verbs=create;update,versions=v1,name=ray-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
+//+kubebuilder:webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=ray.io,resources=rayjobs;rayclusters,verbs=create;update,versions=v1;v1alpha1,name=ray-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
 //+kubebuilder:webhook:path=/validate-kueue,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=inferenceservices,verbs=create;update,versions=v1beta1,name=kserve-kueuelabels-validator.opendatahub.io,admissionReviewVersions=v1
 //nolint:lll
 
@@ -116,11 +116,13 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 func isExpectedKind(kind metav1.GroupVersionKind) bool {
 	// List of expected resource types that the Kueue webhook should handle
 	expectedGVKs := []schema.GroupVersionKind{
-		gvk.Notebook,          // kubeflow.org/v1/Notebook
-		gvk.PyTorchJob,        // kubeflow.org/v1/PyTorchJob
-		gvk.RayJob,            // ray.io/v1/RayJob
-		gvk.RayCluster,        // ray.io/v1/RayCluster
-		gvk.InferenceServices, // serving.kserve.io/v1beta1/InferenceService
+		gvk.Notebook,           // kubeflow.org/v1/Notebook
+		gvk.PyTorchJob,         // kubeflow.org/v1/PyTorchJob
+		gvk.RayJobV1Alpha1,     // ray.io/v1alpha1/RayJob
+		gvk.RayJobV1,           // ray.io/v1/RayJob
+		gvk.RayClusterV1Alpha1, // ray.io/v1alpha1/RayCluster
+		gvk.RayClusterV1,       // ray.io/v1/RayCluster
+		gvk.InferenceServices,  // serving.kserve.io/v1beta1/InferenceService
 	}
 
 	requestGVK := schema.GroupVersionKind{

--- a/internal/webhook/kueue/validation_test.go
+++ b/internal/webhook/kueue/validation_test.go
@@ -176,29 +176,57 @@ func TestKueueWebhook_AcceptsExpectedKinds(t *testing.T) {
 			},
 		},
 		{
-			name: "RayJob",
-			gvk:  gvk.RayJob,
+			name: "RayJob v1alpha1",
+			gvk:  gvk.RayJobV1Alpha1,
 			resource: metav1.GroupVersionResource{
-				Group:    gvk.RayJob.Group,
-				Version:  gvk.RayJob.Version,
+				Group:    gvk.RayJobV1Alpha1.Group,
+				Version:  gvk.RayJobV1Alpha1.Version,
 				Resource: "rayjobs",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-rayjob", testNamespace, func(obj client.Object) {
+				return envtestutil.NewNotebook("test-rayjob-v1alpha1", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},
 		},
 		{
-			name: "RayCluster",
-			gvk:  gvk.RayCluster,
+			name: "RayCluster v1alpha1",
+			gvk:  gvk.RayClusterV1Alpha1,
 			resource: metav1.GroupVersionResource{
-				Group:    gvk.RayCluster.Group,
-				Version:  gvk.RayCluster.Version,
+				Group:    gvk.RayClusterV1Alpha1.Group,
+				Version:  gvk.RayClusterV1Alpha1.Version,
 				Resource: "rayclusters",
 			},
 			objFunc: func() client.Object {
-				return envtestutil.NewNotebook("test-raycluster", testNamespace, func(obj client.Object) {
+				return envtestutil.NewNotebook("test-raycluster-v1alpha1", testNamespace, func(obj client.Object) {
+					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
+				})
+			},
+		},
+		{
+			name: "RayJob v1",
+			gvk:  gvk.RayJobV1,
+			resource: metav1.GroupVersionResource{
+				Group:    gvk.RayJobV1.Group,
+				Version:  gvk.RayJobV1.Version,
+				Resource: "rayjobs",
+			},
+			objFunc: func() client.Object {
+				return envtestutil.NewNotebook("test-rayjob-v1", testNamespace, func(obj client.Object) {
+					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
+				})
+			},
+		},
+		{
+			name: "RayCluster v1",
+			gvk:  gvk.RayClusterV1,
+			resource: metav1.GroupVersionResource{
+				Group:    gvk.RayClusterV1.Group,
+				Version:  gvk.RayClusterV1.Version,
+				Resource: "rayclusters",
+			},
+			objFunc: func() client.Object {
+				return envtestutil.NewNotebook("test-raycluster-v1", testNamespace, func(obj client.Object) {
 					obj.SetLabels(map[string]string{objLabelQueueName: validQueueName})
 				})
 			},

--- a/pkg/cluster/gvk/gvk.go
+++ b/pkg/cluster/gvk/gvk.go
@@ -386,15 +386,27 @@ var (
 		Kind:    "PyTorchJob",
 	}
 
-	RayJob = schema.GroupVersionKind{
+	RayJobV1Alpha1 = schema.GroupVersionKind{
 		Group:   "ray.io",
 		Version: "v1alpha1",
 		Kind:    "RayJob",
 	}
 
-	RayCluster = schema.GroupVersionKind{
+	RayJobV1 = schema.GroupVersionKind{
+		Group:   "ray.io",
+		Version: "v1",
+		Kind:    "RayJob",
+	}
+
+	RayClusterV1Alpha1 = schema.GroupVersionKind{
 		Group:   "ray.io",
 		Version: "v1alpha1",
+		Kind:    "RayCluster",
+	}
+
+	RayClusterV1 = schema.GroupVersionKind{
+		Group:   "ray.io",
+		Version: "v1",
 		Kind:    "RayCluster",
 	}
 


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

Jira: [RHOAIENG-32042](https://issues.redhat.com/browse/RHOAIENG-32042).

## Description
<!--- Describe your changes in detail -->

This PR fixes a bug in the Kueue label validation webhook where Ray resources were being rejected due to API version mismatches. The webhook was configured to only accept `ray.io/v1` resources, but the actual GVK definitions were pointing to `ray.io/v1alpha1`, causing all Ray workloads to be rejected.

**Changes made:**
- Added explicit GVK definitions for both Ray API versions:
  - `RayJobV1Alpha1` (ray.io/v1alpha1/RayJob)
  - `RayJobV1` (ray.io/v1/RayJob)
  - `RayClusterV1Alpha1` (ray.io/v1alpha1/RayCluster)  
  - `RayClusterV1` (ray.io/v1/RayCluster)
- Updated Kueue webhook to validate both API versions in `isExpectedKind()` function
- Updated webhook configuration to support `versions=v1;v1alpha1`
- Added comprehensive test coverage for all four Ray resource versions

**Root Cause:** Mismatch between webhook configuration (expected v1) and actual GVK definitions (v1alpha1), preventing Ray workloads from being validated for Kueue labels.

**Fix Result:** Ray resources using either v1 or v1alpha1 API versions are now properly validated by the Kueue webhook.

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- **Unit Tests:** All existing Kueue webhook tests pass
- **New Test Cases:** Added test coverage for all four Ray resource versions:
  - `RayJob v1alpha1` 
  - `RayJob v1` 
  - `RayCluster v1alpha1` 
  - `RayCluster v1` 
- **Webhook Validation:** Confirmed webhook accepts both API versions in `isExpectedKind()` function
- **Manifest Generation:** Verified webhook configuration correctly includes both versions

**Test Commands Used:**
```bash
go test -mod=readonly -v ./internal/webhook/kueue/... -run "TestKueueWebhook_AcceptsExpectedKinds"
```

**Before Fix:** Ray resources were rejected by webhook due to version mismatch
**After Fix:** Ray resources are properly validated regardless of API version used

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

N/A - This is a backend webhook validation fix.

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded webhook compatibility for Ray resources. RayJob and RayCluster are now supported in both v1alpha1 and v1, ensuring queue label validation works across versions.
  * Broader API coverage improves interoperability with clusters using different Ray API versions.
  * No changes required from users; existing workloads continue to function as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->