### PR TITLE
[backport-3.4] fix: enable MLflow operator by default in the default DSC

### DIFF
--- a/config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -51,7 +51,7 @@ metadata:
               "managementState": "Removed"
             },
             "mlflowoperator": {
-              "managementState": "Removed"
+              "managementState": "Managed"
             },
             "sparkoperator": {
               "managementState": "Removed"

--- a/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -36,6 +36,6 @@ spec:
     llamastackoperator:
       managementState: "Removed"
     mlflowoperator:
-      managementState: "Removed"
+      managementState: "Managed"
     sparkoperator:
       managementState: "Removed"

--- a/config/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -37,6 +37,6 @@ spec:
     llamastackoperator:
       managementState: "Removed"
     mlflowoperator:
-      managementState: "Removed"
+      managementState: "Managed"
     sparkoperator:
       managementState: "Removed"

--- a/pkg/initialinstall/creation.go
+++ b/pkg/initialinstall/creation.go
@@ -65,7 +65,7 @@ func CreateDefaultDSC(ctx context.Context, cli client.Client) error {
 					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Removed},
 				},
 				MLflowOperator: componentApi.DSCMLflowOperator{
-					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Removed},
+					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},
 				},
 				Trainer: componentApi.DSCTrainer{
 					ManagementSpec: common.ManagementSpec{ManagementState: operatorv1.Managed},


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Backport of https://github.com/opendatahub-io/opendatahub-operator/pull/3623
Change the default `DataScienceCluster` created by the operator so `MLflowOperator` is `Managed` instead of `Removed`.

This ensures MLflow is enabled out of the box in both ODH and RHOAI environments, including disconnected installs where the operator-created default DSC is the only configuration source.

Updated in four places to keep them in sync:
- `pkg/initialinstall/creation.go` — the operator's programmatic default DSC
- `config/samples/datasciencecluster_v2_datasciencecluster.yaml` — ODH sample shown in OperatorHub
- `config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml` — RHOAI sample
- `config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml` — OLM `initialization-resource` annotation used for auto-creation of the default DSC

Jira: [RHOAIENG-67648](https://redhat.atlassian.net/browse/RHOAIENG-67648)
<!--- Link your JIRA and related links here for reference. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Verified `make lint` passes with 0 issues.
- Verified `go vet` and `go test -c` compile cleanly for both `pkg/initialinstall/...` and `tests/e2e/...`.
- Confirmed all four changed files (`creation.go`, both sample YAMLs, CSV annotation) are consistent.
- E2E test files are unchanged — the existing `mlflowoperator_test.go` suite already exercises the full `Removed→Managed→Removed` lifecycle via the standard `ValidateComponentEnabled`/`ValidateComponentDisabled` pattern.

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you are not opting out of the E2E requirement -->
This change only modifies the default management state for MLflowOperator from Removed to Managed. The existing E2E suite already covers the MLflowOperator lifecycle (enable/disable/deletion-recovery) via `mlflowoperator_test.go` and the MLflow integration path via `workbenches_test.go`. No new behavior is introduced that requires additional test coverage.