### PR TITLE
offboard llm-d 3.5-ea.2

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -179,15 +179,9 @@ additional_meta:
   odh-llm-d-batch-gateway-processor:
     git.url: https://github.com/red-hat-data-services/batch-gateway
     git.commit: a578c647dafcc29b9a17768bae1343b638b187fe
-  odh-llm-d-inference-scheduler:
-    git.url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
-    git.commit: 22044e0f4deedcaa05a50aedfc6f3b2b15d1e7ab
   odh-llm-d-kv-cache:
     git.url: https://github.com/red-hat-data-services/llm-d-kv-cache
     git.commit: a0e7c4e36a664f3b3e53c5eb1ca295b460f58b94
-  odh-llm-d-routing-sidecar:
-    git.url: https://github.com/red-hat-data-services/llm-d-inference-scheduler
-    git.commit: 22044e0f4deedcaa05a50aedfc6f3b2b15d1e7ab
   odh-maas-controller:
     git.url: https://github.com/red-hat-data-services/models-as-a-service
     git.commit: 1312edee9de6730e315e710aad32d79eebdfe38d

--- a/build/operands-map.yaml
+++ b/build/operands-map.yaml
@@ -67,12 +67,8 @@ relatedImages:
   value: "quay.io/rhoai/odh-llm-d-batch-gateway-operator-rhel9@sha256:9d75138ab2a901d80b813f59137127dac12d6bb97f7531e066956383de087ca9"
 - name: RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE
   value: "quay.io/rhoai/odh-llm-d-batch-gateway-processor-rhel9@sha256:39851c28c7af3cbf53041d3134695c6914544ab21b6dc8a3de0135e34d14191e"
-- name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
-  value: "quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:f9d11f39a52cb80f5a62c27470c1170efd1861c47251e6a6c3a4a055fcb75865"
 - name: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
   value: "quay.io/rhoai/odh-llm-d-kv-cache-rhel9@sha256:32ac10d178218671c7afd0f091f5d100ead1b15275264bbe9f3a745e5dfe56a5"
-- name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
-  value: "quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:ce44d551c58db4c9768e91283a84b36eee8a1189ae07536aaa3bbf49968d04b2"
 - name: RELATED_IMAGE_ODH_MAAS_API_IMAGE
   value: "quay.io/rhoai/odh-maas-api-rhel9@sha256:b92feef97d6869e42b3941e5aba924dab2fe6d97425b8400a0d002ec13615d38"
 - name: RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE

--- a/build/operator-nudging.yaml
+++ b/build/operator-nudging.yaml
@@ -67,12 +67,8 @@ relatedImages:
   value: quay.io/rhoai/odh-llm-d-batch-gateway-operator-rhel9@sha256:9d75138ab2a901d80b813f59137127dac12d6bb97f7531e066956383de087ca9
 - name: RELATED_IMAGE_ODH_LLM_D_BATCH_GATEWAY_PROCESSOR_IMAGE
   value: quay.io/rhoai/odh-llm-d-batch-gateway-processor-rhel9@sha256:39851c28c7af3cbf53041d3134695c6914544ab21b6dc8a3de0135e34d14191e
-- name: RELATED_IMAGE_ODH_LLM_D_INFERENCE_SCHEDULER_IMAGE
-  value: quay.io/rhoai/odh-llm-d-inference-scheduler-rhel9@sha256:277edce9bcd9df46905f8278f603556fbe0d9351fa800971c750ba15ed11fb17
 - name: RELATED_IMAGE_ODH_LLM_D_KV_CACHE_IMAGE
   value: quay.io/rhoai/odh-llm-d-kv-cache-rhel9@sha256:32ac10d178218671c7afd0f091f5d100ead1b15275264bbe9f3a745e5dfe56a5
-- name: RELATED_IMAGE_ODH_LLM_D_ROUTING_SIDECAR_IMAGE
-  value: quay.io/rhoai/odh-llm-d-routing-sidecar-rhel9@sha256:5db37b2a4ae074b2007d21b99ca3d0d0f657725b0f1bd72fc9155709f3f7cdbc
 - name: RELATED_IMAGE_ODH_MAAS_API_IMAGE
   value: quay.io/rhoai/odh-maas-api-rhel9@sha256:b92feef97d6869e42b3941e5aba924dab2fe6d97425b8400a0d002ec13615d38
 - name: RELATED_IMAGE_ODH_MAAS_CONTROLLER_IMAGE


### PR DESCRIPTION
Offboarding llm-d-inference-scheduler and llm-d-routing-sidecar following the succesfull onboarding of llm-d-router-endpoint-picker and llm-d-disagg-sidecar 

jira for offboarding https://redhat.atlassian.net/browse/RHOAIENG-65205

onboarding jiras 
disagg https://redhat.atlassian.net/browse/RHOAIENG-69738
endpoint-picker https://redhat.atlassian.net/browse/RHOAIENG-69343