### PR TITLE
Add odh-agents-operator to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -90,6 +90,11 @@ map:
     dest: ogx
     git.url: https://github.com/red-hat-data-services/ogx-k8s-operator
     git.commit: bff797dacf1c3e9ad48ddff026730b1a0344134c
+  odh-agents-operator:
+    src: kagenti-operator/config
+    dest: agentsoperator
+    git.url: https://github.com/red-hat-data-services/agents-operator
+    git.commit: cf065b76803b18da24d3a1c7848796238396a617
 additional_meta:
   odh-ai-gateway-payload-processing-e2e:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing


### PR DESCRIPTION
Adds 'odh-agents-operator' to the operator manifests config map.

Component: odh-agents-operator
Manifest source path: kagenti-operator/config
Manifest dest path:   agentsoperator
Upstream repo: https://github.com/red-hat-data-services/agents-operator @ rhoai-3.5-ea.2
Jira: https://redhat.atlassian.net/browse/RHOAIENG-63609

**File changed:**
- `build/manifests-config.yaml` — added `odh-agents-operator` entry under `map:`