### PR TITLE
RHOAIENG-60933: Add odh-ogx-operator to manifests-config

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -56,3 +56,6 @@ map:
   odh-workload-variant-autoscaler-controller:
     src: config
     dest: wva
+  odh-ogx-operator:
+    src: config
+    dest: ogx


### PR DESCRIPTION
## Summary

Adds `odh-ogx-operator` to `build/manifests-config.yaml` to integrate the new OGX Operator component with the RHOAI operator bundle.

- Component: `odh-ogx-operator`
- Manifest source path: `config`
- Manifest dest path: `ogx`

Jira: https://redhat.atlassian.net/browse/RHOAIENG-60933