### PR TITLE
fix(feast): Fix Feast operator upgrade failure caused by immutable Deployment selector

### DIFF
--- a/internal/controller/components/feastoperator/feastoperator_controller.go
+++ b/internal/controller/components/feastoperator/feastoperator_controller.go
@@ -48,6 +48,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			kustomize.WithLabel(labels.ODH.Component(ComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, ComponentName),
 		)).
+		WithAction(migrateDeploymentSelector).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).

--- a/internal/controller/components/feastoperator/feastoperator_controller_actions.go
+++ b/internal/controller/components/feastoperator/feastoperator_controller_actions.go
@@ -5,13 +5,73 @@ import (
 	"errors"
 	"fmt"
 
+	appsv1 "k8s.io/api/apps/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	odhdeploy "github.com/opendatahub-io/opendatahub-operator/v2/pkg/deploy"
 )
 
+const (
+	deploymentName     = "feast-operator-controller-manager"
+	selectorLabelKey   = "app.kubernetes.io/name"
+	selectorLabelValue = "feast-operator"
+)
+
 func initialize(_ context.Context, rr *odhtypes.ReconciliationRequest) error { //nolint:unparam
 	rr.Manifests = append(rr.Manifests, manifestPath(rr.ManifestsBasePath, rr.Release.Name))
+	return nil
+}
+
+// migrateDeploymentSelector deletes the feast-operator-controller-manager Deployment if its
+// spec.selector.matchLabels is missing the app.kubernetes.io/name label. This handles upgrades
+// where the selector changed between releases — since spec.selector is immutable on Deployments,
+// the only way to update it is to delete and let the operator recreate it.
+func migrateDeploymentSelector(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	log := logf.FromContext(ctx)
+
+	ns, err := cluster.ApplicationNamespace(ctx, rr.Client)
+	if err != nil {
+		return fmt.Errorf("failed to determine application namespace: %w", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	err = rr.Client.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: ns}, deploy)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get Deployment %s/%s: %w", ns, deploymentName, err)
+	}
+
+	if deploy.Spec.Selector == nil {
+		return nil
+	}
+
+	if deploy.Spec.Selector.MatchLabels[selectorLabelKey] == selectorLabelValue {
+		return nil
+	}
+
+	log.Info("Feast operator Deployment has stale selector, deleting for recreation",
+		"deployment", deploymentName,
+		"namespace", ns,
+		"currentSelector", deploy.Spec.Selector.MatchLabels,
+	)
+
+	if err := rr.Client.Delete(ctx, deploy); err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete Deployment %s/%s with stale selector: %w", ns, deploymentName, err)
+	}
+
+	log.Info("Deleted Feast operator Deployment, it will be recreated with the correct selector",
+		"deployment", deploymentName, "namespace", ns)
+
 	return nil
 }
 

--- a/internal/controller/components/feastoperator/feastoperator_test.go
+++ b/internal/controller/components/feastoperator/feastoperator_test.go
@@ -9,13 +9,16 @@ import (
 	gt "github.com/onsi/gomega/types"
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
@@ -375,6 +378,98 @@ func createDSCWithFeastOperator(managementState operatorv1.ManagementState) *dsc
 	dsc.Spec.Components.FeastOperator.ManagementState = managementState
 
 	return &dsc
+}
+
+func createDSCI(namespace string) *dsciv2.DSCInitialization {
+	dsci := &dsciv2.DSCInitialization{}
+	dsci.SetGroupVersionKind(gvk.DSCInitialization)
+	dsci.SetName("default-dsci")
+	dsci.Spec.ApplicationsNamespace = namespace
+	return dsci
+}
+
+func createFeastDeployment(namespace string, selectorLabels map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: selectorLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "mgr", Image: "test"}}},
+			},
+		},
+	}
+}
+
+func TestMigrateDeploymentSelector(t *testing.T) {
+	const testNS = "redhat-ods-applications"
+
+	t.Run("should delete Deployment with stale selector", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		staleSelector := map[string]string{"control-plane": "controller-manager"}
+		deploy := createFeastDeployment(testNS, staleSelector)
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &types.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+
+		result := &appsv1.Deployment{}
+		err = cli.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: testNS}, result)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+	})
+
+	t.Run("should not delete Deployment with correct selector", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		correctSelector := map[string]string{
+			"control-plane":          "controller-manager",
+			"app.kubernetes.io/name": "feast-operator",
+		}
+		deploy := createFeastDeployment(testNS, correctSelector)
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &types.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+
+		result := &appsv1.Deployment{}
+		err = cli.Get(ctx, client.ObjectKey{Name: deploymentName, Namespace: testNS}, result)
+		g.Expect(err).To(Succeed())
+		g.Expect(result.Spec.Selector.MatchLabels).Should(HaveKeyWithValue("app.kubernetes.io/name", "feast-operator"))
+	})
+
+	t.Run("should be no-op when Deployment does not exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &types.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+	})
 }
 
 func createFeastOperatorCR(ready bool) *componentApi.FeastOperator {


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

Cherry-pick or same as https://github.com/opendatahub-io/opendatahub-operator/pull/3566 for 3.5 EA1 branch

Jira: https://redhat.atlassian.net/browse/RHOAIENG-63549

During upgrades (e.g., 3.4 → 3.5), the feast-operator-controller-manager Deployment
fails to reconcile because spec.selector.matchLabels changed between releases. Kubernetes
rejects the update with:
    field is immutable: spec.selector

The deploy action applies all rendered manifests in a single batch, so the error aborts the
entire reconciliation before any other resources (including a previously attempted migration
Job in the Feast repo https://github.com/opendatahub-io/feast/pull/120 ) can be created.

This PR adds a Feast-specific pre-deploy action (migrateDeploymentSelector) that runs before
the generic deploy action. It checks whether the existing Deployment's selector is missing the
expected app.kubernetes.io/name: feast-operator label and, if so, deletes the Deployment so
the deploy action can recreate it with the correct selector.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->

The migration action only activates during upgrades with a pre-existing stale Deployment, a scenario that cannot occur in a fresh E2E environment. Unit tests cover all code paths. Existing E2E tests (ValidateComponentEnabled, ValidateAllDeletionRecovery) validate the post-migration behavior.
