### PR TITLE
extend nsPlugins to template ns for service monitors

### DIFF
--- a/pkg/deploy/deploy.go
+++ b/pkg/deploy/deploy.go
@@ -104,6 +104,10 @@ func DeployManifestsFromPathWithLabels(
 		return fmt.Errorf("failed applying namespace plugin when preparing Kustomize resources. %w", err)
 	}
 
+	if err := plugins.UpdateServiceMonitorNamespaceSelector(resMap, namespace); err != nil {
+		return fmt.Errorf("failed updating ServiceMonitor namespaceSelector: %w", err)
+	}
+
 	resourceLabels := map[string]string{
 		labels.ODH.Component(componentName): "true",
 		labels.K8SCommon.PartOf:             componentName,

--- a/pkg/manifests/kustomize/kustomize_engine.go
+++ b/pkg/manifests/kustomize/kustomize_engine.go
@@ -45,6 +45,9 @@ func (e *Engine) Render(path string, opts ...RenderOptsFn) ([]unstructured.Unstr
 		if err := plugin.Transform(resMap); err != nil {
 			return nil, fmt.Errorf("failed applying namespace plugin when preparing Kustomize resources. %w", err)
 		}
+		if err := plugins.UpdateServiceMonitorNamespaceSelector(resMap, ro.ns); err != nil {
+			return nil, fmt.Errorf("failed updating ServiceMonitor namespaceSelector: %w", err)
+		}
 	}
 
 	if len(ro.labels) != 0 {

--- a/pkg/plugins/namespacePlugin.go
+++ b/pkg/plugins/namespacePlugin.go
@@ -1,10 +1,14 @@
 package plugins
 
 import (
+	"fmt"
+
 	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck // Remove after package update
 	"sigs.k8s.io/kustomize/api/filters/namespace"
+	"sigs.k8s.io/kustomize/api/resmap"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/resid"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // CreateNamespaceApplierPlugin creates a plugin to ensure resources have the specified target namespace.
@@ -64,4 +68,31 @@ func CreateNamespaceApplierPlugin(targetNamespace string) *builtins.NamespaceTra
 		UnsetOnly:              false,
 		SetRoleBindingSubjects: namespace.AllServiceAccountSubjects,
 	}
+}
+
+// UpdateServiceMonitorNamespaceSelector updates spec.namespaceSelector.matchNames
+// on all ServiceMonitor resources to use the target namespace. The kustomize
+// NamespaceTransformerPlugin only handles scalar fields, but matchNames is a
+// list of strings, so it must be handled separately.
+func UpdateServiceMonitorNamespaceSelector(resMap resmap.ResMap, targetNamespace string) error {
+	for _, res := range resMap.Resources() {
+		if res.GetKind() != "ServiceMonitor" {
+			continue
+		}
+
+		node, err := res.Pipe(yaml.Lookup("spec", "namespaceSelector", "matchNames"))
+		if err != nil || node == nil {
+			continue
+		}
+
+		elements, err := node.Elements()
+		if err != nil {
+			return fmt.Errorf("failed to get matchNames elements on ServiceMonitor %s: %w", res.GetName(), err)
+		}
+
+		for _, elem := range elements {
+			elem.YNode().Value = targetNamespace
+		}
+	}
+	return nil
 }

--- a/pkg/plugins/namespacePlugin_test.go
+++ b/pkg/plugins/namespacePlugin_test.go
@@ -1,0 +1,116 @@
+package plugins
+
+import (
+	"testing"
+
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestUpdateServiceMonitorNamespaceSelector(t *testing.T) {
+	sm := []byte(`
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: test-monitor
+  namespace: workload-variant-autoscaler-system
+spec:
+  namespaceSelector:
+    matchNames:
+    - workload-variant-autoscaler-system
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+`)
+	rf := &resource.Factory{}
+	res, err := rf.FromBytes(sm)
+	if err != nil {
+		t.Fatalf("failed to create resource: %v", err)
+	}
+
+	rm := resmap.New()
+	if err := rm.Append(res); err != nil {
+		t.Fatalf("failed to append resource: %v", err)
+	}
+
+	if err := UpdateServiceMonitorNamespaceSelector(rm, "opendatahub"); err != nil {
+		t.Fatalf("UpdateServiceMonitorNamespaceSelector failed: %v", err)
+	}
+
+	node, err := res.Pipe(yaml.Lookup("spec", "namespaceSelector", "matchNames"))
+	if err != nil {
+		t.Fatalf("failed to lookup matchNames: %v", err)
+	}
+
+	elements, err := node.Elements()
+	if err != nil {
+		t.Fatalf("failed to get elements: %v", err)
+	}
+
+	if len(elements) != 1 {
+		t.Fatalf("expected 1 element, got %d", len(elements))
+	}
+
+	got := elements[0].YNode().Value
+	if got != "opendatahub" {
+		t.Errorf("expected matchNames[0] = 'opendatahub', got '%s'", got)
+	}
+}
+
+func TestUpdateServiceMonitorNamespaceSelector_NoMatchNames(t *testing.T) {
+	sm := []byte(`
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: test-monitor
+spec:
+  namespaceSelector:
+    any: true
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+`)
+	rf := &resource.Factory{}
+	res, err := rf.FromBytes(sm)
+	if err != nil {
+		t.Fatalf("failed to create resource: %v", err)
+	}
+
+	rm := resmap.New()
+	if err := rm.Append(res); err != nil {
+		t.Fatalf("failed to append resource: %v", err)
+	}
+
+	// Should not error when matchNames is absent
+	if err := UpdateServiceMonitorNamespaceSelector(rm, "opendatahub"); err != nil {
+		t.Fatalf("UpdateServiceMonitorNamespaceSelector failed: %v", err)
+	}
+}
+
+func TestUpdateServiceMonitorNamespaceSelector_SkipsNonServiceMonitor(t *testing.T) {
+	dep := []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deploy
+  namespace: original-ns
+spec:
+  replicas: 1
+`)
+	rf := &resource.Factory{}
+	res, err := rf.FromBytes(dep)
+	if err != nil {
+		t.Fatalf("failed to create resource: %v", err)
+	}
+
+	rm := resmap.New()
+	if err := rm.Append(res); err != nil {
+		t.Fatalf("failed to append resource: %v", err)
+	}
+
+	// Should not error on non-ServiceMonitor resources
+	if err := UpdateServiceMonitorNamespaceSelector(rm, "opendatahub"); err != nil {
+		t.Fatalf("UpdateServiceMonitorNamespaceSelector failed: %v", err)
+	}
+}


### PR DESCRIPTION
# Backported Fix ServiceMonitor namespaceSelector not being updated by namespace transformer

Backport of: https://github.com/red-hat-data-services/rhods-operator/pull/22299

## Problem:
When the ODH operator deploys components (e.g. WVA) into a namespace different from the one defined in their source manifests, the CreateNamespaceApplierPlugin correctly updates metadata.namespace on all resources. However, it does not update spec.namespaceSelector.matchNames on ServiceMonitor resources. This causes Prometheus to look for scrape targets in the wrong namespace, resulting in missing metrics.

For example, WVA manifests define namespaceSelector.matchNames: [workload-variant-autoscaler-system], but ODH deploys WVA into opendatahub. The ServiceMonitor ends up in opendatahub but tells Prometheus to scrape from workload-variant-autoscaler-system, which has no pods.

## Fix:
Add a FieldSpec for monitoring.coreos.com/ServiceMonitor targeting spec/namespaceSelector/matchNames to the namespace transformer plugin. This follows the same pattern already used for ClusterRoleBinding subjects, webhook configurations, and CRD conversion webhooks.

##  Validation:
```yaml
  # Before fix — namespaceSelector points to wrong namespace
  $ oc get servicemonitor -n opendatahub -o yaml | grep -A2 namespaceSelector
    namespaceSelector:
      matchNames:
      - workload-variant-autoscaler-system

  # After fix — namespaceSelector matches deployment namespace
  $ oc get servicemonitor -n opendatahub -o yaml | grep -A2 namespaceSelector
    namespaceSelector:
      matchNames:
      - opendatahub
```
cc @pierDipi @vivekk16 @pierDipi @zdtsw 