### PR TITLE
fix: create bundle after webhook removal

### DIFF
--- a/bundle/manifests/rhods-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/rhods-operator.clusterserviceversion.yaml
@@ -113,7 +113,7 @@ metadata:
     categories: AI/Machine Learning, Big Data
     certified: "False"
     containerImage: REPLACE_IMAGE:latest
-    createdAt: "2026-01-02T12:34:28Z"
+    createdAt: "2026-06-29T18:28:12Z"
     description: Operator for deployment and management of Red Hat OpenShift AI
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -1852,66 +1852,3 @@ spec:
     targetPort: 9443
     type: MutatingAdmissionWebhook
     webhookPath: /mutate-hardware-profile
-  - admissionReviewVersions:
-    - v1
-    containerPort: 443
-    deploymentName: rhods-operator
-    failurePolicy: Fail
-    generateName: kserve-kueuelabels-validator.opendatahub.io
-    rules:
-    - apiGroups:
-      - serving.kserve.io
-      apiVersions:
-      - v1beta1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - inferenceservices
-    sideEffects: None
-    targetPort: 9443
-    type: ValidatingAdmissionWebhook
-    webhookPath: /validate-kueue
-  - admissionReviewVersions:
-    - v1
-    containerPort: 443
-    deploymentName: rhods-operator
-    failurePolicy: Fail
-    generateName: kubeflow-kueuelabels-validator.opendatahub.io
-    rules:
-    - apiGroups:
-      - kubeflow.org
-      apiVersions:
-      - v1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - pytorchjobs
-      - notebooks
-    sideEffects: None
-    targetPort: 9443
-    type: ValidatingAdmissionWebhook
-    webhookPath: /validate-kueue
-  - admissionReviewVersions:
-    - v1
-    containerPort: 443
-    deploymentName: rhods-operator
-    failurePolicy: Fail
-    generateName: ray-kueuelabels-validator.opendatahub.io
-    rules:
-    - apiGroups:
-      - ray.io
-      apiVersions:
-      - v1
-      - v1alpha1
-      operations:
-      - CREATE
-      - UPDATE
-      resources:
-      - rayjobs
-      - rayclusters
-    sideEffects: None
-    targetPort: 9443
-    type: ValidatingAdmissionWebhook
-    webhookPath: /validate-kueue

--- a/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -253,7 +253,7 @@ spec:
   - llamastack
   links:
   - name: Red Hat OpenShift AI
-    url: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2.23.0
+    url: https://docs.redhat.com/en/documentation/red_hat_openshift_ai_self-managed/2.25
   maintainers:
   - email: managed-open-data-hub@redhat.com
     name: Red Hat Openshift AI


### PR DESCRIPTION
<!--- 
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

- Removes three `ValidatingAdmissionWebhook` entries from the CSV bundle manifest that registered kueue label validators for InferenceServices, PyTorchJobs, Notebooks, RayJobs, and RayClusters — these webhooks were removed from the operator but the CSV was not updated accordingly

Jira task: https://issues.redhat.com/browse/RHOAIENG-72262

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Bundle generated via `make bundle` (or equivalent) and verified the removed webhooks no longer appear in the CSV
- Confirmed the operator deploys without errors referencing the removed webhook paths

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [x] The developer has run the integration test pipeline and verified that it passed successfully
