### PR TITLE
Fetch kserve manifests using git commit

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -6,11 +6,8 @@ map:
     dest: workbenches/notebooks
     ref_type: branch
   kserve:
-    git.url: https://github.com/red-hat-data-services/kserve
-    git.commit: github.ref_name
     src: config
     dest: kserve
-    ref_type: branch
   odh-kf-notebook-controller:
     src: components/notebook-controller/config
     dest: workbenches/kf-notebook-controller


### PR DESCRIPTION
kserve controller is now being built in internal konflux and we can now fetch the manifest using git commits