### PR TITLE
Add odh-ai-gateway-operator to manifests-config.yaml

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -95,6 +95,11 @@ map:
     dest: agentsoperator
     git.url: https://github.com/red-hat-data-services/agents-operator
     git.commit: 04d867d4e6aa82aee321b0cb97ca4ffb9e1dff74
+  odh-ai-gateway-operator:
+    src: config/manifests
+    dest: ai-gateway-operator
+    git.url: https://github.com/red-hat-data-services/ai-gateway-operator
+    git.commit: a094d7d2a068574b07fbbc52e75abee524221135
 additional_meta:
   odh-ai-gateway-payload-processing-e2e:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing


### PR DESCRIPTION
Adds 'odh-ai-gateway-operator' to the operator manifests config map.

Component: odh-ai-gateway-operator
Manifest source path: config/manifests
Manifest dest path:   ai-gateway-operator
Upstream repo: https://github.com/red-hat-data-services/ai-gateway-operator @ rhoai-3.5-ea.2
Jira: https://redhat.atlassian.net/browse/RHOAIENG-66477

**File changed:**
- `build/manifests-config.yaml` — added `odh-ai-gateway-operator` entry under `map:`