### PR TITLE
feat(ci): add workflow to trigger odh-gitops helm chart sync on manifest changes

### DIFF
--- a/.github/workflows/trigger-gitops-sync.yaml
+++ b/.github/workflows/trigger-gitops-sync.yaml
@@ -1,0 +1,39 @@
+# Prerequisites:
+# - The ODH DevOps GitHub App (secrets ODH_DEVOPS_APP_ID / ODH_DEVOPS_APP_PRIVATE_KEY)
+#   must be installed on opendatahub-io/odh-gitops with contents:write permission.
+
+name: Trigger GitOps Helm Chart Sync
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # CRD type definitions — controller-gen produces CRDs from these
+      - 'api/**'
+      # Controller RBAC markers — controller-gen produces ClusterRoles from these
+      - 'internal/controller/**'
+      # RHOAI kustomize overlays — the entry point for kustomize build
+      - 'config/rhaii/rhoai/**'
+      - 'config/rhoai/**'
+      # Cloud manager kustomize overlays
+      - 'config/cloudmanager/**'
+
+jobs:
+  notify-gitops:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate github-app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app_id: ${{ secrets.ODH_DEVOPS_APP_ID }}
+          private_key: ${{ secrets.ODH_DEVOPS_APP_PRIVATE_KEY }}
+
+      - name: Dispatch sync to odh-gitops
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          repository: opendatahub-io/odh-gitops
+          event-type: operator-manifest-update
+          client-payload: '{"branch": "${{ github.ref_name }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION

## Description

When manifest-relevant files (api/, internal/controller/, config/rhaii/rhoai/, config/rhoai/, config/cloudmanager/) are merged to main or rhoai-* branches, dispatch a repository_dispatch event to odh-gitops so the helm chart sync runs reactively instead of waiting for the daily schedule.

Ref: RHOAIENG-63322



## How Has This Been Tested?
Not really testable - simple workflow change

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
