### PR TITLE
Remove odh-training-operator from operator manifests (offboarding)

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -36,11 +36,6 @@ map:
     type: chart
     git.url: https://github.com/red-hat-data-services/odh-dashboard
     git.commit: d78e0d840a7d6009b41a3a903a12bbc305258780
-  odh-training-operator:
-    src: manifests
-    dest: trainingoperator
-    git.url: https://github.com/red-hat-data-services/training-operator
-    git.commit: 2d1c0617426fe8c6534ecbff3236cbfbfafe8162
   odh-feast-operator:
     src: infra/feast-operator/config
     dest: feastoperator

--- a/build/operator-nudging.yaml
+++ b/build/operator-nudging.yaml
@@ -189,8 +189,6 @@ relatedImages:
   value: quay.io/rhoai/odh-training-cuda128-torch28-py312-rhel9@sha256:37c5c427ab040d0ce554f9ea5e4a1624fa4389f0ad93b0150eafd97a3d804e25
 - name: RELATED_IMAGE_ODH_TRAINING_CUDA128_TORCH29_PY312_IMAGE
   value: quay.io/rhoai/odh-training-cuda128-torch29-py312-rhel9@sha256:9ec61a637d9e45789d2b7c6cbdfbb85e1f9064e7e217664049fc946e02516f93
-- name: RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE
-  value: quay.io/rhoai/odh-training-operator-rhel9@sha256:341a6eee684d1901a923af26874778d8804d4a77a6e572ac655236e7b1a5d9c7
 - name: RELATED_IMAGE_ODH_TRAINING_ROCM62_TORCH24_PY311_IMAGE
   value: quay.io/rhoai/odh-training-rocm62-torch24-py311-rhel9@sha256:820d3c378d7d2c28c4e1670bcc37b5d67be9be638c488acb9db0824bbeae22fd
 - name: RELATED_IMAGE_ODH_TRAINING_ROCM62_TORCH25_PY311_IMAGE


### PR DESCRIPTION
## Summary
- Remove `odh-training-operator` entry from `build/manifests-config.yaml`
- Remove `RELATED_IMAGE_ODH_TRAINING_OPERATOR_IMAGE` from `build/operator-nudging.yaml`

The component was already removed from `bundle-patch.yaml` (RHOAI-Build-Config#27797), but the release branch still had the operator manifest and nudging entries. This mismatch causes the operator workflow to fail because it tries to include manifests for a component that no longer exists in the bundle config, blocking nightly builds.

The training *image* entries (cuda, rocm, latency-predictor) are separate components and remain unchanged.

Ref: RHOAIENG-79608

## Test plan
- [ ] Operator workflow completes successfully after merge
- [ ] Nightly build unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)