### PR TITLE
[RHOAIENG-57737] Revert temporary embargo changes on rhoai-3.2

### DIFF
--- a/.github/workflows/operator-processor.yaml
+++ b/.github/workflows/operator-processor.yaml
@@ -1,0 +1,187 @@
+name: Operator Processor
+
+on:
+  # workflow_dispatch:  # disabled
+  push:
+    branches:
+      - 'rhoai-[23].[0-9]' # Matches branches like 'rhoai-2.0', 'rhoai-3.1', etc.
+      - 'rhoai-[23].[0-9][0-9]' # Matches branches like 'rhoai-2.10', 'rhoai-3.12', etc.
+      - '!rhoai-3.2'
+    paths:
+      - build/operator-nudging.yaml
+
+
+env:
+  GITHUB_ORG: red-hat-data-services
+  GITHUB_RKA_ORG: rhoai-rhtap
+
+permissions:
+  contents: write
+
+jobs:
+  operator-processor:
+    if: ${{ github.ref_name != 'main' && (github.event_name == 'workflow_dispatch' || ( github.event_name == 'push' && github.event.commits[0].author.name == 'konflux-internal-p02[bot]' )) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout RBC repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
+          ref: ${{ github.ref_name }}
+          path: RBC
+          sparse-checkout: |
+            bundle/bundle-patch.yaml
+          sparse-checkout-cone-mode: false
+      - name: Git checkout utils
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
+          ref: main
+          path: utils
+          sparse-checkout: |
+            utils/operator-processor
+          sparse-checkout-cone-mode: false
+      - name: Git checkout utils
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_ORG }}/rhods-operator
+          ref: ${{ github.ref_name }}
+          path: rhods-operator
+          sparse-checkout: |
+            build
+            prefetched-manifests
+            .tekton
+          sparse-checkout-cone-mode: false
+      - name: Install dependencies
+        run: |
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/')"
+          yq_version="v4.44.3"
+          yq_filename="yq-$yq_version"
+          echo "-> Downloading yq" >&2
+          curl -sSfLo "$yq_filename" "https://github.com/mikefarah/yq/releases/download/$yq_version/yq_${os}_${arch}"
+          chmod +x $yq_filename
+          ln -s $yq_filename yq
+          cp $yq_filename /usr/local/bin/yq
+
+          pip install --default-timeout=100 -r utils/utils/operator-processor/requirements.txt
+
+      - name: Execute Operator Processor
+        env:
+          BRANCH: ${{ github.ref_name }}
+          RHOAI_QUAY_API_TOKEN: ${{ secrets.RHOAI_QUAY_API_TOKEN }}
+        run: |
+          RHOAI_VERSION=v${BRANCH/rhoai-/}
+          COMPONENT_SUFFIX=${RHOAI_VERSION/./-}
+          ODH_OPERATOR_COMPONENT_NAME=odh-operator-${COMPONENT_SUFFIX}
+          PUSH_PIPELINE_PATH=rhods-operator/.tekton/${ODH_OPERATOR_COMPONENT_NAME}-push.yaml
+
+          PATCH_YAML_PATH=RBC/bundle/bundle-patch.yaml
+          OPERANDS_MAP_PATH=rhods-operator/build/operands-map.yaml
+          NUDGING_YAML_PATH=rhods-operator/build/operator-nudging.yaml
+          MANIFEST_CONFIG_PATH=rhods-operator/build/manifests-config.yaml
+
+          python3 utils/utils/operator-processor/operator-processor.py  -op process-operator-yamls --patch-yaml-path ${PATCH_YAML_PATH} --operands-map-path ${OPERANDS_MAP_PATH} --nudging-yaml-path ${NUDGING_YAML_PATH} --manifest-config-path ${MANIFEST_CONFIG_PATH} --rhoai-version ${BRANCH} --push-pipeline-yaml-path ${PUSH_PIPELINE_PATH} --push-pipeline-operation enable
+
+          echo "----- NUDGING_YAML ------"
+          cat $NUDGING_YAML_PATH
+          echo "----- OPERANDS_MAP ------"
+          cat $OPERANDS_MAP_PATH
+          echo "----- MANIFEST_CONFIG ------"
+          cat $MANIFEST_CONFIG_PATH
+          echo "current dir = $(pwd)"
+      - name: Fetch all manifests
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          #!/bin/bash
+          set -e
+          echo "current dir = $(pwd)"
+          MANIFEST_CONFIG_PATH=${{ github.workspace }}/rhods-operator/build/manifests-config.yaml
+          PREFETCHED_MANIFEST_DIR_PATH="rhods-operator/prefetched-manifests"
+
+          # Clean up old prefetched manifests
+          if [ -d "$PREFETCHED_MANIFEST_DIR_PATH" ]; then
+              echo "Cleaning up old prefetched manifests..."
+              rm -rf "$PREFETCHED_MANIFEST_DIR_PATH"
+          fi
+
+          # Create fresh directories
+          mkdir -p "$PREFETCHED_MANIFEST_DIR_PATH"
+          mkdir -p manifests
+          cd manifests
+          while IFS= read -r value;
+          do
+              value=${value/- /}
+              component=$value
+
+              # Skip empty keys
+              [[ -z "$component" ]] && continue
+               
+              echo "=============================================================="
+              echo "Fetching Manifest for component: $component"
+              echo "=============================================================="
+              if [[ -n $component ]]
+              then	
+                  git_url=$(value="$value" yq '.map[strenv(value)]["git.url"]' ${MANIFEST_CONFIG_PATH})
+                  git_commit=$(value="$value" yq '.map[strenv(value)]["git.commit"]' ${MANIFEST_CONFIG_PATH})
+                  ref_type=$(value="$value" yq '.map[strenv(value)]["ref_type"]' ${MANIFEST_CONFIG_PATH})
+
+                  # If ref_type is branch, resolve the actual commit SHA
+                  if [[ "$ref_type" == "branch" ]]; then
+                    # Fetch latest commit SHA for the branch from remote
+                    git_commit=$(git ls-remote "$git_url" "refs/heads/$BRANCH" | awk '{print $1}')
+                    echo "Resolved git.commit for branch '$BRANCH' to commit SHA $git_commit"
+
+                    # Update the git.commit field in manifests-config.yaml for the current component.
+                    # Using strenv() to safely reference both the component key ($value) and the new commit SHA ($git_commit).
+                    # This avoids issues with --arg, which is not supported in this yq version, and prevents creating an empty "" key.
+                    value="$value" git_commit="$git_commit" yq -i eval '.map[strenv(value)]["git.commit"] = strenv(git_commit)' ${MANIFEST_CONFIG_PATH}
+
+                  fi
+
+                  src=$(value="$value" yq '.map[strenv(value)]["src"]' ${MANIFEST_CONFIG_PATH})
+                  dest=$(value="$value" yq '.map[strenv(value)]["dest"]' ${MANIFEST_CONFIG_PATH})
+                  
+                  echo "component = $component"
+                  echo "git_url = $git_url"
+                  echo "git_commit = $git_commit"
+                  echo "src = $src"
+                  echo "dest = $dest"
+
+                  mkdir -p $component
+                  cd $component
+
+                  git config --global init.defaultBranch ${BRANCH}
+                  git init
+                  git remote add origin $git_url
+                  git config core.sparseCheckout true
+                  git config core.sparseCheckoutCone false
+                  echo "$src" >> .git/info/sparse-checkout
+                  git fetch --depth=1 origin $git_commit
+                  git checkout $git_commit
+
+                  cd ../
+                  echo "current dir = $(pwd)"
+                  
+                  dest_dir_path=${{ github.workspace }}/${PREFETCHED_MANIFEST_DIR_PATH}/$dest
+                  mkdir -p ${dest_dir_path}
+
+                  cp -r $component/$src/* ${dest_dir_path}
+                  echo ""
+              fi
+          done < <(yq e '.map | keys' ${MANIFEST_CONFIG_PATH} )
+
+          cd ${{ github.workspace }}/${PREFETCHED_MANIFEST_DIR_PATH}
+          tree
+
+      - name: Commit and push the changes to release branch
+        uses: actions-js/push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref_name }}
+          message: "Updating the operator repo with latest images and manifests"
+          repository: ${{ env.GITHUB_ORG }}/rhods-operator
+          directory: rhods-operator
+          author_name: Openshift-AI DevOps
+          author_email: openshift-ai-devops@redhat.com

--- a/.github/workflows/operator-processor.yaml
+++ b/.github/workflows/operator-processor.yaml
@@ -1,12 +1,11 @@
 name: Operator Processor
 
 on:
-  # workflow_dispatch:  # disabled
+  workflow_dispatch:
   push:
     branches:
       - 'rhoai-[23].[0-9]' # Matches branches like 'rhoai-2.0', 'rhoai-3.1', etc.
       - 'rhoai-[23].[0-9][0-9]' # Matches branches like 'rhoai-2.10', 'rhoai-3.12', etc.
-      - '!rhoai-3.2'
     paths:
       - build/operator-nudging.yaml
 
@@ -63,7 +62,7 @@ jobs:
           chmod +x $yq_filename
           ln -s $yq_filename yq
           cp $yq_filename /usr/local/bin/yq
-
+  
           pip install --default-timeout=100 -r utils/utils/operator-processor/requirements.txt
 
       - name: Execute Operator Processor
@@ -75,14 +74,14 @@ jobs:
           COMPONENT_SUFFIX=${RHOAI_VERSION/./-}
           ODH_OPERATOR_COMPONENT_NAME=odh-operator-${COMPONENT_SUFFIX}
           PUSH_PIPELINE_PATH=rhods-operator/.tekton/${ODH_OPERATOR_COMPONENT_NAME}-push.yaml
-
+          
           PATCH_YAML_PATH=RBC/bundle/bundle-patch.yaml
           OPERANDS_MAP_PATH=rhods-operator/build/operands-map.yaml
           NUDGING_YAML_PATH=rhods-operator/build/operator-nudging.yaml
           MANIFEST_CONFIG_PATH=rhods-operator/build/manifests-config.yaml
-
+          
           python3 utils/utils/operator-processor/operator-processor.py  -op process-operator-yamls --patch-yaml-path ${PATCH_YAML_PATH} --operands-map-path ${OPERANDS_MAP_PATH} --nudging-yaml-path ${NUDGING_YAML_PATH} --manifest-config-path ${MANIFEST_CONFIG_PATH} --rhoai-version ${BRANCH} --push-pipeline-yaml-path ${PUSH_PIPELINE_PATH} --push-pipeline-operation enable
-
+          
           echo "----- NUDGING_YAML ------"
           cat $NUDGING_YAML_PATH
           echo "----- OPERANDS_MAP ------"
@@ -148,10 +147,10 @@ jobs:
                   echo "git_commit = $git_commit"
                   echo "src = $src"
                   echo "dest = $dest"
-
+          
                   mkdir -p $component
                   cd $component
-
+          
                   git config --global init.defaultBranch ${BRANCH}
                   git init
                   git remote add origin $git_url
@@ -160,7 +159,7 @@ jobs:
                   echo "$src" >> .git/info/sparse-checkout
                   git fetch --depth=1 origin $git_commit
                   git checkout $git_commit
-
+          
                   cd ../
                   echo "current dir = $(pwd)"
                   
@@ -171,7 +170,7 @@ jobs:
                   echo ""
               fi
           done < <(yq e '.map | keys' ${MANIFEST_CONFIG_PATH} )
-
+          
           cd ${{ github.workspace }}/${PREFETCHED_MANIFEST_DIR_PATH}
           tree
 

--- a/.github/workflows/trigger-nightly-operator-build.yaml
+++ b/.github/workflows/trigger-nightly-operator-build.yaml
@@ -1,0 +1,154 @@
+name: Trigger Nightly Operator Build
+run-name: Trigger Nightly Operator Build [${{ inputs.distinct_id && inputs.distinct_id || '' }}]
+
+on:
+  workflow_dispatch:
+    inputs:
+      distinct_id:
+        description: 'Distinct ID'
+        required: false
+
+env:
+  GITHUB_ORG: red-hat-data-services
+  GITHUB_RKA_ORG: rhoai-rhtap
+  RESOLVE_CONFLICTS_FOR: build/operator-nudging.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  operator-processor:
+    if: ${{ github.ref_name != 'main' && (github.event_name == 'workflow_dispatch' || ( github.event_name == 'push' && github.event.commits[0].author.name == 'konflux-internal-p02' )) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout RBC repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
+          ref: ${{ github.ref_name }}
+          path: RBC
+          sparse-checkout: |
+            bundle/bundle-patch.yaml
+          sparse-checkout-cone-mode: false
+      - name: Git checkout utils
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
+          ref: main
+          path: utils
+          sparse-checkout: |
+            utils/operator-processor
+          sparse-checkout-cone-mode: false
+      - name: Git checkout operator repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_ORG }}/rhods-operator
+          ref: ${{ github.ref_name }}
+          path: rhods-operator
+          sparse-checkout: |
+            build
+            prefetched-manifests
+            .tekton
+          sparse-checkout-cone-mode: false
+      - name: Install dependencies
+        run: |
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/')"
+          yq_version="v4.44.3"
+          yq_filename="yq-$yq_version"
+          echo "-> Downloading yq" >&2
+          curl -sSfLo "$yq_filename" "https://github.com/mikefarah/yq/releases/download/$yq_version/yq_${os}_${arch}"
+          chmod +x $yq_filename
+          ln -s $yq_filename yq
+          cp $yq_filename /usr/local/bin/yq
+  
+          pip install --default-timeout=100 -r utils/utils/operator-processor/requirements.txt
+
+      - name: Execute Operator Processor
+        env:
+          BRANCH: ${{ github.ref_name }}
+          RHOAI_QUAY_API_TOKEN: ${{ secrets.RHOAI_QUAY_API_TOKEN }}
+        run: |
+          RHOAI_VERSION=v${BRANCH/rhoai-/}
+          COMPONENT_SUFFIX=${RHOAI_VERSION/./-}
+          ODH_OPERATOR_COMPONENT_NAME=odh-operator-${COMPONENT_SUFFIX}
+          PUSH_PIPELINE_PATH=rhods-operator/.tekton/${ODH_OPERATOR_COMPONENT_NAME}-push.yaml
+          
+          PATCH_YAML_PATH=RBC/bundle/bundle-patch.yaml
+          OPERANDS_MAP_PATH=rhods-operator/build/operands-map.yaml
+          NUDGING_YAML_PATH=rhods-operator/build/operator-nudging.yaml
+          MANIFEST_CONFIG_PATH=rhods-operator/build/manifests-config.yaml
+          
+          python3 utils/utils/operator-processor/operator-processor.py  -op process-operator-yamls --patch-yaml-path ${PATCH_YAML_PATH} --operands-map-path ${OPERANDS_MAP_PATH} --nudging-yaml-path ${NUDGING_YAML_PATH} --manifest-config-path ${MANIFEST_CONFIG_PATH} --rhoai-version ${BRANCH} --push-pipeline-yaml-path ${PUSH_PIPELINE_PATH} --push-pipeline-operation disable
+          
+          echo "----- NUDGING_YAML ------"
+          cat $NUDGING_YAML_PATH
+          echo "----- OPERANDS_MAP ------"
+          cat $OPERANDS_MAP_PATH
+          echo "----- MANIFEST_CONFIG ------"
+          cat $MANIFEST_CONFIG_PATH
+          echo "current dir = $(pwd)"
+      - name: Fetch all manifests
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          #!/bin/bash
+          set -e
+          echo "current dir = $(pwd)"
+          MANIFEST_CONFIG_PATH=${{ github.workspace }}/rhods-operator/build/manifests-config.yaml
+          mkdir -p rhods-operator/prefetched-manifests
+          mkdir -p manifests
+          cd manifests
+          while IFS= read -r value;
+          do
+              value=${value/- /}
+              component=$value
+              if [[ -n $component ]]
+              then	
+                  git_url=$(value="$value" yq '.map[strenv(value)]["git.url"]' ${MANIFEST_CONFIG_PATH})
+                  git_commit=$(value="$value" yq '.map[strenv(value)]["git.commit"]' ${MANIFEST_CONFIG_PATH})
+                  if [[ "$git_commit" == "github.ref_name" ]]; then git_commit=${BRANCH}; echo "changed the value to $BRANCH"; fi
+                  
+                  src=$(value="$value" yq '.map[strenv(value)]["src"]' ${MANIFEST_CONFIG_PATH})
+                  dest=$(value="$value" yq '.map[strenv(value)]["dest"]' ${MANIFEST_CONFIG_PATH})
+                  
+                  echo "component = $component"
+                  echo "git_url = $git_url"
+                  echo "git_commit = $git_commit"
+                  echo "src = $src"
+                  echo "dest = $dest"
+          
+                  mkdir -p $component
+                  cd $component
+          
+                  git config --global init.defaultBranch ${BRANCH}
+                  git init
+                  git remote add origin $git_url
+                  git config core.sparseCheckout true
+                  git config core.sparseCheckoutCone false
+                  echo "$src" >> .git/info/sparse-checkout
+                  git fetch --depth=1 origin $git_commit
+                  git checkout $git_commit
+          
+                  cd ../
+                  echo "current dir = $(pwd)"
+                  
+                  mkdir -p ${{ github.workspace }}/rhods-operator/prefetched-manifests/$dest
+                  cp -r $component/$src/* ${{ github.workspace }}/rhods-operator/prefetched-manifests/$dest
+              fi
+          done < <(yq e '.map | keys' ${MANIFEST_CONFIG_PATH} )
+          
+          cd ${{ github.workspace }}/rhods-operator/prefetched-manifests
+          tree
+          # Update the schedule file to trigger the nightly build 
+          echo $(date +'%d-%m-%Y %H:%M:%S:%3N') > ${{ github.workspace }}/rhods-operator/build/schedule/operator-tekton-trigger.txt
+      - name: Commit and push the changes to release branch
+        uses: actions-js/push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref_name }}
+          message: "Updating the operator repo with latest images and manifests"
+          repository: ${{ env.GITHUB_ORG }}/rhods-operator
+          directory: ${{ github.workspace }}/rhods-operator
+          author_name: Openshift-AI DevOps
+          author_email: openshift-ai-devops@redhat.com


### PR DESCRIPTION
## Description

Reverts the temporary "disable builds" PRs that were applied during the embargo period:

- **Revert #23215** — "Disable builds for rhoai-3.2"
- **Revert #23187** — "Disable operator-processor for rhoai-3.2"

This re-enables the operator-processor workflow and nightly build trigger for the rhoai-3.2 branch.

**JIRA:** [RHOAIENG-57737](https://issues.redhat.com/browse/RHOAIENG-57737)
**Parent:** [RHOAIENG-57438](https://issues.redhat.com/browse/RHOAIENG-57438)

---
🤖 Generated with [Claude Code](https://claude.ai/code) Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>