### PR TITLE
refactor(modelsasservice): [3.5] move NetworkPolicy to upstream manifests

### DIFF
--- a/internal/controller/components/modelsasservice/modelsasservice_support.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support.go
@@ -191,8 +191,6 @@ func buildMaasOperatorInstallManifests(ctx context.Context, rr *odhtypes.Reconci
 	}
 	extra = append(extra, *paramsCM)
 
-	extra = append(extra, payloadProcessingNetworkPolicy(componentLabels))
-
 	out := make([]client.Object, len(extra))
 	for i := range extra {
 		out[i] = &extra[i]
@@ -241,92 +239,6 @@ func maasParametersConfigMapFromParamsEnv(manifestsBasePath string, appNs string
 		},
 	}
 	return cm, nil
-}
-
-// payloadProcessingNetworkPolicy returns a NetworkPolicy for the
-// payload-processing pod in the gateway namespace. OCP 4.22 introduced a
-// deny-all NetworkPolicy in openshift-ingress; without explicit rules the pod
-// cannot reach the Kubernetes API server (egress) or receive ext_proc calls
-// from the gateway (ingress).
-func payloadProcessingNetworkPolicy(componentLabels map[string]string) unstructured.Unstructured {
-	npLabels := make(map[string]any, len(componentLabels)+1)
-	for k, v := range componentLabels {
-		npLabels[k] = v
-	}
-	npLabels["app"] = "payload-processing"
-
-	return unstructured.Unstructured{
-		Object: map[string]any{
-			"apiVersion": "networking.k8s.io/v1",
-			"kind":       "NetworkPolicy",
-			"metadata": map[string]any{
-				"name":      "payload-processing",
-				"namespace": DefaultGatewayNamespace,
-				"labels":    npLabels,
-			},
-			"spec": map[string]any{
-				"podSelector": map[string]any{
-					"matchLabels": map[string]any{
-						"app": "payload-processing",
-					},
-				},
-				"policyTypes": []any{"Ingress", "Egress"},
-				"ingress": []any{
-					map[string]any{
-						"from": []any{
-							map[string]any{
-								"podSelector": map[string]any{
-									"matchLabels": map[string]any{
-										"gateway.networking.k8s.io/gateway-name": "data-science-gateway",
-									},
-								},
-								"namespaceSelector": map[string]any{
-									"matchLabels": map[string]any{
-										"kubernetes.io/metadata.name": DefaultGatewayNamespace,
-									},
-								},
-							},
-						},
-						"ports": []any{
-							map[string]any{
-								"protocol": "TCP",
-								"port":     int64(9004),
-							},
-						},
-					},
-					map[string]any{
-						"from": []any{
-							map[string]any{
-								"namespaceSelector": map[string]any{
-									"matchLabels": map[string]any{
-										"kubernetes.io/metadata.name": "openshift-monitoring",
-									},
-								},
-							},
-							map[string]any{
-								"namespaceSelector": map[string]any{
-									"matchLabels": map[string]any{
-										"kubernetes.io/metadata.name": "openshift-user-workload-monitoring",
-									},
-								},
-							},
-						},
-						"ports": []any{
-							map[string]any{
-								"protocol": "TCP",
-								"port":     int64(9005),
-							},
-							map[string]any{
-								"protocol": "TCP",
-								"port":     int64(9090),
-							},
-						},
-					},
-				},
-				"egress": []any{map[string]any{}},
-			},
-		},
-	}
 }
 
 // parseParamsEnv reads a key=value env file, skipping comments and blank lines.

--- a/internal/controller/components/modelsasservice/modelsasservice_support_test.go
+++ b/internal/controller/components/modelsasservice/modelsasservice_support_test.go
@@ -56,13 +56,6 @@ metadata:
   name: payload-processing-plugins
   namespace: redhat-ods-applications
 `,
-		`
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: payload-processing
-  namespace: redhat-ods-applications
-`,
 		// Unrelated resource that should NOT be moved
 		`
 apiVersion: apps/v1
@@ -187,50 +180,6 @@ roleRef:
 	}
 }
 
-func TestPayloadProcessingNetworkPolicy(t *testing.T) {
-	g := NewWithT(t)
-
-	labels := map[string]string{
-		"opendatahub.io/component":  "true",
-		"app.kubernetes.io/part-of": "modelsasservice",
-	}
-
-	np := payloadProcessingNetworkPolicy(labels)
-
-	g.Expect(np.GetKind()).To(Equal("NetworkPolicy"))
-	g.Expect(np.GetName()).To(Equal("payload-processing"))
-	g.Expect(np.GetNamespace()).To(Equal(DefaultGatewayNamespace))
-
-	npLabels := np.GetLabels()
-	g.Expect(npLabels).To(HaveKeyWithValue("app", "payload-processing"))
-	g.Expect(npLabels).To(HaveKeyWithValue("opendatahub.io/component", "true"))
-	g.Expect(npLabels).To(HaveKeyWithValue("app.kubernetes.io/part-of", "modelsasservice"))
-
-	spec, ok := np.Object["spec"].(map[string]any)
-	g.Expect(ok).To(BeTrue(), "spec should be a map")
-
-	podSelector, ok := spec["podSelector"].(map[string]any)
-	g.Expect(ok).To(BeTrue(), "podSelector should be a map")
-	matchLabels, ok := podSelector["matchLabels"].(map[string]any)
-	g.Expect(ok).To(BeTrue(), "matchLabels should be a map")
-	g.Expect(matchLabels).To(HaveKeyWithValue("app", "payload-processing"))
-
-	policyTypes, ok := spec["policyTypes"].([]any)
-	g.Expect(ok).To(BeTrue(), "policyTypes should be an array")
-	g.Expect(policyTypes).To(ConsistOf("Ingress", "Egress"))
-
-	// Verify egress allows all outbound traffic
-	egress, ok := spec["egress"].([]any)
-	g.Expect(ok).To(BeTrue(), "egress should be an array")
-	g.Expect(egress).To(HaveLen(1))
-	g.Expect(egress[0]).To(Equal(map[string]any{}))
-
-	// Verify ingress rules: gateway on 9004, monitoring on 9090
-	ingress, ok := spec["ingress"].([]any)
-	g.Expect(ok).To(BeTrue(), "ingress should be an array")
-	g.Expect(ingress).To(HaveLen(2))
-}
-
 func TestRestoreCRBSubjectsNamespace_NoSubjects(t *testing.T) {
 	g := NewWithT(t)
 
@@ -248,4 +197,12 @@ roleRef:
 
 	err = restoreCRBSubjectsNamespace(res, "openshift-ingress")
 	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestGatewayNamespaceResources_IncludesNetworkPolicy(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(gatewayNamespaceResources).To(HaveKey(
+		resourceKey{kind: "NetworkPolicy", name: "payload-processing"}),
+		"NetworkPolicy must be registered for namespace restoration")
 }

--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -343,12 +343,14 @@ func (tc *ModelsAsServiceTestCtx) ValidatePayloadProcessingNetworkPolicy(t *test
 			Namespace: maasGatewayNamespace,
 		}),
 		WithCondition(And(
-			jq.Match(`.spec.podSelector.matchLabels.app == "payload-processing"`),
+			jq.Match(`.spec.podSelector.matchExpressions[]
+				| select(.key == "app") | .operator == "In" and (.values | sort == ["payload-pre-processing","payload-processing"])`),
 			jq.Match(`.spec.policyTypes | any(. == "Ingress")`),
 			jq.Match(`.spec.policyTypes | any(. == "Egress")`),
 			jq.Match(`.spec.ingress | length == 2`),
-			jq.Match(`.spec.egress | length == 1`),
-			jq.Match(`.spec.egress[0] == {}`),
+			jq.Match(`.spec.egress | length == 2`),
+			jq.Match(`.spec.egress[] | select(.ports[] | .port == 53) | .ports | length == 4`),
+			jq.Match(`.spec.egress[] | select(.ports[] | .port == 443) | .ports | length == 2`),
 		)),
 		WithCustomErrorMsg("NetworkPolicy should exist with correct ingress and egress rules for payload-processing in %s", maasGatewayNamespace),
 	)


### PR DESCRIPTION
## Description

Cherry-pick of [opendatahub-io/opendatahub-operator#3747](https://github.com/opendatahub-io/opendatahub-operator/pull/3747) for rhoai-3.5.

Moves the payload-processing NetworkPolicy from Go-constructed code to the upstream models-as-a-service kustomize bundle.

### What changed

- Removed `payloadProcessingNetworkPolicy()` Go builder function
- The NP now comes from the upstream kustomize bundle and flows through the existing rendering pipeline (kustomize build, namespace transform, `restoreGatewayNamespaceResources`, label injection, GC cleanup)
- `gatewayNamespaceResources` already includes the NP entry for namespace restoration

### Why

The payload-processing Deployment, Service, ServiceAccount, and ConfigMap already come from the upstream kustomize bundle. The NP was the only resource the operator was constructing in Go.

### Related PRs

- Upstream (main): [opendatahub-io/opendatahub-operator#3747](https://github.com/opendatahub-io/opendatahub-operator/pull/3747)
- MaaS upstream manifest: [opendatahub-io/models-as-a-service#1084](https://github.com/opendatahub-io/models-as-a-service/pull/1084)