### PR TITLE
Remove odh-llama-stack-k8s-operator entry

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -38,9 +38,6 @@ map:
   odh-feast-operator:
     src: infra/feast-operator/config
     dest: feastoperator
-  odh-llama-stack-k8s-operator:
-    src: config
-    dest: llamastackoperator
   odh-trainer:
     src: manifests
     dest: trainer


### PR DESCRIPTION
odh-llama-stack-k8s-operator was renamed to odh-ogx-k8s-operator https://redhat-internal.slack.com/archives/C07SBP17R7Z/p1778667173430519?thread_ts=1778605490.975389&cid=C07SBP17R7Z

An entry for odh-ogx-k8s-operator was added https://github.com/red-hat-data-services/rhods-operator/commit/e8f71d1c4c0cbbe4e3b882b365eebf96ef4e44e9
