### PR TITLE
Remove odh-training-operator from operator manifests (offboarding)

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -22,9 +22,6 @@ map:
     src: dashboard-operator/charts/dashboard
     dest: dashboard-operator
     type: chart
-  odh-training-operator:
-    src: manifests
-    dest: trainingoperator
   odh-feast-operator:
     src: infra/feast-operator/config
     dest: feastoperator


### PR DESCRIPTION
Removes 'odh-training-operator' entry from build/manifests-config.yaml.

Jira: https://redhat.atlassian.net/browse/RHOAIENG-79608