### PR TITLE
Add odh-feast-module-operator to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -107,8 +107,9 @@ map:
     git.url: https://github.com/red-hat-data-services/mcp-lifecycle-module-operator
     git.commit: 1cabdc32dbdc975d3f54efbf2b89b7bc0013bb00
   odh-feast-module-operator:
-    src: config/manifests
-    dest: config/manifests
+    src: config/chart
+    dest: feastoperator
+    type: chart
 additional_meta:
   odh-ai-gateway-payload-processing-e2e:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -106,6 +106,9 @@ map:
     dest: mcplifecycleoperator
     git.url: https://github.com/red-hat-data-services/mcp-lifecycle-module-operator
     git.commit: 1cabdc32dbdc975d3f54efbf2b89b7bc0013bb00
+  odh-feast-module-operator:
+    src: config/manifests
+    dest: config/manifests
 additional_meta:
   odh-ai-gateway-payload-processing-e2e:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing


### PR DESCRIPTION
Adds 'odh-feast-module-operator' entry to build/manifests-config.yaml.

Repo: https://github.com/red-hat-data-services/feast-module-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-75017