### PR TITLE
fix(maas): keep payload-processing in gateway namespace after namespace transform (#3545)

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -124,7 +124,7 @@ func AppendOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconcilia
 	// to attach ext_proc filters. Restore their namespace to the gateway ns.
 	// See RHOAIENG-59726.
 	if err := restoreGatewayNamespaceResources(resMap); err != nil {
-		return nil, fmt.Errorf("restore gateway namespace for payload-processing: %w", err)
+		return fmt.Errorf("restore gateway namespace for payload-processing: %w", err)
 	}
 
 	componentLabels := map[string]string{

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -30,8 +30,10 @@ import (
 	"sigs.k8s.io/kustomize/api/builtins" //nolint:staticcheck // Remove after package update
 	"sigs.k8s.io/kustomize/api/krusty"
 	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/kustomize/api/types"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	kyaml "sigs.k8s.io/kustomize/kyaml/yaml"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -247,28 +249,71 @@ func normalizeUnstructuredObject(obj map[string]any) (map[string]any, error) {
 	return out, nil
 }
 
-// gatewayNamespaceResourceNames lists namespaced resources that must remain in the
-// gateway namespace after the blanket NamespaceApplierPlugin transform.
-// Only namespaced resources are listed here; cluster-scoped resources like
-// ClusterRoleBinding are not affected by SetNamespace and are not included.
-var gatewayNamespaceResourceNames = map[string]bool{
-	"payload-processing":         true, // Deployment, Service, ServiceAccount
-	"payload-processing-plugins": true, // ConfigMap
+type resourceKey struct {
+	kind string
+	name string
+}
+
+// gatewayNamespaceResources lists the specific resources that must remain in the
+// gateway namespace after the blanket NamespaceApplierPlugin transform. Keyed by
+// kind+name to avoid accidentally matching unrelated resources.
+var gatewayNamespaceResources = map[resourceKey]bool{
+	{kind: "Deployment", name: "payload-processing"}:            true,
+	{kind: "Service", name: "payload-processing"}:               true,
+	{kind: "ServiceAccount", name: "payload-processing"}:        true,
+	{kind: "ConfigMap", name: "payload-processing-plugins"}:     true,
+	{kind: "ClusterRoleBinding", name: "payload-processing-reader"}: true,
 }
 
 // restoreGatewayNamespaceResources moves resources that belong in the gateway
 // namespace back from the application namespace. The blanket NamespaceApplierPlugin
 // moves everything to appNs, but payload-processing resources must stay in the
 // gateway namespace for the EnvoyFilter to attach to the Gateway.
+//
+// For ClusterRoleBindings, the NamespaceApplierPlugin also rewrites
+// subjects[].namespace; this function restores it to the gateway namespace
+// so the RBAC binding matches the actual ServiceAccount location.
 func restoreGatewayNamespaceResources(resMap resmap.ResMap) error {
 	for _, res := range resMap.Resources() {
-		if !gatewayNamespaceResourceNames[res.GetName()] {
+		k := resourceKey{kind: res.GetKind(), name: res.GetName()}
+		if !gatewayNamespaceResources[k] {
+			continue
+		}
+		if res.GetKind() == "ClusterRoleBinding" {
+			if err := restoreCRBSubjectsNamespace(res, DefaultGatewayNamespace); err != nil {
+				return fmt.Errorf("restore subjects namespace on ClusterRoleBinding %s: %w", res.GetName(), err)
+			}
 			continue
 		}
 		if err := res.SetNamespace(DefaultGatewayNamespace); err != nil {
 			return fmt.Errorf("set namespace on %s %s: %w", res.GetKind(), res.GetName(), err)
 		}
 	}
+	return nil
+}
+
+// restoreCRBSubjectsNamespace updates subjects[].namespace on a ClusterRoleBinding
+// resource. SetNamespace only changes metadata.namespace which is meaningless for
+// cluster-scoped resources; the NamespaceApplierPlugin rewrites subjects separately.
+func restoreCRBSubjectsNamespace(res *resource.Resource, namespace string) error {
+	m, err := res.Map()
+	if err != nil {
+		return err
+	}
+	subjects, ok := m["subjects"].([]any)
+	if !ok {
+		return nil
+	}
+	for _, s := range subjects {
+		if subject, ok := s.(map[string]any); ok {
+			subject["namespace"] = namespace
+		}
+	}
+	node, err := kyaml.FromMap(m)
+	if err != nil {
+		return err
+	}
+	res.RNode = *node
 	return nil
 }
 

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -116,6 +116,15 @@ func AppendOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconcilia
 		return fmt.Errorf("namespace transform for maas-controller bundle: %w", err)
 	}
 
+	// The blanket namespace transform above moves ALL resources to appNs, but
+	// payload-processing resources must remain in the gateway namespace because
+	// the EnvoyFilter must run in the same namespace as the Gateway for Envoy
+	// to attach ext_proc filters. Restore their namespace to the gateway ns.
+	// See RHOAIENG-59726.
+	if err := restoreGatewayNamespaceResources(resMap); err != nil {
+		return nil, fmt.Errorf("restore gateway namespace for payload-processing: %w", err)
+	}
+
 	componentLabels := map[string]string{
 		labels.ODH.Component(componentApi.ModelsAsServiceComponentName): labels.True,
 		labels.K8SCommon.PartOf: componentApi.ModelsAsServiceComponentName,
@@ -236,6 +245,32 @@ func normalizeUnstructuredObject(obj map[string]any) (map[string]any, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// gatewayNamespaceResourceNames lists resources that must remain in the gateway
+// namespace after the blanket NamespaceApplierPlugin transform. These resources
+// are deployed to openshift-ingress in the base manifests because the EnvoyFilter
+// must run in the same namespace as the Gateway.
+var gatewayNamespaceResourceNames = map[string]bool{
+	"payload-processing":         true, // Deployment, Service, ServiceAccount
+	"payload-processing-plugins": true, // ConfigMap
+	"payload-processing-reader":  true, // ClusterRoleBinding (subjects namespace)
+}
+
+// restoreGatewayNamespaceResources moves resources that belong in the gateway
+// namespace back from the application namespace. The blanket NamespaceApplierPlugin
+// moves everything to appNs, but payload-processing resources must stay in the
+// gateway namespace for the EnvoyFilter to attach to the Gateway.
+func restoreGatewayNamespaceResources(resMap resmap.ResMap) error {
+	for _, res := range resMap.Resources() {
+		if !gatewayNamespaceResourceNames[res.GetName()] {
+			continue
+		}
+		if err := res.SetNamespace(DefaultGatewayNamespace); err != nil {
+			return fmt.Errorf("set namespace on %s %s: %w", res.GetKind(), res.GetName(), err)
+		}
+	}
+	return nil
 }
 
 // deployImageParams maps the kustomize image name (as rendered by the images

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -258,10 +258,10 @@ type resourceKey struct {
 // gateway namespace after the blanket NamespaceApplierPlugin transform. Keyed by
 // kind+name to avoid accidentally matching unrelated resources.
 var gatewayNamespaceResources = map[resourceKey]bool{
-	{kind: "Deployment", name: "payload-processing"}:            true,
-	{kind: "Service", name: "payload-processing"}:               true,
-	{kind: "ServiceAccount", name: "payload-processing"}:        true,
-	{kind: "ConfigMap", name: "payload-processing-plugins"}:     true,
+	{kind: "Deployment", name: "payload-processing"}:                true,
+	{kind: "Service", name: "payload-processing"}:                   true,
+	{kind: "ServiceAccount", name: "payload-processing"}:            true,
+	{kind: "ConfigMap", name: "payload-processing-plugins"}:         true,
 	{kind: "ClusterRoleBinding", name: "payload-processing-reader"}: true,
 }
 

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -247,14 +247,13 @@ func normalizeUnstructuredObject(obj map[string]any) (map[string]any, error) {
 	return out, nil
 }
 
-// gatewayNamespaceResourceNames lists resources that must remain in the gateway
-// namespace after the blanket NamespaceApplierPlugin transform. These resources
-// are deployed to openshift-ingress in the base manifests because the EnvoyFilter
-// must run in the same namespace as the Gateway.
+// gatewayNamespaceResourceNames lists namespaced resources that must remain in the
+// gateway namespace after the blanket NamespaceApplierPlugin transform.
+// Only namespaced resources are listed here; cluster-scoped resources like
+// ClusterRoleBinding are not affected by SetNamespace and are not included.
 var gatewayNamespaceResourceNames = map[string]bool{
 	"payload-processing":         true, // Deployment, Service, ServiceAccount
 	"payload-processing-plugins": true, // ConfigMap
-	"payload-processing-reader":  true, // ClusterRoleBinding (subjects namespace)
 }
 
 // restoreGatewayNamespaceResources moves resources that belong in the gateway

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -1,0 +1,199 @@
+//nolint:testpackage
+package modelsasservice
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/kustomize/api/provider"
+	"sigs.k8s.io/kustomize/api/resmap"
+)
+
+var rf = provider.NewDefaultDepProvider().GetResourceFactory()
+
+func buildTestResMap(t *testing.T, yamls ...string) resmap.ResMap {
+	t.Helper()
+	g := NewWithT(t)
+	rm := resmap.New()
+	for _, y := range yamls {
+		res, err := rf.FromBytes([]byte(y))
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(rm.Append(res)).ShouldNot(HaveOccurred())
+	}
+	return rm
+}
+
+func TestRestoreGatewayNamespaceResources(t *testing.T) {
+	g := NewWithT(t)
+
+	rm := buildTestResMap(t,
+		`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
+		`
+apiVersion: v1
+kind: Service
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
+		`
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
+		`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: payload-processing-plugins
+  namespace: redhat-ods-applications
+`,
+		// Unrelated resource that should NOT be moved
+		`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: maas-controller
+  namespace: redhat-ods-applications
+`,
+		// CRB with subjects in the wrong namespace
+		`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: payload-processing-reader
+subjects:
+- kind: ServiceAccount
+  name: payload-processing
+  namespace: redhat-ods-applications
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: payload-processing-reader
+`,
+	)
+
+	err := restoreGatewayNamespaceResources(rm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	for _, res := range rm.Resources() {
+		k := resourceKey{kind: res.GetKind(), name: res.GetName()}
+
+		switch {
+		case k == (resourceKey{kind: "Deployment", name: "maas-controller"}):
+			g.Expect(res.GetNamespace()).To(Equal("redhat-ods-applications"),
+				"unrelated resource should keep app namespace")
+
+		case k.kind == "ClusterRoleBinding":
+			m, err := res.Map()
+			g.Expect(err).ShouldNot(HaveOccurred())
+			subjects, ok := m["subjects"].([]any)
+			g.Expect(ok).To(BeTrue(), "CRB should have subjects")
+			for _, s := range subjects {
+				subj, ok := s.(map[string]any)
+				g.Expect(ok).To(BeTrue())
+				g.Expect(subj["namespace"]).To(Equal(DefaultGatewayNamespace),
+					"CRB subjects[].namespace should be restored to gateway namespace")
+			}
+
+		case gatewayNamespaceResources[k]:
+			g.Expect(res.GetNamespace()).To(Equal(DefaultGatewayNamespace),
+				"%s/%s should be moved to gateway namespace", k.kind, k.name)
+		}
+	}
+}
+
+func TestRestoreGatewayNamespaceResources_IgnoresNonAllowlisted(t *testing.T) {
+	g := NewWithT(t)
+
+	rm := buildTestResMap(t,
+		`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: some-other-deployment
+  namespace: redhat-ods-applications
+`,
+		// Same name but different kind — should NOT match
+		`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
+	)
+
+	err := restoreGatewayNamespaceResources(rm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	for _, res := range rm.Resources() {
+		g.Expect(res.GetNamespace()).To(Equal("redhat-ods-applications"),
+			"%s/%s should not be moved", res.GetKind(), res.GetName())
+	}
+}
+
+func TestRestoreCRBSubjectsNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	res, err := rf.FromBytes([]byte(`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: payload-processing-reader
+subjects:
+- kind: ServiceAccount
+  name: payload-processing
+  namespace: wrong-namespace
+- kind: ServiceAccount
+  name: another-sa
+  namespace: wrong-namespace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: payload-processing-reader
+`))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = restoreCRBSubjectsNamespace(res, "openshift-ingress")
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	m, err := res.Map()
+	g.Expect(err).ShouldNot(HaveOccurred())
+	subjects, ok := m["subjects"].([]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(subjects).To(HaveLen(2))
+
+	for i, s := range subjects {
+		subj, ok := s.(map[string]any)
+		g.Expect(ok).To(BeTrue())
+		g.Expect(subj["namespace"]).To(Equal("openshift-ingress"),
+			"subjects[%d].namespace should be restored", i)
+	}
+}
+
+func TestRestoreCRBSubjectsNamespace_NoSubjects(t *testing.T) {
+	g := NewWithT(t)
+
+	res, err := rf.FromBytes([]byte(`
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: no-subjects-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: some-role
+`))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	err = restoreCRBSubjectsNamespace(res, "openshift-ingress")
+	g.Expect(err).ShouldNot(HaveOccurred())
+}

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -4,14 +4,15 @@ package modelsasservice
 import (
 	"testing"
 
-	. "github.com/onsi/gomega"
 	"sigs.k8s.io/kustomize/api/provider"
 	"sigs.k8s.io/kustomize/api/resmap"
+
+	. "github.com/onsi/gomega"
 )
 
 var rf = provider.NewDefaultDepProvider().GetResourceFactory()
 
-func buildTestResMap(t *testing.T, yamls ...string) resmap.ResMap {
+func buildTestResMap(t *testing.T, yamls ...string) resmap.ResMap { //nolint:ireturn
 	t.Helper()
 	g := NewWithT(t)
 	rm := resmap.New()


### PR DESCRIPTION
---------

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
* fix(maas): keep payload-processing in gateway namespace after namespace transform

The NamespaceApplierPlugin moves ALL resources to the app namespace, but payload-processing resources (Deployment, Service, EnvoyFilter, DestinationRule) must remain in the gateway namespace (openshift-ingress) because the EnvoyFilter must run in the same namespace as the Gateway.

After the blanket namespace transform, restore payload-processing resources back to the gateway namespace. This ensures the EnvoyFilter cluster_name FQDN matches the actual service location.

Ref: RHOAIENG-59726



* fix: remove ClusterRoleBinding from gateway namespace allowlist

Remove payload-processing-reader from gatewayNamespaceResourceNames. ClusterRoleBindings are cluster-scoped so SetNamespace() does not apply, and the NamespaceApplierPlugin changes subjects[].namespace which this function does not restore.

The CRB is also not part of the maas-controller install bundle (deployment/base/maas-controller/default), so it would never be encountered by this code path.



* fix: use kind+name selector for gateway namespace allowlist

Switch from name-only string matching to kind+name struct keys so the allowlist cannot accidentally match unrelated resources that share a name. Also restore payload-processing-reader ClusterRoleBinding to the allowlist with subjects[].namespace restoration — the NamespaceApplierPlugin rewrites subjects, not just metadata.namespace, so the CRB must be fixed separately from namespaced resources.



* style: fix gci formatting in gatewayNamespaceResources map



* test: add unit tests for gateway namespace restoration

Verify restoreGatewayNamespaceResources and restoreCRBSubjectsNamespace:
- Payload-processing resources are moved to gateway namespace
- ClusterRoleBinding subjects[].namespace is restored
- Unrelated resources remain in app namespace
- Kind+name matching prevents false positives


* fix: resolve gci import order and ireturn lint errors in test helper

<!--- Describe your changes in detail -->

<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
