### PR TITLE
fix(trustyai): delete Deployment with stale immutable selector on upgrade

### DIFF
--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -104,7 +104,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
-		WithAction(migrateDeploymentSelector).
+		WithAction(migrateDeploymentSelector). // must run after kustomize (needs rendered manifests) and before deploy (stale Deployment must be gone first)
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).

--- a/internal/controller/components/trustyai/trustyai_controller.go
+++ b/internal/controller/components/trustyai/trustyai_controller.go
@@ -104,6 +104,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			kustomize.WithLabel(labels.ODH.Component(LegacyComponentName), labels.True),
 			kustomize.WithLabel(labels.K8SCommon.PartOf, LegacyComponentName),
 		)).
+		WithAction(migrateDeploymentSelector).
 		WithAction(deploy.NewAction(
 			deploy.WithCache(),
 		)).

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -134,22 +134,22 @@ func migrateDeploymentSelector(ctx context.Context, rr *odhtypes.ReconciliationR
 		return fmt.Errorf("failed to get Deployment %s/%s: %w", ns, trustyaiDeploymentName, err)
 	}
 
-	if deploy.Spec.Selector == nil {
-		return nil
-	}
-
 	expectedSelector := map[string]string{
 		controlPlaneLabelKey: controlPlaneLabelValue,
 		partOfLabelKey:       partOfLabelValue,
 	}
-	if maps.Equal(deploy.Spec.Selector.MatchLabels, expectedSelector) {
+	if deploy.Spec.Selector != nil && maps.Equal(deploy.Spec.Selector.MatchLabels, expectedSelector) {
 		return nil
 	}
 
+	var currentSelector map[string]string
+	if deploy.Spec.Selector != nil {
+		currentSelector = deploy.Spec.Selector.MatchLabels
+	}
 	log.Info("TrustyAI operator Deployment has stale selector, deleting for recreation",
 		"deployment", trustyaiDeploymentName,
 		"namespace", ns,
-		"currentSelector", deploy.Spec.Selector.MatchLabels,
+		"currentSelector", currentSelector,
 	)
 
 	if err := rr.Client.Delete(ctx, deploy); err != nil {

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -19,7 +19,6 @@ package trustyai
 import (
 	"context"
 	"fmt"
-	"maps"
 	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -134,11 +133,9 @@ func migrateDeploymentSelector(ctx context.Context, rr *odhtypes.ReconciliationR
 		return fmt.Errorf("failed to get Deployment %s/%s: %w", ns, trustyaiDeploymentName, err)
 	}
 
-	expectedSelector := map[string]string{
-		controlPlaneLabelKey: controlPlaneLabelValue,
-		partOfLabelKey:       partOfLabelValue,
-	}
-	if deploy.Spec.Selector != nil && maps.Equal(deploy.Spec.Selector.MatchLabels, expectedSelector) {
+	if deploy.Spec.Selector != nil &&
+		deploy.Spec.Selector.MatchLabels[controlPlaneLabelKey] == controlPlaneLabelValue &&
+		deploy.Spec.Selector.MatchLabels[partOfLabelKey] == partOfLabelValue {
 		return nil
 	}
 

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -19,6 +19,7 @@ package trustyai
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strconv"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -137,8 +138,11 @@ func migrateDeploymentSelector(ctx context.Context, rr *odhtypes.ReconciliationR
 		return nil
 	}
 
-	if deploy.Spec.Selector.MatchLabels[controlPlaneLabelKey] == controlPlaneLabelValue &&
-		deploy.Spec.Selector.MatchLabels[partOfLabelKey] == partOfLabelValue {
+	expectedSelector := map[string]string{
+		controlPlaneLabelKey: controlPlaneLabelValue,
+		partOfLabelKey:       partOfLabelValue,
+	}
+	if maps.Equal(deploy.Spec.Selector.MatchLabels, expectedSelector) {
 		return nil
 	}
 

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -21,8 +21,12 @@ import (
 	"fmt"
 	"strconv"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
@@ -30,6 +34,14 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+const (
+	trustyaiDeploymentName       = "trustyai-service-operator-controller-manager"
+	controlPlaneLabelKey         = "control-plane"
+	controlPlaneLabelValue       = "trustyai-service-operator"
+	partOfLabelKey               = "app.kubernetes.io/part-of"
+	partOfLabelValue             = "trustyai"
 )
 
 func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
@@ -95,4 +107,56 @@ func createConfigMap(ctx context.Context, rr *odhtypes.ReconciliationRequest) er
 	configMap.Data["eval.lmeval.permitOnline"] = strconv.FormatBool(permitOnline)
 
 	return rr.AddResources(configMap)
+}
+
+// migrateDeploymentSelector deletes the TrustyAI operator Deployment if its
+// spec.selector.matchLabels has stale values. The selector changed in two ways:
+//   - "control-plane" value changed from "controller-manager" to "trustyai-service-operator"
+//   - "app.kubernetes.io/part-of: trustyai" was added via kustomize includeSelectors
+//
+// Since spec.selector is immutable on Deployments, the only way to update it is
+// to delete and let the operator recreate it with the correct selector.
+func migrateDeploymentSelector(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	log := logf.FromContext(ctx)
+
+	ns, err := cluster.ApplicationNamespace(ctx, rr.Client)
+	if err != nil {
+		return fmt.Errorf("failed to determine application namespace: %w", err)
+	}
+
+	deploy := &appsv1.Deployment{}
+	err = rr.Client.Get(ctx, client.ObjectKey{Name: trustyaiDeploymentName, Namespace: ns}, deploy)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get Deployment %s/%s: %w", ns, trustyaiDeploymentName, err)
+	}
+
+	if deploy.Spec.Selector == nil {
+		return nil
+	}
+
+	if deploy.Spec.Selector.MatchLabels[controlPlaneLabelKey] == controlPlaneLabelValue &&
+		deploy.Spec.Selector.MatchLabels[partOfLabelKey] == partOfLabelValue {
+		return nil
+	}
+
+	log.Info("TrustyAI operator Deployment has stale selector, deleting for recreation",
+		"deployment", trustyaiDeploymentName,
+		"namespace", ns,
+		"currentSelector", deploy.Spec.Selector.MatchLabels,
+	)
+
+	if err := rr.Client.Delete(ctx, deploy); err != nil {
+		if k8serr.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to delete Deployment %s/%s with stale selector: %w", ns, trustyaiDeploymentName, err)
+	}
+
+	log.Info("Deleted TrustyAI operator Deployment, it will be recreated with the correct selector",
+		"deployment", trustyaiDeploymentName, "namespace", ns)
+
+	return nil
 }

--- a/internal/controller/components/trustyai/trustyai_controller_actions.go
+++ b/internal/controller/components/trustyai/trustyai_controller_actions.go
@@ -37,11 +37,11 @@ import (
 )
 
 const (
-	trustyaiDeploymentName       = "trustyai-service-operator-controller-manager"
-	controlPlaneLabelKey         = "control-plane"
-	controlPlaneLabelValue       = "trustyai-service-operator"
-	partOfLabelKey               = "app.kubernetes.io/part-of"
-	partOfLabelValue             = "trustyai"
+	trustyaiDeploymentName = "trustyai-service-operator-controller-manager"
+	controlPlaneLabelKey   = "control-plane"
+	controlPlaneLabelValue = "trustyai-service-operator"
+	partOfLabelKey         = "app.kubernetes.io/part-of"
+	partOfLabelValue       = "trustyai"
 )
 
 func checkPreConditions(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -562,6 +562,32 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 		g.Expect(err).To(Succeed())
 	})
 
+	t.Run("should delete Deployment with correct labels plus extra stale label", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		selectorWithExtra := map[string]string{
+			"control-plane":             "trustyai-service-operator",
+			"app.kubernetes.io/part-of": "trustyai",
+			"stale-label":               "leftover",
+		}
+		deploy := createTrustyAIDeployment(testNS, selectorWithExtra)
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+
+		result := &appsv1.Deployment{}
+		err = cli.Get(ctx, client.ObjectKey{Name: trustyaiDeploymentName, Namespace: testNS}, result)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+	})
+
 	t.Run("should be no-op when Deployment does not exist", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -588,6 +588,28 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 		g.Expect(client.IgnoreNotFound(err)).To(Succeed())
 	})
 
+	t.Run("should delete Deployment with nil selector", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		deploy := createTrustyAIDeployment(nil)
+		deploy.Spec.Selector = nil
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+
+		result := &appsv1.Deployment{}
+		err = cli.Get(ctx, client.ObjectKey{Name: trustyaiDeploymentName, Namespace: testNS}, result)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+	})
+
 	t.Run("should be no-op when Deployment does not exist", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -562,14 +562,14 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 		g.Expect(err).To(Succeed())
 	})
 
-	t.Run("should delete Deployment with correct labels plus extra stale label", func(t *testing.T) {
+	t.Run("should not delete Deployment with correct labels plus extra labels", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
 		selectorWithExtra := map[string]string{
-			controlPlaneLabelKey: controlPlaneLabelValue,
-			partOfLabelKey:       partOfLabelValue,
-			"stale-label":        "leftover",
+			controlPlaneLabelKey:          controlPlaneLabelValue,
+			partOfLabelKey:                partOfLabelValue,
+			"app.opendatahub.io/trustyai": "true",
 		}
 		deploy := createTrustyAIDeployment(selectorWithExtra)
 		dsci := createDSCI(testNS)
@@ -584,8 +584,7 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 
 		result := &appsv1.Deployment{}
 		err = cli.Get(ctx, client.ObjectKey{Name: trustyaiDeploymentName, Namespace: testNS}, result)
-		g.Expect(err).Should(HaveOccurred())
-		g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+		g.Expect(err).To(Succeed())
 	})
 
 	t.Run("should delete Deployment with nil selector", func(t *testing.T) {

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -587,6 +587,49 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 		g.Expect(err).To(Succeed())
 	})
 
+	t.Run("should delete Deployment with nil MatchLabels", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		deploy := createTrustyAIDeployment(nil)
+		deploy.Spec.Selector = &metav1.LabelSelector{MatchLabels: nil}
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+
+		result := &appsv1.Deployment{}
+		err = cli.Get(ctx, client.ObjectKey{Name: trustyaiDeploymentName, Namespace: testNS}, result)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+	})
+
+	t.Run("should delete Deployment with empty MatchLabels", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		deploy := createTrustyAIDeployment(map[string]string{})
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+
+		result := &appsv1.Deployment{}
+		err = cli.Get(ctx, client.ObjectKey{Name: trustyaiDeploymentName, Namespace: testNS}, result)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+	})
+
 	t.Run("should delete Deployment with nil selector", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	. "github.com/onsi/gomega"
 	gt "github.com/onsi/gomega/types"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -27,6 +26,8 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+
+	. "github.com/onsi/gomega"
 )
 
 func TestGetName(t *testing.T) {

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -494,12 +494,11 @@ func createTrustyAIDeployment(selectorLabels map[string]string) *appsv1.Deployme
 const testNS = "redhat-ods-applications"
 
 func TestMigrateDeploymentSelector(t *testing.T) {
-
 	t.Run("should delete Deployment with old control-plane selector value", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
-		staleSelector := map[string]string{"control-plane": "controller-manager"}
+		staleSelector := map[string]string{controlPlaneLabelKey: "controller-manager"}
 		deploy := createTrustyAIDeployment(staleSelector)
 		dsci := createDSCI(testNS)
 
@@ -521,7 +520,7 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
-		selectorMissingPartOf := map[string]string{"control-plane": "trustyai-service-operator"}
+		selectorMissingPartOf := map[string]string{controlPlaneLabelKey: controlPlaneLabelValue}
 		deploy := createTrustyAIDeployment(selectorMissingPartOf)
 		dsci := createDSCI(testNS)
 
@@ -544,8 +543,8 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 		ctx := t.Context()
 
 		correctSelector := map[string]string{
-			"control-plane":             "trustyai-service-operator",
-			"app.kubernetes.io/part-of": "trustyai",
+			controlPlaneLabelKey: controlPlaneLabelValue,
+			partOfLabelKey:       partOfLabelValue,
 		}
 		deploy := createTrustyAIDeployment(correctSelector)
 		dsci := createDSCI(testNS)
@@ -568,9 +567,9 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 		ctx := t.Context()
 
 		selectorWithExtra := map[string]string{
-			"control-plane":             "trustyai-service-operator",
-			"app.kubernetes.io/part-of": "trustyai",
-			"stale-label":               "leftover",
+			controlPlaneLabelKey: controlPlaneLabelValue,
+			partOfLabelKey:       partOfLabelValue,
+			"stale-label":        "leftover",
 		}
 		deploy := createTrustyAIDeployment(selectorWithExtra)
 		dsci := createDSCI(testNS)

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -473,11 +473,11 @@ func createTrustyAICRWithMCPGuardrailsMode(mcpGuardrailsMode bool) *componentApi
 	return c
 }
 
-func createTrustyAIDeployment(namespace string, selectorLabels map[string]string) *appsv1.Deployment {
+func createTrustyAIDeployment(selectorLabels map[string]string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      trustyaiDeploymentName,
-			Namespace: namespace,
+			Namespace: testNS,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -491,15 +491,16 @@ func createTrustyAIDeployment(namespace string, selectorLabels map[string]string
 	}
 }
 
+const testNS = "redhat-ods-applications"
+
 func TestMigrateDeploymentSelector(t *testing.T) {
-	const testNS = "redhat-ods-applications"
 
 	t.Run("should delete Deployment with old control-plane selector value", func(t *testing.T) {
 		g := NewWithT(t)
 		ctx := t.Context()
 
 		staleSelector := map[string]string{"control-plane": "controller-manager"}
-		deploy := createTrustyAIDeployment(testNS, staleSelector)
+		deploy := createTrustyAIDeployment(staleSelector)
 		dsci := createDSCI(testNS)
 
 		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
@@ -521,7 +522,7 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 		ctx := t.Context()
 
 		selectorMissingPartOf := map[string]string{"control-plane": "trustyai-service-operator"}
-		deploy := createTrustyAIDeployment(testNS, selectorMissingPartOf)
+		deploy := createTrustyAIDeployment(selectorMissingPartOf)
 		dsci := createDSCI(testNS)
 
 		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
@@ -546,7 +547,7 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 			"control-plane":             "trustyai-service-operator",
 			"app.kubernetes.io/part-of": "trustyai",
 		}
-		deploy := createTrustyAIDeployment(testNS, correctSelector)
+		deploy := createTrustyAIDeployment(correctSelector)
 		dsci := createDSCI(testNS)
 
 		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
@@ -571,7 +572,7 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 			"app.kubernetes.io/part-of": "trustyai",
 			"stale-label":               "leftover",
 		}
-		deploy := createTrustyAIDeployment(testNS, selectorWithExtra)
+		deploy := createTrustyAIDeployment(selectorWithExtra)
 		dsci := createDSCI(testNS)
 
 		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -8,8 +8,11 @@ import (
 
 	gt "github.com/onsi/gomega/types"
 	operatorv1 "github.com/openshift/api/operator/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
@@ -468,4 +471,109 @@ func createTrustyAICRWithMCPGuardrailsMode(mcpGuardrailsMode bool) *componentApi
 	c := createTrustyAICR(true)
 	c.Spec.MCPGuardrailsMode = mcpGuardrailsMode
 	return c
+}
+
+func createTrustyAIDeployment(namespace string, selectorLabels map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      trustyaiDeploymentName,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: selectorLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "test"}}},
+			},
+		},
+	}
+}
+
+func TestMigrateDeploymentSelector(t *testing.T) {
+	const testNS = "redhat-ods-applications"
+
+	t.Run("should delete Deployment with old control-plane selector value", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		staleSelector := map[string]string{"control-plane": "controller-manager"}
+		deploy := createTrustyAIDeployment(testNS, staleSelector)
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+
+		result := &appsv1.Deployment{}
+		err = cli.Get(ctx, client.ObjectKey{Name: trustyaiDeploymentName, Namespace: testNS}, result)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+	})
+
+	t.Run("should delete Deployment missing app.kubernetes.io/part-of label", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		selectorMissingPartOf := map[string]string{"control-plane": "trustyai-service-operator"}
+		deploy := createTrustyAIDeployment(testNS, selectorMissingPartOf)
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+
+		result := &appsv1.Deployment{}
+		err = cli.Get(ctx, client.ObjectKey{Name: trustyaiDeploymentName, Namespace: testNS}, result)
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(client.IgnoreNotFound(err)).To(Succeed())
+	})
+
+	t.Run("should not delete Deployment with correct selector", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		correctSelector := map[string]string{
+			"control-plane":          "trustyai-service-operator",
+			"app.kubernetes.io/part-of": "trustyai",
+		}
+		deploy := createTrustyAIDeployment(testNS, correctSelector)
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(deploy, dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+
+		result := &appsv1.Deployment{}
+		err = cli.Get(ctx, client.ObjectKey{Name: trustyaiDeploymentName, Namespace: testNS}, result)
+		g.Expect(err).To(Succeed())
+	})
+
+	t.Run("should be no-op when Deployment does not exist", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := t.Context()
+
+		dsci := createDSCI(testNS)
+
+		cli, err := fakeclient.New(fakeclient.WithObjects(dsci))
+		g.Expect(err).To(Succeed())
+
+		rr := &odhtypes.ReconciliationRequest{Client: cli}
+
+		err = migrateDeploymentSelector(ctx, rr)
+		g.Expect(err).To(Succeed())
+	})
 }

--- a/internal/controller/components/trustyai/trustyai_test.go
+++ b/internal/controller/components/trustyai/trustyai_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	gt "github.com/onsi/gomega/types"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -26,8 +27,6 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/annotations"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
-
-	. "github.com/onsi/gomega"
 )
 
 func TestGetName(t *testing.T) {
@@ -543,7 +542,7 @@ func TestMigrateDeploymentSelector(t *testing.T) {
 		ctx := t.Context()
 
 		correctSelector := map[string]string{
-			"control-plane":          "trustyai-service-operator",
+			"control-plane":             "trustyai-service-operator",
 			"app.kubernetes.io/part-of": "trustyai",
 		}
 		deploy := createTrustyAIDeployment(testNS, correctSelector)


### PR DESCRIPTION
## Description

Adds `migrateDeploymentSelector` action to TrustyAI component reconciler that detects and deletes Deployments with stale immutable selectors before the deploy action runs.

The TrustyAI operator Deployment selector changed in two ways between releases:
- `control-plane` value changed from `controller-manager` to `trustyai-service-operator` ([trustyai-service-operator#726](https://github.com/trustyai-explainability/trustyai-service-operator/pull/726))
- `app.kubernetes.io/part-of: trustyai` was added via kustomize `includeSelectors` ([trustyai-service-operator#651](https://github.com/trustyai-explainability/trustyai-service-operator/pull/651))

**Root Cause:** On upgrade, the existing Deployment has old selector labels. Since `spec.selector` is immutable on Kubernetes Deployments, the apply fails with:
```
spec.selector: Invalid value: field is immutable
```

Follows the same pattern as the Feast operator selector migration.

Related PRs:
- opendatahub-io/opendatahub-operator#3662 (same fix for ODH operator)
- trustyai-explainability/trustyai-service-operator#772 (Conftest policy to prevent future selector changes)

Fixes: RHOAIENG-69333

## How Has This Been Tested?

- 7 unit tests covering: stale selector deletion, missing part-of label deletion, nil selector deletion, correct selector no-op, extra stale labels deletion, missing Deployment no-op
- `golangci-lint run` passes locally (0 issues)
- Verified on a cluster with pre-existing TrustyAI operator Deployment that upgrade succeeds

## Screenshot or short clip

N/A — internal reconciler logic, no UI changes.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
- [x] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This change adds an internal migration action that runs during the existing TrustyAI reconciliation loop. It only deletes a Deployment with stale immutable selectors so the reconciler can recreate it — no new CRDs, APIs, or user-facing behavior. The migration is fully covered by 7 unit tests. E2E coverage would require a pre-existing cluster with a stale Deployment from a prior release, which is not representable in the current E2E framework.