### PR TITLE
[RHOAIENG-57736] Revert temporary embargo changes on rhoai-2.25

### DIFF
--- a/.github/workflows/operator-processor.yaml
+++ b/.github/workflows/operator-processor.yaml
@@ -1,12 +1,11 @@
 name: Operator Processor
 
 on:
-  # workflow_dispatch:  # disabled
+  workflow_dispatch:
   push:
     branches:
       - 'rhoai-2.1[6-9]+'
       - 'rhoai-2.2[0-9]+'  # Trigger the workflow on pushes to any rhoai-2.20 branch and above
-      - '!rhoai-2.25'
     paths:
       - build/operator-nudging.yaml
 
@@ -63,7 +62,7 @@ jobs:
           chmod +x $yq_filename
           ln -s $yq_filename yq
           cp $yq_filename /usr/local/bin/yq
-
+  
           pip install --default-timeout=100 -r utils/utils/operator-processor/requirements.txt
 
       - name: Execute Operator Processor
@@ -75,14 +74,14 @@ jobs:
           COMPONENT_SUFFIX=${RHOAI_VERSION/./-}
           ODH_OPERATOR_COMPONENT_NAME=odh-operator-${COMPONENT_SUFFIX}
           PUSH_PIPELINE_PATH=rhods-operator/.tekton/${ODH_OPERATOR_COMPONENT_NAME}-push.yaml
-
+          
           PATCH_YAML_PATH=RBC/bundle/bundle-patch.yaml
           OPERANDS_MAP_PATH=rhods-operator/build/operands-map.yaml
           NUDGING_YAML_PATH=rhods-operator/build/operator-nudging.yaml
           MANIFEST_CONFIG_PATH=rhods-operator/build/manifests-config.yaml
-
+          
           python3 utils/utils/operator-processor/operator-processor.py  -op process-operator-yamls --patch-yaml-path ${PATCH_YAML_PATH} --operands-map-path ${OPERANDS_MAP_PATH} --nudging-yaml-path ${NUDGING_YAML_PATH} --manifest-config-path ${MANIFEST_CONFIG_PATH} --rhoai-version ${BRANCH} --push-pipeline-yaml-path ${PUSH_PIPELINE_PATH} --push-pipeline-operation enable
-
+          
           echo "----- NUDGING_YAML ------"
           cat $NUDGING_YAML_PATH
           echo "----- OPERANDS_MAP ------"
@@ -119,10 +118,10 @@ jobs:
                   echo "git_commit = $git_commit"
                   echo "src = $src"
                   echo "dest = $dest"
-
+          
                   mkdir -p $component
                   cd $component
-
+          
                   git config --global init.defaultBranch ${BRANCH}
                   git init
                   git remote add origin $git_url
@@ -131,7 +130,7 @@ jobs:
                   echo "$src" >> .git/info/sparse-checkout
                   git fetch --depth=1 origin $git_commit
                   git checkout $git_commit
-
+          
                   cd ../
                   echo "current dir = $(pwd)"
                   
@@ -146,7 +145,7 @@ jobs:
                   cp -r $component/$src/* ${dest_dir_path}
               fi
           done < <(yq e '.map | keys' ${MANIFEST_CONFIG_PATH} )
-
+          
           cd ${{ github.workspace }}/rhods-operator/prefetched-manifests
           tree
 

--- a/.github/workflows/operator-processor.yaml
+++ b/.github/workflows/operator-processor.yaml
@@ -1,0 +1,162 @@
+name: Operator Processor
+
+on:
+  # workflow_dispatch:  # disabled
+  push:
+    branches:
+      - 'rhoai-2.1[6-9]+'
+      - 'rhoai-2.2[0-9]+'  # Trigger the workflow on pushes to any rhoai-2.20 branch and above
+      - '!rhoai-2.25'
+    paths:
+      - build/operator-nudging.yaml
+
+
+env:
+  GITHUB_ORG: red-hat-data-services
+  GITHUB_RKA_ORG: rhoai-rhtap
+
+permissions:
+  contents: write
+
+jobs:
+  operator-processor:
+    if: ${{ github.ref_name != 'main' && (github.event_name == 'workflow_dispatch' || ( github.event_name == 'push' && github.event.commits[0].author.name == 'konflux-internal-p02[bot]' )) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout RBC repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
+          ref: ${{ github.ref_name }}
+          path: RBC
+          sparse-checkout: |
+            bundle/bundle-patch.yaml
+          sparse-checkout-cone-mode: false
+      - name: Git checkout utils
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
+          ref: main
+          path: utils
+          sparse-checkout: |
+            utils/operator-processor
+          sparse-checkout-cone-mode: false
+      - name: Git checkout utils
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_ORG }}/rhods-operator
+          ref: ${{ github.ref_name }}
+          path: rhods-operator
+          sparse-checkout: |
+            build
+            prefetched-manifests
+            .tekton
+          sparse-checkout-cone-mode: false
+      - name: Install dependencies
+        run: |
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/')"
+          yq_version="v4.44.3"
+          yq_filename="yq-$yq_version"
+          echo "-> Downloading yq" >&2
+          curl -sSfLo "$yq_filename" "https://github.com/mikefarah/yq/releases/download/$yq_version/yq_${os}_${arch}"
+          chmod +x $yq_filename
+          ln -s $yq_filename yq
+          cp $yq_filename /usr/local/bin/yq
+
+          pip install --default-timeout=100 -r utils/utils/operator-processor/requirements.txt
+
+      - name: Execute Operator Processor
+        env:
+          BRANCH: ${{ github.ref_name }}
+          RHOAI_QUAY_API_TOKEN: ${{ secrets.RHOAI_QUAY_API_TOKEN }}
+        run: |
+          RHOAI_VERSION=v${BRANCH/rhoai-/}
+          COMPONENT_SUFFIX=${RHOAI_VERSION/./-}
+          ODH_OPERATOR_COMPONENT_NAME=odh-operator-${COMPONENT_SUFFIX}
+          PUSH_PIPELINE_PATH=rhods-operator/.tekton/${ODH_OPERATOR_COMPONENT_NAME}-push.yaml
+
+          PATCH_YAML_PATH=RBC/bundle/bundle-patch.yaml
+          OPERANDS_MAP_PATH=rhods-operator/build/operands-map.yaml
+          NUDGING_YAML_PATH=rhods-operator/build/operator-nudging.yaml
+          MANIFEST_CONFIG_PATH=rhods-operator/build/manifests-config.yaml
+
+          python3 utils/utils/operator-processor/operator-processor.py  -op process-operator-yamls --patch-yaml-path ${PATCH_YAML_PATH} --operands-map-path ${OPERANDS_MAP_PATH} --nudging-yaml-path ${NUDGING_YAML_PATH} --manifest-config-path ${MANIFEST_CONFIG_PATH} --rhoai-version ${BRANCH} --push-pipeline-yaml-path ${PUSH_PIPELINE_PATH} --push-pipeline-operation enable
+
+          echo "----- NUDGING_YAML ------"
+          cat $NUDGING_YAML_PATH
+          echo "----- OPERANDS_MAP ------"
+          cat $OPERANDS_MAP_PATH
+          echo "----- MANIFEST_CONFIG ------"
+          cat $MANIFEST_CONFIG_PATH
+          echo "current dir = $(pwd)"
+      - name: Fetch all manifests
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          #!/bin/bash
+          set -e
+          echo "current dir = $(pwd)"
+          MANIFEST_CONFIG_PATH=${{ github.workspace }}/rhods-operator/build/manifests-config.yaml
+          mkdir -p rhods-operator/prefetched-manifests
+          mkdir -p manifests
+          cd manifests
+          while IFS= read -r value;
+          do
+              value=${value/- /}
+              component=$value
+              if [[ -n $component ]]
+              then	
+                  git_url=$(value="$value" yq '.map[strenv(value)]["git.url"]' ${MANIFEST_CONFIG_PATH})
+                  git_commit=$(value="$value" yq '.map[strenv(value)]["git.commit"]' ${MANIFEST_CONFIG_PATH})
+                  if [[ "$git_commit" == "github.ref_name" ]]; then git_commit=${BRANCH}; echo "changed the value to $BRANCH"; fi
+                  
+                  src=$(value="$value" yq '.map[strenv(value)]["src"]' ${MANIFEST_CONFIG_PATH})
+                  dest=$(value="$value" yq '.map[strenv(value)]["dest"]' ${MANIFEST_CONFIG_PATH})
+                  
+                  echo "component = $component"
+                  echo "git_url = $git_url"
+                  echo "git_commit = $git_commit"
+                  echo "src = $src"
+                  echo "dest = $dest"
+
+                  mkdir -p $component
+                  cd $component
+
+                  git config --global init.defaultBranch ${BRANCH}
+                  git init
+                  git remote add origin $git_url
+                  git config core.sparseCheckout true
+                  git config core.sparseCheckoutCone false
+                  echo "$src" >> .git/info/sparse-checkout
+                  git fetch --depth=1 origin $git_commit
+                  git checkout $git_commit
+
+                  cd ../
+                  echo "current dir = $(pwd)"
+                  
+                  dest_dir_path=${{ github.workspace }}/rhods-operator/prefetched-manifests/$dest
+                  if [[ -n "$dest" ]] && [[ -d "${dest_dir_path}" ]]
+                  then
+                      # delete the existing dir content
+                      rm -rf ${dest_dir_path}
+                  fi
+
+                  mkdir -p ${dest_dir_path}
+                  cp -r $component/$src/* ${dest_dir_path}
+              fi
+          done < <(yq e '.map | keys' ${MANIFEST_CONFIG_PATH} )
+
+          cd ${{ github.workspace }}/rhods-operator/prefetched-manifests
+          tree
+
+      - name: Commit and push the changes to release branch
+        uses: actions-js/push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref_name }}
+          message: "Updating the operator repo with latest images and manifests"
+          repository: ${{ env.GITHUB_ORG }}/rhods-operator
+          directory: rhods-operator
+          author_name: Openshift-AI DevOps
+          author_email: openshift-ai-devops@redhat.com

--- a/.github/workflows/trigger-nightly-operator-build.yaml
+++ b/.github/workflows/trigger-nightly-operator-build.yaml
@@ -1,0 +1,161 @@
+name: Trigger Nightly Operator Build
+run-name: Trigger Nightly Operator Build [${{ inputs.distinct_id && inputs.distinct_id || '' }}]
+
+on:
+  workflow_dispatch:
+    inputs:
+      distinct_id:
+        description: 'Distinct ID'
+        required: false
+
+env:
+  GITHUB_ORG: red-hat-data-services
+  GITHUB_RKA_ORG: rhoai-rhtap
+  RESOLVE_CONFLICTS_FOR: build/operator-nudging.yaml
+
+permissions:
+  contents: write
+
+jobs:
+  operator-processor:
+    if: ${{ github.ref_name != 'main' && (github.event_name == 'workflow_dispatch' || ( github.event_name == 'push' && github.event.commits[0].author.name == 'konflux-internal-p02' )) }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout RBC repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
+          ref: ${{ github.ref_name }}
+          path: RBC
+          sparse-checkout: |
+            bundle/bundle-patch.yaml
+          sparse-checkout-cone-mode: false
+      - name: Git checkout utils
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_RKA_ORG }}/RHOAI-Konflux-Automation
+          ref: main
+          path: utils
+          sparse-checkout: |
+            utils/operator-processor
+          sparse-checkout-cone-mode: false
+      - name: Git checkout operator repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.GITHUB_ORG }}/rhods-operator
+          ref: ${{ github.ref_name }}
+          path: rhods-operator
+          sparse-checkout: |
+            build
+            prefetched-manifests
+            .tekton
+          sparse-checkout-cone-mode: false
+      - name: Install dependencies
+        run: |
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/')"
+          yq_version="v4.44.3"
+          yq_filename="yq-$yq_version"
+          echo "-> Downloading yq" >&2
+          curl -sSfLo "$yq_filename" "https://github.com/mikefarah/yq/releases/download/$yq_version/yq_${os}_${arch}"
+          chmod +x $yq_filename
+          ln -s $yq_filename yq
+          cp $yq_filename /usr/local/bin/yq
+  
+          pip install --default-timeout=100 -r utils/utils/operator-processor/requirements.txt
+
+      - name: Execute Operator Processor
+        env:
+          BRANCH: ${{ github.ref_name }}
+          RHOAI_QUAY_API_TOKEN: ${{ secrets.RHOAI_QUAY_API_TOKEN }}
+        run: |
+          RHOAI_VERSION=v${BRANCH/rhoai-/}
+          COMPONENT_SUFFIX=${RHOAI_VERSION/./-}
+          ODH_OPERATOR_COMPONENT_NAME=odh-operator-${COMPONENT_SUFFIX}
+          PUSH_PIPELINE_PATH=rhods-operator/.tekton/${ODH_OPERATOR_COMPONENT_NAME}-push.yaml
+          
+          PATCH_YAML_PATH=RBC/bundle/bundle-patch.yaml
+          OPERANDS_MAP_PATH=rhods-operator/build/operands-map.yaml
+          NUDGING_YAML_PATH=rhods-operator/build/operator-nudging.yaml
+          MANIFEST_CONFIG_PATH=rhods-operator/build/manifests-config.yaml
+          
+          python3 utils/utils/operator-processor/operator-processor.py  -op process-operator-yamls --patch-yaml-path ${PATCH_YAML_PATH} --operands-map-path ${OPERANDS_MAP_PATH} --nudging-yaml-path ${NUDGING_YAML_PATH} --manifest-config-path ${MANIFEST_CONFIG_PATH} --rhoai-version ${BRANCH} --push-pipeline-yaml-path ${PUSH_PIPELINE_PATH} --push-pipeline-operation disable
+          
+          echo "----- NUDGING_YAML ------"
+          cat $NUDGING_YAML_PATH
+          echo "----- OPERANDS_MAP ------"
+          cat $OPERANDS_MAP_PATH
+          echo "----- MANIFEST_CONFIG ------"
+          cat $MANIFEST_CONFIG_PATH
+          echo "current dir = $(pwd)"
+      - name: Fetch all manifests
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          #!/bin/bash
+          set -e
+          echo "current dir = $(pwd)"
+          MANIFEST_CONFIG_PATH=${{ github.workspace }}/rhods-operator/build/manifests-config.yaml
+          mkdir -p rhods-operator/prefetched-manifests
+          mkdir -p manifests
+          cd manifests
+          while IFS= read -r value;
+          do
+              value=${value/- /}
+              component=$value
+              if [[ -n $component ]]
+              then	
+                  git_url=$(value="$value" yq '.map[strenv(value)]["git.url"]' ${MANIFEST_CONFIG_PATH})
+                  git_commit=$(value="$value" yq '.map[strenv(value)]["git.commit"]' ${MANIFEST_CONFIG_PATH})
+                  if [[ "$git_commit" == "github.ref_name" ]]; then git_commit=${BRANCH}; echo "changed the value to $BRANCH"; fi
+                  
+                  src=$(value="$value" yq '.map[strenv(value)]["src"]' ${MANIFEST_CONFIG_PATH})
+                  dest=$(value="$value" yq '.map[strenv(value)]["dest"]' ${MANIFEST_CONFIG_PATH})
+                  
+                  echo "component = $component"
+                  echo "git_url = $git_url"
+                  echo "git_commit = $git_commit"
+                  echo "src = $src"
+                  echo "dest = $dest"
+          
+                  mkdir -p $component
+                  cd $component
+          
+                  git config --global init.defaultBranch ${BRANCH}
+                  git init
+                  git remote add origin $git_url
+                  git config core.sparseCheckout true
+                  git config core.sparseCheckoutCone false
+                  echo "$src" >> .git/info/sparse-checkout
+                  git fetch --depth=1 origin $git_commit
+                  git checkout $git_commit
+          
+                  cd ../
+                  echo "current dir = $(pwd)"
+                  
+                  dest_dir_path=${{ github.workspace }}/rhods-operator/prefetched-manifests/$dest
+                  if [[ -n "$dest" ]] && [[ -d "${dest_dir_path}" ]]
+                  then
+                      # delete the existing dir content
+                      rm -rf ${dest_dir_path}
+                  fi
+
+                  mkdir -p ${dest_dir_path}
+                  cp -r $component/$src/* ${dest_dir_path}
+              fi
+          done < <(yq e '.map | keys' ${MANIFEST_CONFIG_PATH} )
+          
+          cd ${{ github.workspace }}/rhods-operator/prefetched-manifests
+          tree
+          # Update the schedule file to trigger the nightly build 
+          echo $(date +'%d-%m-%Y %H:%M:%S:%3N') > ${{ github.workspace }}/rhods-operator/build/schedule/operator-tekton-trigger.txt
+      - name: Commit and push the changes to release branch
+        uses: actions-js/push@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref_name }}
+          message: "Updating the operator repo with latest images and manifests"
+          repository: ${{ env.GITHUB_ORG }}/rhods-operator
+          directory: ${{ github.workspace }}/rhods-operator
+          author_name: Openshift-AI DevOps
+          author_email: openshift-ai-devops@redhat.com


### PR DESCRIPTION
## Description

Reverts the temporary "disable builds" PRs that were applied during the embargo period:

- **Revert #23214** — "Disable builds for rhoai-2.25"
- **Revert #23184** — "Disable operator-processor for rhoai-2.25"

This re-enables the operator-processor workflow and nightly build trigger for the rhoai-2.25 branch.

**JIRA:** [RHOAIENG-57736](https://issues.redhat.com/browse/RHOAIENG-57736)
**Parent:** [RHOAIENG-57438](https://issues.redhat.com/browse/RHOAIENG-57438)

---
🤖 Generated with [Claude Code](https://claude.ai/code) Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>