### PR TITLE
Harden GitHub Actions workflows against supply-chain attacks

### DIFF
--- a/.github/workflows/bundle-sync.yml
+++ b/.github/workflows/bundle-sync.yml
@@ -26,12 +26,12 @@ jobs:
     steps:
       - name: Generate github-app token
         id: app-token
-        uses: getsentry/action-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app_id: ${{ secrets.RHOAI_DEVOPS_APP_ID }}
-          private_key: ${{ secrets.RHOAI_DEVOPS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RHOAI_DEVOPS_APP_ID }}
+          private-key: ${{ secrets.RHOAI_DEVOPS_APP_PRIVATE_KEY }}
       - name: Checkout source repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: ${{ env.GITHUB_ORG }}/rhods-operator
           path: source_repo
@@ -39,7 +39,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout target repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
           path: target_repo
@@ -77,13 +77,10 @@ jobs:
           fi
 
       - name: Commit and push the changes to release branch
-        uses: actions-js/push@master
         if: ${{ steps.bundle-change-check.outputs.bundle_changes == 'present' }}
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          branch: ${{ github.ref_name }}
-          message: "Sync changes from source repo"
-          repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
-          directory: target_repo
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: target_repo
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Sync changes from source repo" && git push origin ${{ github.ref_name }})

--- a/.github/workflows/operator-insta-merge.yaml
+++ b/.github/workflows/operator-insta-merge.yaml
@@ -27,30 +27,28 @@ permissions:
   statuses: write
 
 jobs:
-  insta-merge:
+  check-files:
     #    we also have the author and title check to be on safer side since we are using pull_request_target event,
     if: ${{ github.event.sender.login == 'konflux-internal-p02[bot]'  && ( startsWith(github.event.pull_request.title, 'Update ') || startsWith(github.event.pull_request.title, 'chore(deps)') ) }}
     runs-on: ubuntu-latest
+    outputs:
+      feasible: ${{ steps.merge-feasibility-check.outputs.FEASIBLE }}
+      base_branch: ${{ steps.merge-feasibility-check.outputs.BASE_BRANCH }}
+      head_branch: ${{ steps.merge-feasibility-check.outputs.HEAD_BRANCH }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Get changed files using command
-        id: changes
-        run: |
-          echo $(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} )
-      - name: Get changed files
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
-      - name: List all changed files
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-        run: |
-          echo $ALL_CHANGED_FILES
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
-          done
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        with:
+          filters: |
+            nudging:
+              - 'build/operator-nudging.yaml'
+            all:
+              - '**'
 
       - name: Merge Feasibility Check
-        if: ${{ steps.changed-files.outputs.all_changed_files == 'build/operator-nudging.yaml' }}
+        if: ${{ steps.changed-files.outputs.all_count == '1' && steps.changed-files.outputs.nudging == 'true' }}
         id: merge-feasibility-check
         run: |
           # Declare variables
@@ -62,9 +60,9 @@ jobs:
           echo "HEAD_BRANCH=$HEAD_BRANCH"
 
           TITLE="${{ github.event.pull_request.title }}"
-          
+
           if [[ $TITLE == chore\(deps\)* ]]
-          then 
+          then
             TITLE=${TITLE/chore\(deps\): u/U}
           fi
           REGEX="^Update.*-$SUFFIX to [0-9a-z]{1,40}$"
@@ -82,25 +80,29 @@ jobs:
           echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_OUTPUT
           echo "HEAD_BRANCH=$HEAD_BRANCH" >> $GITHUB_OUTPUT
 
+  merge:
+    needs: check-files
+    if: ${{ needs.check-files.outputs.feasible == 'Yes' }}
+    runs-on: ubuntu-latest
+    steps:
       - name: Generate github-app token
         id: app-token
-        uses: getsentry/action-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app_id: ${{ secrets.RHOAI_DEVOPS_APP_ID }}
-          private_key: ${{ secrets.RHOAI_DEVOPS_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RHOAI_DEVOPS_APP_ID }}
+          private-key: ${{ secrets.RHOAI_DEVOPS_APP_PRIVATE_KEY }}
 
-      - uses: Wandalen/wretry.action@v3.5.0
-        if: ${{ steps.merge-feasibility-check.outputs.FEASIBLE == 'Yes' }}
+      - uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
         with:
-          action: red-hat-data-services/insta-merge@main
+          action: red-hat-data-services/insta-merge@47b53270117978bb95afa0ce4ccd4d80fe08644c # main
           retry_condition: steps._this.outputs.code == 0
           attempt_limit: 5
           github_token: ${{ steps.app-token.outputs.token }}
           with: |
             upstream_repo: "https://github.com/${GITHUB_ORG}/rhods-operator.git"
-            upstream_branch: "${{ steps.merge-feasibility-check.outputs.BASE_BRANCH }}"
+            upstream_branch: "${{ needs.check-files.outputs.base_branch }}"
             downstream_repo: "https://github.com/${GITHUB_ORG}/rhods-operator.git"
-            downstream_branch: "${{ steps.merge-feasibility-check.outputs.HEAD_BRANCH }}"
+            downstream_branch: "${{ needs.check-files.outputs.head_branch }}"
             token: ${{ steps.app-token.outputs.token }}
             resolve_conflicts_for: "${RESOLVE_CONFLICTS_FOR}"
             merge_args: "--no-edit"

--- a/.github/workflows/operator-processor.yaml
+++ b/.github/workflows/operator-processor.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout RBC repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
           ref: ${{ github.ref_name }}
@@ -35,7 +35,7 @@ jobs:
             bundle/bundle-patch.yaml
           sparse-checkout-cone-mode: false
       - name: Git checkout utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_ORG }}/RHOAI-Konflux-Automation
           ref: main
@@ -44,7 +44,7 @@ jobs:
             utils/processors
           sparse-checkout-cone-mode: false
       - name: Git checkout operator repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_ORG }}/rhods-operator
           ref: ${{ github.ref_name }}
@@ -261,15 +261,12 @@ jobs:
           tree
 
       - name: Commit and push the changes to release branch
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref_name }}
-          message: "Updating the operator repo with latest images and manifests"
-          repository: ${{ env.GITHUB_ORG }}/rhods-operator
-          directory: rhods-operator
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: rhods-operator
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Updating the operator repo with latest images and manifests" && git push origin ${{ github.ref_name }})
 
       - name: Upload debug logs
         if: always()

--- a/.github/workflows/trigger-nightly-operator-build.yaml
+++ b/.github/workflows/trigger-nightly-operator-build.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout RBC repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_ORG }}/RHOAI-Build-Config
           ref: ${{ github.ref_name }}
@@ -31,7 +31,7 @@ jobs:
             bundle/bundle-patch.yaml
           sparse-checkout-cone-mode: false
       - name: Git checkout utils
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_ORG }}/RHOAI-Konflux-Automation
           ref: main
@@ -40,7 +40,7 @@ jobs:
             utils/processors
           sparse-checkout-cone-mode: false
       - name: Git checkout operator repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: ${{ env.GITHUB_ORG }}/rhods-operator
           ref: ${{ github.ref_name }}
@@ -260,15 +260,12 @@ jobs:
           tree
 
       - name: Commit and push the changes to release branch
-        uses: actions-js/push@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref_name }}
-          message: "Updating the operator repo with latest images and manifests"
-          repository: ${{ env.GITHUB_ORG }}/rhods-operator
-          directory: rhods-operator
-          author_name: Openshift-AI DevOps
-          author_email: openshift-ai-devops@redhat.com
+        working-directory: rhods-operator
+        run: |
+          git config user.name "Openshift-AI DevOps"
+          git config user.email "openshift-ai-devops@redhat.com"
+          git add -A
+          git diff --staged --quiet || (git commit -m "Updating the operator repo with latest images and manifests" && git push origin ${{ github.ref_name }})
 
       - name: Upload debug logs
         if: always()


### PR DESCRIPTION
  - Replace third-party actions with official GitHub-maintained alternatives where available
  - Replace third-party actions with inline scripts where no official alternative exists
  - Pin all action references to immutable commit SHAs instead of mutable tags or branches
  - Isolate secret generation into separate jobs away from third-party actions