### PR TITLE
Add odh-ogx-k8s-operator to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -59,3 +59,6 @@ map:
   odh-ogx-operator:
     src: config
     dest: ogx
+  odh-ogx-k8s-operator:
+    src: config
+    dest: ogx


### PR DESCRIPTION
Adds 'odh-ogx-k8s-operator' to the operator manifests config map.

Component: odh-ogx-k8s-operator
Manifest source path: config
Manifest dest path:   ogx
Upstream repo: https://github.com/red-hat-data-services/ogx-k8s-operator @ rhoai-3.5-ea.1
Jira: https://redhat.atlassian.net/browse/RHOAIENG-60933

**File changed:**
- `build/manifests-config.yaml` — added `odh-ogx-k8s-operator` entry under `map:`