### PR TITLE
RHOAIENG-58364: feat(kserve): apply LLMInferenceServiceConfig resources last during deploy

### DIFF
--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -18,6 +18,7 @@ package kserve
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -26,6 +27,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
@@ -46,6 +48,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/reconciler"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
+	pkgresources "github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 // NewComponentReconciler creates a ComponentReconciler for the Kserve API.
@@ -158,7 +161,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		}).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
-			deploy.WithApplyOrder(),
+			WithApplyOrderLLMInferenceServiceConfigLast(),
 		)).
 		WithAction(deployments.NewAction()).
 		// must be the final action
@@ -169,4 +172,48 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		Build(ctx)
 
 	return err
+}
+
+// WithApplyOrderLLMInferenceServiceConfigLast returns a deploy option that sorts
+// resources using the standard apply order (CRDs first, webhooks last), then
+// moves all LLMInferenceServiceConfig resources to the very end.
+//
+// This ordering is critical for upgrades (e.g. 3.3 → 3.4). In 3.3, a single
+// kserve controller handled LLMInferenceServiceConfig validation. In 3.4,
+// validation moves to the separate llmisvc controller with its own webhook.
+// During upgrades the kserve controller is updated to 3.4 first, but the old
+// ValidatingWebhookConfiguration still points to kserve-webhook-server-service
+// which no longer serves the LLMInferenceServiceConfig validation endpoint.
+// Since WithApplyOrder places webhooks last, if LLMInferenceServiceConfig
+// resources are applied before the new ValidatingWebhookConfiguration replaces
+// the old one, validation fails and the operator stops — preventing the new
+// webhook configuration from ever being applied.
+// Placing LLMInferenceServiceConfig resources after webhooks ensures the new
+// ValidatingWebhookConfiguration is applied first.
+func WithApplyOrderLLMInferenceServiceConfigLast() deploy.ActionOpts {
+	return deploy.WithSortFn(deploy.SortFn(pkgresources.SortByApplyOrder).Then(sortLLMInferenceServiceConfigLast))
+}
+
+func sortLLMInferenceServiceConfigLast(_ context.Context, objects []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
+	result := objects
+	// Stable-sort LLMInferenceServiceConfig resources after everything else
+	// so they are applied only once the webhook(s) are updated.
+	slices.SortStableFunc(result, func(a, b unstructured.Unstructured) int {
+		if isLLMInferenceServiceConfig(a) && isLLMInferenceServiceConfig(b) {
+			// Keep the original order.
+			return 0
+		}
+		if isLLMInferenceServiceConfig(a) {
+			return 1
+		}
+		if isLLMInferenceServiceConfig(b) {
+			return -1
+		}
+		return 0
+	})
+	return result, nil
+}
+
+func isLLMInferenceServiceConfig(r unstructured.Unstructured) bool {
+	return r.GetKind() == gvk.LLMInferenceServiceConfigV1Alpha2.Kind
 }

--- a/internal/controller/components/kserve/kserve_controller.go
+++ b/internal/controller/components/kserve/kserve_controller.go
@@ -215,5 +215,6 @@ func sortLLMInferenceServiceConfigLast(_ context.Context, objects []unstructured
 }
 
 func isLLMInferenceServiceConfig(r unstructured.Unstructured) bool {
-	return r.GetKind() == gvk.LLMInferenceServiceConfigV1Alpha2.Kind
+	return r.GroupVersionKind().Group == gvk.LLMInferenceServiceConfigV1Alpha2.Group &&
+		r.GetKind() == gvk.LLMInferenceServiceConfigV1Alpha2.Kind
 }

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -784,6 +784,9 @@ func TestSortLLMInferenceServiceConfigLast(t *testing.T) {
 		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(result).To(HaveLen(3))
+		g.Expect(result[0].GetName()).To(Equal("deploy"))
+		g.Expect(result[1].GetName()).To(Equal("svc"))
+		g.Expect(result[2].GetName()).To(Equal("cm"))
 	})
 
 	t.Run("all LLMInferenceServiceConfig resources preserves input order", func(t *testing.T) {

--- a/internal/controller/components/kserve/kserve_controller_actions_test.go
+++ b/internal/controller/components/kserve/kserve_controller_actions_test.go
@@ -708,6 +708,112 @@ func TestCheckOperatorAndCRDDependencies(t *testing.T) {
 	})
 }
 
+func TestSortLLMInferenceServiceConfigLast(t *testing.T) {
+	newRes := func(group, version, kind, name string) unstructured.Unstructured {
+		u := unstructured.Unstructured{}
+		u.SetGroupVersionKind(schema.GroupVersionKind{Group: group, Version: version, Kind: kind})
+		u.SetName(name)
+		return u
+	}
+
+	llmISvcConfig := func(name string) unstructured.Unstructured {
+		return newRes(
+			gvk.LLMInferenceServiceConfigV1Alpha2.Group,
+			gvk.LLMInferenceServiceConfigV1Alpha2.Version,
+			gvk.LLMInferenceServiceConfigV1Alpha2.Kind,
+			name,
+		)
+	}
+
+	t.Run("LLMInferenceServiceConfig resources are placed after all other resources", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		input := []unstructured.Unstructured{
+			llmISvcConfig("config-a"),
+			newRes("apps", "v1", "Deployment", "my-deploy"),
+			llmISvcConfig("config-b"),
+			newRes("", "v1", "Service", "my-svc"),
+		}
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// Non-LLMInferenceServiceConfig resources should come first
+		g.Expect(result[len(result)-2].GetName()).To(Equal("config-a"))
+		g.Expect(result[len(result)-1].GetName()).To(Equal("config-b"))
+
+		// All non-LLMInferenceServiceConfig resources should precede them
+		for _, r := range result[:len(result)-2] {
+			g.Expect(r.GetKind()).NotTo(Equal(gvk.LLMInferenceServiceConfigV1Alpha2.Kind))
+		}
+	})
+
+	t.Run("preserves relative order among LLMInferenceServiceConfig resources", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		input := []unstructured.Unstructured{
+			llmISvcConfig("config-z"),
+			newRes("apps", "v1", "Deployment", "deploy"),
+			llmISvcConfig("config-a"),
+			llmISvcConfig("config-m"),
+		}
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		// The three LLMInferenceServiceConfig resources should be at the end,
+		// in their original relative order (stable sort).
+		configs := result[len(result)-3:]
+		g.Expect(configs[0].GetName()).To(Equal("config-z"))
+		g.Expect(configs[1].GetName()).To(Equal("config-a"))
+		g.Expect(configs[2].GetName()).To(Equal("config-m"))
+	})
+
+	t.Run("no LLMInferenceServiceConfig resources leaves order unchanged", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		input := []unstructured.Unstructured{
+			newRes("apps", "v1", "Deployment", "deploy"),
+			newRes("", "v1", "Service", "svc"),
+			newRes("", "v1", "ConfigMap", "cm"),
+		}
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(HaveLen(3))
+	})
+
+	t.Run("all LLMInferenceServiceConfig resources preserves input order", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		input := []unstructured.Unstructured{
+			llmISvcConfig("config-b"),
+			llmISvcConfig("config-a"),
+			llmISvcConfig("config-c"),
+		}
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, input)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(HaveLen(3))
+		g.Expect(result[0].GetName()).To(Equal("config-b"))
+		g.Expect(result[1].GetName()).To(Equal("config-a"))
+		g.Expect(result[2].GetName()).To(Equal("config-c"))
+	})
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		result, err := sortLLMInferenceServiceConfigLast(ctx, nil)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result).To(BeEmpty())
+	})
+}
+
 func createTestConfigMap() *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/controller/actions/deploy/action_deploy.go
+++ b/pkg/controller/actions/deploy/action_deploy.go
@@ -34,6 +34,16 @@ const (
 // SortFn defines a function that reorders resources before deployment.
 type SortFn func(ctx context.Context, resources []unstructured.Unstructured) ([]unstructured.Unstructured, error)
 
+func (s SortFn) Then(then SortFn) SortFn {
+	return func(ctx context.Context, resources []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
+		output, err := s(ctx, resources)
+		if err != nil {
+			return nil, err
+		}
+		return then(ctx, output)
+	}
+}
+
 // Action deploys the resources that are included in the ReconciliationRequest using
 // the same create or patch machinery implemented as part of deploy.DeployManifestsFromPath.
 type Action struct {


### PR DESCRIPTION
## Description

During 3.3 → 3.4 upgrades, the kserve controller is updated first but the
old ValidatingWebhookConfiguration still points to kserve-webhook-server-service
which no longer serves the LLMInferenceServiceConfig validation endpoint.
Since WithApplyOrder places webhooks last, if LLMInferenceServiceConfig
resources are applied before the new ValidatingWebhookConfiguration replaces
the old one, validation fails and the operator stops — preventing the new
webhook configuration from ever being applied.

Add WithApplyOrderLLMInferenceServiceConfigLast which composes
SortByApplyOrder with a stable sort that pushes LLMInferenceServiceConfig
resources after webhooks. Add SortFn.Then to enable sort function composition.

https://redhat.atlassian.net/browse/RHOAIENG-58364