### PR TITLE
fix(modelsasservice): [3.5-ea.2] extend NetworkPolicy to cover payload-pre-processing

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_controller.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller.go
@@ -83,6 +83,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			deployments.WithSelectorLabel(labels.ODH.Component(componentApi.ModelsAsServiceComponentName), labels.True),
 		)).
 		WithAction(gc.NewAction()).
+		WithAction(cleanupGatewayNamespaceResources).
 		WithConditions(conditionTypes...).
 		Build(ctx)
 

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -20,7 +20,13 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 )
 
@@ -38,6 +44,63 @@ func renderMaasOperatorInstall(ctx context.Context, rr *odhtypes.ReconciliationR
 	rr.Resources = nil
 	if err := rr.AddResources(out...); err != nil {
 		return fmt.Errorf("add maas-controller install manifest: %w", err)
+	}
+
+	return nil
+}
+
+// cleanupGatewayNamespaceResources deletes resources in the gateway namespace
+// that have the MaaS component label but are no longer in the rendered manifests.
+// Standard gc.NewAction() only covers the operator namespace; resources deployed
+// cross-namespace (e.g. payload-processing in openshift-ingress) need explicit cleanup.
+func cleanupGatewayNamespaceResources(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	l := log.FromContext(ctx)
+	componentLabel := labels.ODH.Component(componentApi.ModelsAsServiceComponentName)
+
+	// Build set of expected resources from the current rendered manifests.
+	type objKey struct {
+		gvk       schema.GroupVersionKind
+		namespace string
+		name      string
+	}
+	expected := make(map[objKey]bool)
+	for i := range rr.Resources {
+		res := &rr.Resources[i]
+		if res.GetNamespace() == DefaultGatewayNamespace {
+			expected[objKey{gvk: res.GroupVersionKind(), namespace: res.GetNamespace(), name: res.GetName()}] = true
+		}
+	}
+
+	// GVKs to scan in the gateway namespace.
+	gvks := []schema.GroupVersionKind{
+		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Version: "v1", Kind: "Service"},
+		{Version: "v1", Kind: "ServiceAccount"},
+		{Version: "v1", Kind: "ConfigMap"},
+		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+	}
+
+	for _, gvk := range gvks {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(gvk)
+		if err := rr.Client.List(ctx, list,
+			client.InNamespace(DefaultGatewayNamespace),
+			client.MatchingLabels{componentLabel: labels.True},
+		); err != nil {
+			continue
+		}
+		for i := range list.Items {
+			item := &list.Items[i]
+			k := objKey{gvk: item.GroupVersionKind(), namespace: item.GetNamespace(), name: item.GetName()}
+			if expected[k] {
+				continue
+			}
+			l.Info("deleting stale gateway namespace resource",
+				"kind", item.GetKind(), "name", item.GetName(), "ns", item.GetNamespace())
+			if err := rr.Client.Delete(ctx, item); client.IgnoreNotFound(err) != nil {
+				return fmt.Errorf("delete stale %s %s/%s: %w", item.GetKind(), item.GetNamespace(), item.GetName(), err)
+			}
+		}
 	}
 
 	return nil

--- a/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_controller_actions.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 )
 
 func renderMaasOperatorInstall(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
@@ -87,7 +87,7 @@ func cleanupGatewayNamespaceResources(ctx context.Context, rr *odhtypes.Reconcil
 			client.InNamespace(DefaultGatewayNamespace),
 			client.MatchingLabels{componentLabel: labels.True},
 		); err != nil {
-			continue
+			return fmt.Errorf("list gateway namespace %s resources: %w", gvk.String(), err)
 		}
 		for i := range list.Items {
 			item := &list.Items[i]

--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -226,11 +226,11 @@ func maasParametersConfigMapFromParamsEnv(manifestsBasePath string, appNs string
 	return cm, nil
 }
 
-// payloadProcessingNetworkPolicy returns a NetworkPolicy for the
-// payload-processing pod in the gateway namespace. OCP 4.22 introduced a
-// deny-all NetworkPolicy in openshift-ingress; without explicit rules the pod
-// cannot reach the Kubernetes API server (egress) or receive ext_proc calls
-// from the gateway (ingress).
+// payloadProcessingNetworkPolicy returns a NetworkPolicy for both the
+// payload-processing and payload-pre-processing pods in the gateway namespace.
+// OCP 4.22 introduced a deny-all NetworkPolicy in openshift-ingress; without
+// explicit rules the pods cannot reach the Kubernetes API server (egress) or
+// receive ext_proc calls from the gateway (ingress).
 func payloadProcessingNetworkPolicy(componentLabels map[string]string) unstructured.Unstructured {
 	npLabels := make(map[string]any, len(componentLabels)+1)
 	for k, v := range componentLabels {
@@ -249,8 +249,12 @@ func payloadProcessingNetworkPolicy(componentLabels map[string]string) unstructu
 			},
 			"spec": map[string]any{
 				"podSelector": map[string]any{
-					"matchLabels": map[string]any{
-						"app": "payload-processing",
+					"matchExpressions": []any{
+						map[string]any{
+							"key":      "app",
+							"operator": "In",
+							"values":   []any{"payload-processing", "payload-pre-processing"},
+						},
 					},
 				},
 				"policyTypes": []any{"Ingress", "Egress"},
@@ -364,7 +368,9 @@ type resourceKey struct {
 // kind+name to avoid accidentally matching unrelated resources.
 var gatewayNamespaceResources = map[resourceKey]bool{
 	{kind: "Deployment", name: "payload-processing"}:                true,
+	{kind: "Deployment", name: "payload-pre-processing"}:            true,
 	{kind: "Service", name: "payload-processing"}:                   true,
+	{kind: "Service", name: "payload-pre-processing"}:               true,
 	{kind: "ServiceAccount", name: "payload-processing"}:            true,
 	{kind: "ConfigMap", name: "payload-processing-plugins"}:         true,
 	{kind: "NetworkPolicy", name: "payload-processing"}:             true,

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -211,9 +211,14 @@ func TestPayloadProcessingNetworkPolicy(t *testing.T) {
 
 	podSelector, ok := spec["podSelector"].(map[string]any)
 	g.Expect(ok).To(BeTrue(), "podSelector should be a map")
-	matchLabels, ok := podSelector["matchLabels"].(map[string]any)
-	g.Expect(ok).To(BeTrue(), "matchLabels should be a map")
-	g.Expect(matchLabels).To(HaveKeyWithValue("app", "payload-processing"))
+	matchExpressions, ok := podSelector["matchExpressions"].([]any)
+	g.Expect(ok).To(BeTrue(), "matchExpressions should be an array")
+	g.Expect(matchExpressions).To(HaveLen(1))
+	expr, ok := matchExpressions[0].(map[string]any)
+	g.Expect(ok).To(BeTrue())
+	g.Expect(expr["key"]).To(Equal("app"))
+	g.Expect(expr["operator"]).To(Equal("In"))
+	g.Expect(expr["values"]).To(ConsistOf("payload-processing", "payload-pre-processing"))
 
 	policyTypes, ok := spec["policyTypes"].([]any)
 	g.Expect(ok).To(BeTrue(), "policyTypes should be an array")

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -315,8 +315,8 @@ func (tc *ModelsAsServiceTestCtx) ValidateTenantSingletonEnforcement(t *testing.
 }
 
 // ValidatePayloadProcessingNetworkPolicy verifies that the NetworkPolicy for
-// payload-processing exists in the gateway namespace with correct ingress and
-// egress rules.
+// payload-processing and payload-pre-processing exists in the gateway namespace
+// with correct ingress and egress rules.
 func (tc *ModelsAsServiceTestCtx) ValidatePayloadProcessingNetworkPolicy(t *testing.T) {
 	t.Helper()
 	skipUnless(t, Tier1)
@@ -329,7 +329,10 @@ func (tc *ModelsAsServiceTestCtx) ValidatePayloadProcessingNetworkPolicy(t *test
 			Namespace: maasGatewayNamespace,
 		}),
 		WithCondition(And(
-			jq.Match(`.spec.podSelector.matchLabels.app == "payload-processing"`),
+			jq.Match(`.spec.podSelector.matchExpressions | length == 1`),
+			jq.Match(`.spec.podSelector.matchExpressions[0].key == "app"`),
+			jq.Match(`.spec.podSelector.matchExpressions[0].operator == "In"`),
+			jq.Match(`.spec.podSelector.matchExpressions[0].values | sort == ["payload-pre-processing", "payload-processing"]`),
 			jq.Match(`.spec.policyTypes | any(. == "Ingress")`),
 			jq.Match(`.spec.policyTypes | any(. == "Egress")`),
 			jq.Match(`.spec.ingress | length == 2`),


### PR DESCRIPTION
## Summary
- Extend the payload-processing NetworkPolicy to also cover `payload-pre-processing` pods, which were introduced in 3.5EA2
- Switch `podSelector` from `matchLabels` to `matchExpressions` with `In` operator to match both `payload-processing` and `payload-pre-processing` in a single NetworkPolicy
- Add `payload-pre-processing` Deployment and Service to the gateway namespace resource allowlist

Cherry-pick of opendatahub-io/opendatahub-operator#3731 onto `rhoai-3.5-ea.2`. Builds on top of #33675. Without this change, `payload-pre-processing` pods will CrashLoopBackOff on OCP 4.22 due to the deny-all NetworkPolicy in `openshift-ingress`.

## Test plan
- [x] Unit tests pass (`TestPayloadProcessingNetworkPolicy`, `TestRestoreGatewayNamespaceResources`)
- [ ] Deploy on OCP 4.22 cluster and verify both payload-processing and payload-pre-processing pods are Running

Jira: RHOAIENG-71268

🤖 Generated with [Claude Code](https://claude.com/claude-code)