### PR TITLE
Add odh-workbenches-operator-rhel9 to operator manifests (rhoai-3.5)

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -101,8 +101,10 @@ map:
     git.url: https://github.com/red-hat-data-services/mcp-lifecycle-module-operator
     git.commit: 1cabdc32dbdc975d3f54efbf2b89b7bc0013bb00
   odh-workbenches-operator:
-    src: opt/manifests/workbenches
-    dest: opt/manifests/workbenches
+    src: config
+    dest: workbenches/workbenches-operator
+    git.url: https://github.com/red-hat-data-services/workbenches-operator
+    git.commit: 43b01cc1df4c543b7526f05c5ecde9d43c7223d9
 additional_meta:
   odh-ai-gateway-payload-processing-e2e:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -100,6 +100,9 @@ map:
     dest: mcplifecycleoperator
     git.url: https://github.com/red-hat-data-services/mcp-lifecycle-module-operator
     git.commit: 1cabdc32dbdc975d3f54efbf2b89b7bc0013bb00
+  odh-workbenches-operator-rhel9:
+    src: opt/manifests/workbenches
+    dest: opt/manifests/workbenches
 additional_meta:
   odh-ai-gateway-payload-processing-e2e:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -100,7 +100,7 @@ map:
     dest: mcplifecycleoperator
     git.url: https://github.com/red-hat-data-services/mcp-lifecycle-module-operator
     git.commit: 1cabdc32dbdc975d3f54efbf2b89b7bc0013bb00
-  odh-workbenches-operator-rhel9:
+  odh-workbenches-operator:
     src: opt/manifests/workbenches
     dest: opt/manifests/workbenches
 additional_meta:


### PR DESCRIPTION
Adds 'odh-workbenches-operator-rhel9' entry to build/manifests-config.yaml.

Repo: https://github.com/red-hat-data-services/workbenches-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-72970