### PR TITLE
fix(modelsasservice): [3.4] add NetworkPolicy for payload-processing on OCP 4.22

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -160,6 +160,8 @@ func AppendOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconcilia
 	}
 	extra = append(extra, *paramsCM)
 
+	extra = append(extra, payloadProcessingNetworkPolicy(componentLabels))
+
 	sortedExtra, err := resources.SortByApplyOrder(ctx, extra)
 	if err != nil {
 		return fmt.Errorf("sort maas-controller install bundle: %w", err)
@@ -205,6 +207,92 @@ func maasParametersConfigMapFromParamsEnv(manifestsBasePath string, appNs string
 		},
 	}
 	return cm, nil
+}
+
+// payloadProcessingNetworkPolicy returns a NetworkPolicy for the
+// payload-processing pod in the gateway namespace. OCP 4.22 introduced a
+// deny-all NetworkPolicy in openshift-ingress; without explicit rules the pod
+// cannot reach the Kubernetes API server (egress) or receive ext_proc calls
+// from the gateway (ingress).
+func payloadProcessingNetworkPolicy(componentLabels map[string]string) unstructured.Unstructured {
+	npLabels := make(map[string]any, len(componentLabels)+1)
+	for k, v := range componentLabels {
+		npLabels[k] = v
+	}
+	npLabels["app"] = "payload-processing"
+
+	return unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "networking.k8s.io/v1",
+			"kind":       "NetworkPolicy",
+			"metadata": map[string]any{
+				"name":      "payload-processing",
+				"namespace": DefaultGatewayNamespace,
+				"labels":    npLabels,
+			},
+			"spec": map[string]any{
+				"podSelector": map[string]any{
+					"matchLabels": map[string]any{
+						"app": "payload-processing",
+					},
+				},
+				"policyTypes": []any{"Ingress", "Egress"},
+				"ingress": []any{
+					map[string]any{
+						"from": []any{
+							map[string]any{
+								"podSelector": map[string]any{
+									"matchLabels": map[string]any{
+										"gateway.networking.k8s.io/gateway-name": "data-science-gateway",
+									},
+								},
+								"namespaceSelector": map[string]any{
+									"matchLabels": map[string]any{
+										"kubernetes.io/metadata.name": DefaultGatewayNamespace,
+									},
+								},
+							},
+						},
+						"ports": []any{
+							map[string]any{
+								"protocol": "TCP",
+								"port":     int64(9004),
+							},
+						},
+					},
+					map[string]any{
+						"from": []any{
+							map[string]any{
+								"namespaceSelector": map[string]any{
+									"matchLabels": map[string]any{
+										"kubernetes.io/metadata.name": "openshift-monitoring",
+									},
+								},
+							},
+							map[string]any{
+								"namespaceSelector": map[string]any{
+									"matchLabels": map[string]any{
+										"kubernetes.io/metadata.name": "openshift-user-workload-monitoring",
+									},
+								},
+							},
+						},
+						"ports": []any{
+							map[string]any{
+								"protocol": "TCP",
+								"port":     int64(9005),
+							},
+							map[string]any{
+								"protocol": "TCP",
+								"port":     int64(9090),
+							},
+						},
+					},
+				},
+				"egress": []any{map[string]any{}},
+			},
+		},
+	}
 }
 
 // parseParamsEnv reads a key=value env file, skipping comments and blank lines.
@@ -262,6 +350,7 @@ var gatewayNamespaceResources = map[resourceKey]bool{
 	{kind: "Service", name: "payload-processing"}:                   true,
 	{kind: "ServiceAccount", name: "payload-processing"}:            true,
 	{kind: "ConfigMap", name: "payload-processing-plugins"}:         true,
+	{kind: "NetworkPolicy", name: "payload-processing"}:             true,
 	{kind: "ClusterRoleBinding", name: "payload-processing-reader"}: true,
 }
 

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -56,6 +56,13 @@ metadata:
   name: payload-processing-plugins
   namespace: redhat-ods-applications
 `,
+		`
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: payload-processing
+  namespace: redhat-ods-applications
+`,
 		// Unrelated resource that should NOT be moved
 		`
 apiVersion: apps/v1
@@ -178,6 +185,50 @@ roleRef:
 		g.Expect(subj["namespace"]).To(Equal("openshift-ingress"),
 			"subjects[%d].namespace should be restored", i)
 	}
+}
+
+func TestPayloadProcessingNetworkPolicy(t *testing.T) {
+	g := NewWithT(t)
+
+	labels := map[string]string{
+		"opendatahub.io/component":  "true",
+		"app.kubernetes.io/part-of": "modelsasservice",
+	}
+
+	np := payloadProcessingNetworkPolicy(labels)
+
+	g.Expect(np.GetKind()).To(Equal("NetworkPolicy"))
+	g.Expect(np.GetName()).To(Equal("payload-processing"))
+	g.Expect(np.GetNamespace()).To(Equal(DefaultGatewayNamespace))
+
+	npLabels := np.GetLabels()
+	g.Expect(npLabels).To(HaveKeyWithValue("app", "payload-processing"))
+	g.Expect(npLabels).To(HaveKeyWithValue("opendatahub.io/component", "true"))
+	g.Expect(npLabels).To(HaveKeyWithValue("app.kubernetes.io/part-of", "modelsasservice"))
+
+	spec, ok := np.Object["spec"].(map[string]any)
+	g.Expect(ok).To(BeTrue(), "spec should be a map")
+
+	podSelector, ok := spec["podSelector"].(map[string]any)
+	g.Expect(ok).To(BeTrue(), "podSelector should be a map")
+	matchLabels, ok := podSelector["matchLabels"].(map[string]any)
+	g.Expect(ok).To(BeTrue(), "matchLabels should be a map")
+	g.Expect(matchLabels).To(HaveKeyWithValue("app", "payload-processing"))
+
+	policyTypes, ok := spec["policyTypes"].([]any)
+	g.Expect(ok).To(BeTrue(), "policyTypes should be an array")
+	g.Expect(policyTypes).To(ConsistOf("Ingress", "Egress"))
+
+	// Verify egress allows all outbound traffic
+	egress, ok := spec["egress"].([]any)
+	g.Expect(ok).To(BeTrue(), "egress should be an array")
+	g.Expect(egress).To(HaveLen(1))
+	g.Expect(egress[0]).To(Equal(map[string]any{}))
+
+	// Verify ingress rules: gateway on 9004, monitoring on 9090
+	ingress, ok := spec["ingress"].([]any)
+	g.Expect(ok).To(BeTrue(), "ingress should be an array")
+	g.Expect(ingress).To(HaveLen(2))
 }
 
 func TestRestoreCRBSubjectsNamespace_NoSubjects(t *testing.T) {

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -76,6 +76,7 @@ func modelsAsServiceTestSuite(t *testing.T) {
 		{"Validate Tenant CR in subscription namespace", componentCtx.ValidateTenantInSubscriptionNamespace},
 		{"Validate Tenant CRD is namespace-scoped", componentCtx.ValidateTenantCRDNamespaceScoped},
 		{"Validate Tenant singleton enforcement", componentCtx.ValidateTenantSingletonEnforcement},
+		{"Validate payload-processing egress NetworkPolicy", componentCtx.ValidatePayloadProcessingNetworkPolicy},
 		{"Validate Tenant deleted on disable", componentCtx.ValidateTenantDeletedOnDisable},
 	}
 
@@ -297,6 +298,32 @@ func (tc *ModelsAsServiceTestCtx) ValidateTenantSingletonEnforcement(t *testing.
 	t.Cleanup(func() {
 		_ = tc.Client().Delete(tc.Context(), u)
 	})
+}
+
+// ValidatePayloadProcessingNetworkPolicy verifies that the NetworkPolicy for
+// payload-processing exists in the gateway namespace with correct ingress and
+// egress rules.
+func (tc *ModelsAsServiceTestCtx) ValidatePayloadProcessingNetworkPolicy(t *testing.T) {
+	t.Helper()
+	skipUnless(t, Tier1)
+
+	t.Logf("Validating NetworkPolicy for payload-processing in %s", maasGatewayNamespace)
+
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.NetworkPolicy, types.NamespacedName{
+			Name:      "payload-processing",
+			Namespace: maasGatewayNamespace,
+		}),
+		WithCondition(And(
+			jq.Match(`.spec.podSelector.matchLabels.app == "payload-processing"`),
+			jq.Match(`.spec.policyTypes | any(. == "Ingress")`),
+			jq.Match(`.spec.policyTypes | any(. == "Egress")`),
+			jq.Match(`.spec.ingress | length == 2`),
+			jq.Match(`.spec.egress | length == 1`),
+			jq.Match(`.spec.egress[0] == {}`),
+		)),
+		WithCustomErrorMsg("NetworkPolicy should exist with correct ingress and egress rules for payload-processing in %s", maasGatewayNamespace),
+	)
 }
 
 // ValidateTenantDeletedOnDisable verifies that the Tenant CR is cleaned up when MaaS is


### PR DESCRIPTION
## Description

Jira: [RHOAIENG-71268](https://redhat.atlassian.net/browse/RHOAIENG-71268)

Cherry-pick of [opendatahub-io/opendatahub-operator#3699](https://github.com/opendatahub-io/opendatahub-operator/pull/3699) for rhoai-3.4 backport.

OCP 4.22 introduced a deny-all NetworkPolicy in openshift-ingress. The payload-processing pod had no NetworkPolicy, causing CrashLoopBackOff (egress blocked) and silent ext_proc failure (ingress blocked).

### Related PRs
- Upstream (main): [opendatahub-io/opendatahub-operator#3699](https://github.com/opendatahub-io/opendatahub-operator/pull/3699)
- Backport 3.5-ea.2: pending