### PR TITLE
add declaritive manifest for dependency installs

### DIFF
--- a/docs/install/wva/00-uwm-cm.yaml
+++ b/docs/install/wva/00-uwm-cm.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/docs/install/wva/01-custom-metrics-autoscaler.yaml
+++ b/docs/install/wva/01-custom-metrics-autoscaler.yaml
@@ -1,0 +1,31 @@
+# Custom Metrics Autoscaler (KEDA) Operator for OpenShift
+# Installs the Red Hat supported custom-metrics-autoscaler operator from the
+# redhat-operators catalog via OLM.
+#
+# This operator provides the KedaController CRD and manages KEDA on the cluster,
+# which is a dependency of the Workload Variant Autoscaler (WVA).
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-keda
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-keda
+  namespace: openshift-keda
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-custom-metrics-autoscaler-operator
+  namespace: openshift-keda
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: openshift-custom-metrics-autoscaler-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/docs/install/wva/02-prometheus-adapter.yaml
+++ b/docs/install/wva/02-prometheus-adapter.yaml
@@ -1,0 +1,468 @@
+# Prometheus Adapter for OpenShift - Declarative Manifests
+# Based on prometheus-community/prometheus-adapter helm chart v4.11.0 (app v0.12.0),
+# which is the version used by upstream llm-d WVA v0.5.1.
+# Adapted with OCP-specific values for the Workload Variant Autoscaler (WVA).
+#
+# Prerequisites:
+#   1. User Workload Monitoring (UWM) must be enabled on the cluster.
+#
+# OCP integrations used (no manual certificate management required):
+#   - "service.beta.openshift.io/inject-cabundle: true" on ConfigMap and APIServices
+#     for automatic CA bundle injection.
+#   - "service.beta.openshift.io/serving-cert-secret-name" on the Service to generate
+#     a TLS serving certificate, enabling proper TLS for the adapter's API endpoint.
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: workload-variant-autoscaler-monitoring
+---
+# OpenShift auto-injects the service-serving CA into this ConfigMap.
+# This CA is used by the prometheus-adapter to verify TLS when connecting
+# to Thanos Querier (which uses a service-serving cert).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-ca
+  namespace: workload-variant-autoscaler-monitoring
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+data: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter
+  namespace: workload-variant-autoscaler-monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-adapter
+  namespace: workload-variant-autoscaler-monitoring
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+data:
+  config.yaml: |
+    rules:
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters: []
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
+        by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_seconds_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>,container!="POD"}[5m]))
+        by (<<.GroupBy>>)
+    - seriesQuery: '{__name__=~"^container_.*",container!="POD",namespace!="",pod!=""}'
+      seriesFilters:
+      - isNot: ^container_.*_total$
+      resources:
+        overrides:
+          namespace:
+            resource: namespace
+          pod:
+            resource: pod
+      name:
+        matches: ^container_(.*)$
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>,container!="POD"}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_total$
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ""
+        as: ""
+      metricsQuery: sum(<<.Series>>{<<.LabelMatchers>>}) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters:
+      - isNot: .*_seconds_total
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
+    - seriesQuery: '{namespace!="",__name__!~"^container_.*"}'
+      seriesFilters: []
+      resources:
+        template: <<.Resource>>
+      name:
+        matches: ^(.*)_seconds_total$
+        as: ""
+      metricsQuery: sum(rate(<<.Series>>{<<.LabelMatchers>>}[5m])) by (<<.GroupBy>>)
+    externalRules:
+    - seriesQuery: wva_desired_replicas{variant_name!="",exported_namespace!=""}
+      resources:
+        overrides:
+          exported_namespace:
+            resource: namespace
+          variant_name:
+            resource: deployment
+      name:
+        matches: ^wva_desired_replicas
+        as: wva_desired_replicas
+      metricsQuery: wva_desired_replicas{<<.LabelMatchers>>}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter-resource-reader
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - services
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter-server-resources
+rules:
+- apiGroups:
+  - custom.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter-external-metrics
+rules:
+- apiGroups:
+  - external.metrics.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - list
+  - get
+  - watch
+---
+# Grants the prometheus-adapter SA access to query Thanos Querier
+# (the OCP cluster monitoring stack).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter-cluster-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: prometheus-adapter
+  namespace: workload-variant-autoscaler-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter-system-auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-adapter
+  namespace: workload-variant-autoscaler-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter-resource-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-adapter-resource-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-adapter
+  namespace: workload-variant-autoscaler-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter-hpa-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-adapter-server-resources
+subjects:
+- kind: ServiceAccount
+  name: prometheus-adapter
+  namespace: workload-variant-autoscaler-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter-hpa-controller-external-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-adapter-external-metrics
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: prometheus-adapter
+  namespace: workload-variant-autoscaler-monitoring
+---
+# The serving-cert-secret-name annotation causes OpenShift to generate a TLS
+# certificate for this Service and store it in the named Secret. This allows
+# the adapter to serve with a proper cert trusted by the cluster, eliminating
+# the need for insecureSkipTLSVerify on the APIService resources.
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: prometheus-adapter-tls
+  name: prometheus-adapter
+  namespace: workload-variant-autoscaler-monitoring
+spec:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  name: prometheus-adapter
+  namespace: workload-variant-autoscaler-monitoring
+spec:
+  replicas: 2
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: prometheus-adapter
+      app.kubernetes.io/name: prometheus-adapter
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/instance: prometheus-adapter
+        app.kubernetes.io/name: prometheus-adapter
+        app.kubernetes.io/part-of: prometheus-adapter
+      name: prometheus-adapter
+    spec:
+      serviceAccountName: prometheus-adapter
+      containers:
+      - name: prometheus-adapter
+        image: registry.k8s.io/prometheus-adapter/prometheus-adapter:v0.12.0
+        imagePullPolicy: IfNotPresent
+        args:
+        - /adapter
+        - --secure-port=6443
+        - --tls-cert-file=/etc/serving-certs/tls.crt
+        - --tls-private-key-file=/etc/serving-certs/tls.key
+        - --prometheus-url=https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+        - --metrics-relist-interval=1m
+        - --v=4
+        - --config=/etc/adapter/config.yaml
+        - --prometheus-ca-file=/etc/prometheus-ca/service-ca.crt
+        - --prometheus-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+        ports:
+        - containerPort: 6443
+          name: https
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: https
+            scheme: HTTPS
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
+        volumeMounts:
+        - mountPath: /etc/serving-certs
+          name: serving-certs
+          readOnly: true
+        - mountPath: /etc/prometheus-ca
+          name: prometheus-ca
+          readOnly: true
+        - mountPath: /etc/adapter/
+          name: config
+          readOnly: true
+        - mountPath: /tmp
+          name: tmp
+      volumes:
+      - name: serving-certs
+        secret:
+          secretName: prometheus-adapter-tls
+      - name: prometheus-ca
+        configMap:
+          name: prometheus-ca
+      - name: config
+        configMap:
+          name: prometheus-adapter
+      - name: tmp
+        emptyDir: {}
+---
+# The inject-cabundle annotation causes OpenShift to populate the caBundle field
+# with the service-serving CA, matching the cert generated for the adapter Service.
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: v1beta1.custom.metrics.k8s.io
+spec:
+  service:
+    name: prometheus-adapter
+    namespace: workload-variant-autoscaler-monitoring
+  group: custom.metrics.k8s.io
+  version: v1beta1
+  groupPriorityMinimum: 100
+  versionPriority: 100
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/instance: prometheus-adapter
+    app.kubernetes.io/name: prometheus-adapter
+    app.kubernetes.io/part-of: prometheus-adapter
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: v1beta1.external.metrics.k8s.io
+spec:
+  service:
+    name: prometheus-adapter
+    namespace: workload-variant-autoscaler-monitoring
+  group: external.metrics.k8s.io
+  version: v1beta1
+  groupPriorityMinimum: 100
+  versionPriority: 100

--- a/docs/install/wva/02-prometheus-adapter.yaml
+++ b/docs/install/wva/02-prometheus-adapter.yaml
@@ -12,11 +12,6 @@
 #   - "service.beta.openshift.io/serving-cert-secret-name" on the Service to generate
 #     a TLS serving certificate, enabling proper TLS for the adapter's API endpoint.
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: workload-variant-autoscaler-monitoring
----
 # OpenShift auto-injects the service-serving CA into this ConfigMap.
 # This CA is used by the prometheus-adapter to verify TLS when connecting
 # to Thanos Querier (which uses a service-serving cert).
@@ -24,7 +19,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-ca
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
 data: {}
@@ -38,13 +33,13 @@ metadata:
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
   name: prometheus-adapter
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: prometheus-adapter
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
   labels:
     app.kubernetes.io/component: metrics
     app.kubernetes.io/instance: prometheus-adapter
@@ -208,7 +203,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-adapter
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -226,7 +221,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-adapter
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -244,7 +239,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-adapter
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -262,7 +257,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-adapter
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -299,7 +294,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus-adapter
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
 ---
 # The serving-cert-secret-name annotation causes OpenShift to generate a TLS
 # certificate for this Service and store it in the named Secret. This allows
@@ -316,7 +311,7 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: prometheus-adapter-tls
   name: prometheus-adapter
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
 spec:
   ports:
   - name: https
@@ -337,7 +332,7 @@ metadata:
     app.kubernetes.io/name: prometheus-adapter
     app.kubernetes.io/part-of: prometheus-adapter
   name: prometheus-adapter
-  namespace: workload-variant-autoscaler-monitoring
+  namespace: openshift-user-workload-monitoring
 spec:
   replicas: 2
   strategy:
@@ -441,7 +436,7 @@ metadata:
 spec:
   service:
     name: prometheus-adapter
-    namespace: workload-variant-autoscaler-monitoring
+    namespace: openshift-user-workload-monitoring
   group: custom.metrics.k8s.io
   version: v1beta1
   groupPriorityMinimum: 100
@@ -461,7 +456,7 @@ metadata:
 spec:
   service:
     name: prometheus-adapter
-    namespace: workload-variant-autoscaler-monitoring
+    namespace: openshift-user-workload-monitoring
   group: external.metrics.k8s.io
   version: v1beta1
   groupPriorityMinimum: 100


### PR DESCRIPTION
## Description

Adds declarative manifests for install. WVA prom charts just pull latest and so are brittle.

## How Has This Been Tested?
Tested manually for wva path

## Merge criteria

We dont have to merge this against RHOAi-3.4EA2 product branch, we could instead keep this on ODH since this is for DP level docs. I am doing this here just to show the diff
