### PR TITLE
Fix manifest pre-fetch script in nightly build workflow

### DIFF
--- a/.github/workflows/trigger-nightly-operator-build.yaml
+++ b/.github/workflows/trigger-nightly-operator-build.yaml
@@ -96,31 +96,60 @@ jobs:
           set -e
           echo "current dir = $(pwd)"
           MANIFEST_CONFIG_PATH=${{ github.workspace }}/rhods-operator/build/manifests-config.yaml
-          mkdir -p rhods-operator/prefetched-manifests
+          PREFETCHED_MANIFEST_DIR_PATH="rhods-operator/prefetched-manifests"
+
+          # Clean up old prefetched manifests
+          if [ -d "$PREFETCHED_MANIFEST_DIR_PATH" ]; then
+              echo "Cleaning up old prefetched manifests..."
+              rm -rf "$PREFETCHED_MANIFEST_DIR_PATH"
+          fi
+
+          # Create fresh directories
+          mkdir -p "$PREFETCHED_MANIFEST_DIR_PATH"
           mkdir -p manifests
           cd manifests
           while IFS= read -r value;
           do
               value=${value/- /}
               component=$value
+
+              # Skip empty keys
+              [[ -z "$component" ]] && continue
+
+              echo "=============================================================="
+              echo "Fetching Manifest for component: $component"
+              echo "=============================================================="
               if [[ -n $component ]]
-              then	
+              then
                   git_url=$(value="$value" yq '.map[strenv(value)]["git.url"]' ${MANIFEST_CONFIG_PATH})
                   git_commit=$(value="$value" yq '.map[strenv(value)]["git.commit"]' ${MANIFEST_CONFIG_PATH})
-                  if [[ "$git_commit" == "github.ref_name" ]]; then git_commit=${BRANCH}; echo "changed the value to $BRANCH"; fi
-                  
+                  ref_type=$(value="$value" yq '.map[strenv(value)]["ref_type"]' ${MANIFEST_CONFIG_PATH})
+
+                  # If ref_type is branch, resolve the actual commit SHA
+                  if [[ "$ref_type" == "branch" ]]; then
+                    # Fetch latest commit SHA for the branch from remote
+                    git_commit=$(git ls-remote "$git_url" "refs/heads/$BRANCH" | awk '{print $1}')
+                    echo "Resolved git.commit for branch '$BRANCH' to commit SHA $git_commit"
+
+                    # Update the git.commit field in manifests-config.yaml for the current component.
+                    # Using strenv() to safely reference both the component key ($value) and the new commit SHA ($git_commit).
+                    # This avoids issues with --arg, which is not supported in this yq version, and prevents creating an empty "" key.
+                    value="$value" git_commit="$git_commit" yq -i eval '.map[strenv(value)]["git.commit"] = strenv(git_commit)' ${MANIFEST_CONFIG_PATH}
+
+                  fi
+
                   src=$(value="$value" yq '.map[strenv(value)]["src"]' ${MANIFEST_CONFIG_PATH})
                   dest=$(value="$value" yq '.map[strenv(value)]["dest"]' ${MANIFEST_CONFIG_PATH})
-                  
+
                   echo "component = $component"
                   echo "git_url = $git_url"
                   echo "git_commit = $git_commit"
                   echo "src = $src"
                   echo "dest = $dest"
-          
+
                   mkdir -p $component
                   cd $component
-          
+
                   git config --global init.defaultBranch ${BRANCH}
                   git init
                   git remote add origin $git_url
@@ -129,16 +158,19 @@ jobs:
                   echo "$src" >> .git/info/sparse-checkout
                   git fetch --depth=1 origin $git_commit
                   git checkout $git_commit
-          
+
                   cd ../
                   echo "current dir = $(pwd)"
-                  
-                  mkdir -p ${{ github.workspace }}/rhods-operator/prefetched-manifests/$dest
-                  cp -r $component/$src/* ${{ github.workspace }}/rhods-operator/prefetched-manifests/$dest
+
+                  dest_dir_path=${{ github.workspace }}/${PREFETCHED_MANIFEST_DIR_PATH}/$dest
+                  mkdir -p ${dest_dir_path}
+
+                  cp -r $component/$src/* ${dest_dir_path}
+                  echo ""
               fi
           done < <(yq e '.map | keys' ${MANIFEST_CONFIG_PATH} )
-          
-          cd ${{ github.workspace }}/rhods-operator/prefetched-manifests
+
+          cd ${{ github.workspace }}/${PREFETCHED_MANIFEST_DIR_PATH}
           tree
           # Update the schedule file to trigger the nightly build 
           echo $(date +'%d-%m-%Y %H:%M:%S:%3N') > ${{ github.workspace }}/rhods-operator/build/schedule/operator-tekton-trigger.txt


### PR DESCRIPTION
## Summary
- Aligns the "Fetch all manifests" step in `trigger-nightly-operator-build.yaml` with the fix already applied in `operator-processor.yaml` (commit 43ace21)
- Adds `ref_type` field support to resolve branch references to actual commit SHAs via `git ls-remote`
- Cleans up old prefetched manifests before fetching new ones to prevent stale data
- Skips empty component keys and adds better logging

## Test plan
- [ ] Trigger nightly build workflow on rhoai-3.3 branch and verify manifests are fetched correctly
- [ ] Verify ref_type=branch components resolve to correct commit SHAs

Ref: RHOAIENG-56991

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>