### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-operator-v2-20

### DIFF
--- a/Dockerfiles/Dockerfile.konflux
+++ b/Dockerfiles/Dockerfile.konflux
@@ -52,7 +52,8 @@ ENTRYPOINT ["/manager"]
 
 LABEL com.redhat.component="odh-operator-container" \
       description="rhoai-operator" \
-      name="managed-open-data-hub/odh-rhel8-operator" \
+      name="rhoai/odh-rhel8-operator" \
+      cpe="cpe:/a:redhat:openshift_ai:2.20::el8" \
       summary="odh-operator" \
       maintainer="['managed-open-data-hub@redhat.com']" \
       io.openshift.expose-services="" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
