### PR TITLE
fix issues with llama-stack core image sha

### DIFF
--- a/build/operands-map.yaml
+++ b/build/operands-map.yaml
@@ -153,7 +153,5 @@ relatedImages:
   value: "quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:c0482a03d45fbe3a2acff4e9d583830d54324e939ba1bb19472af4f29d5e233f"
 - name: RELATED_IMAGE_ODH_LLAMA_STACK_CORE_IMAGE
   value: "quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:43b60b1ee6f66fec38fe2ffbbe08dca8541ef162332e4bd8e422ecd24ee02646"
-- name: RELATED_IMAGE_ODH_LLAMA_STACK_CORE_IMAGE
-  value: "quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:43b60b1ee6f66fec38fe2ffbbe08dca8541ef162332e4bd8e422ecd24ee02646"
 - name: RELATED_IMAGE_ODH_OPERATOR_IMAGE
   value: quay.io/rhoai/odh-rhel9-operator@sha256:337251214962fb5c4e718eeea3f5233b04097de754a12f3a153f2674580c4a17

--- a/build/operator-nudging.yaml
+++ b/build/operator-nudging.yaml
@@ -144,4 +144,4 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_WORKBENCH_JUPYTER_TRUSTYAI_CPU_PY312_IMAGE
   value: quay.io/rhoai/odh-workbench-jupyter-trustyai-cpu-py312-rhel9@sha256:c0482a03d45fbe3a2acff4e9d583830d54324e939ba1bb19472af4f29d5e233f
 - name: RELATED_IMAGE_ODH_LLAMA_STACK_CORE_IMAGE
-  value: quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:sha256:43b60b1ee6f66fec38fe2ffbbe08dca8541ef162332e4bd8e422ecd24ee02646
+  value: quay.io/rhoai/odh-llama-stack-core-rhel9@sha256:43b60b1ee6f66fec38fe2ffbbe08dca8541ef162332e4bd8e422ecd24ee02646


### PR DESCRIPTION
duplicate entries in operands-map.yaml; typo in operator-nudging.yaml

<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Fix for https://issues.redhat.com/browse/RHAIENG-797

sha256:43b60b1ee6f66fec38fe2ffbbe08dca8541ef162332e4bd8e422ecd24ee02646 should be the latest llama stack core image from https://quay.io/repository/rhoai/odh-llama-stack-core-rhel9

