### PR TITLE
fix(dashboard): add automl and autorag pipeline runtime image mappings

### DIFF
--- a/internal/controller/components/dashboard/dashboard_support.go
+++ b/internal/controller/components/dashboard/dashboard_support.go
@@ -44,16 +44,18 @@ var (
 	}
 
 	imagesMap = map[string]string{
-		"odh-dashboard-image":      "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
-		"model-registry-ui-image":  "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
-		"gen-ai-ui-image":          "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
-		"mlflow-ui-image":          "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
-		"maas-ui-image":            "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
-		"eval-hub-ui-image":        "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
-		"kube-rbac-proxy":          "RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",
-		"images-jobs-async-upload": "RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
-		"automl-ui-image":          "RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
-		"autorag-ui-image":         "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
+		"odh-dashboard-image":            "RELATED_IMAGE_ODH_DASHBOARD_IMAGE",
+		"model-registry-ui-image":        "RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE",
+		"gen-ai-ui-image":                "RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE",
+		"mlflow-ui-image":                "RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE",
+		"maas-ui-image":                  "RELATED_IMAGE_ODH_MOD_ARCH_MAAS_IMAGE",
+		"eval-hub-ui-image":              "RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE",
+		"kube-rbac-proxy":                "RELATED_IMAGE_OSE_KUBE_RBAC_PROXY_IMAGE",
+		"images-jobs-async-upload":       "RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE",
+		"automl-ui-image":                "RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE",
+		"automl-pipeline-runtime-image":  "RELATED_IMAGE_ODH_AUTOML_IMAGE",
+		"autorag-ui-image":               "RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE",
+		"autorag-pipeline-runtime-image": "RELATED_IMAGE_ODH_AUTORAG_IMAGE",
 	}
 
 	conditionTypes = []string{


### PR DESCRIPTION
## Summary

Backport of opendatahub-io/opendatahub-operator#3595 to `rhoai-3.4` for the 3.4.1 z-stream release.  Associated issue: https://issues.redhat.com/browse/RHOAIENG-64768. 

- Adds `imagesMap` entries for `automl-pipeline-runtime-image` → `RELATED_IMAGE_ODH_AUTOML_IMAGE` and `autorag-pipeline-runtime-image` → `RELATED_IMAGE_ODH_AUTORAG_IMAGE`
- Without these mappings, the operator has the `RELATED_IMAGE_*` env vars in the CSV but doesn't know to propagate them to the dashboard deployment
- The corresponding dashboard-side change (injecting these env vars onto automl/autorag sidecar containers) depends on this mapping being in place

## Upstream PR

https://github.com/opendatahub-io/opendatahub-operator/pull/3595 (merged 2026-06-01)

## Test plan

- [ ] Verify `golangci-lint` passes (alignment reformatting included)
- [ ] Verify operator builds successfully
- [ ] Deploy and confirm `RELATED_IMAGE_ODH_AUTOML_IMAGE` and `RELATED_IMAGE_ODH_AUTORAG_IMAGE` are propagated to dashboard deployment containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)