### PR TITLE
Add odh-ogx-module-operator to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -57,8 +57,8 @@ map:
   odh-workload-variant-autoscaler-controller:
     src: config
     dest: wva
-  odh-ogx-k8s-operator:
-    src: config
+  odh-ogx-module-operator:
+    src: config/
     dest: ogx
   odh-ai-gateway-operator:
     src: config

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -58,7 +58,7 @@ map:
     src: config
     dest: wva
   odh-ogx-module-operator:
-    src: config/
+    src: config
     dest: ogx
   odh-ai-gateway-operator:
     src: config


### PR DESCRIPTION
Adds 'odh-ogx-module-operator' entry to build/manifests-config.yaml.

Repo: https://github.com/opendatahub-io/ogx-k8s-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-78492