### PR TITLE
fix(modules): treat mirrored submodule conditions as informational, not gating (#3898)

### DIFF
--- a/internal/controller/modules/base.go
+++ b/internal/controller/modules/base.go
@@ -510,9 +510,14 @@ func (b *BaseHandler) deleteRenderedResources(
 	return nil
 }
 
-// ParseConditions extracts []metav1.Condition from an unstructured object's
-// .status.conditions field.
-func ParseConditions(u *unstructured.Unstructured) ([]metav1.Condition, error) {
+// ParseConditions extracts []common.Condition from an unstructured object's
+// .status.conditions field. common.Condition is used instead of
+// metav1.Condition because it carries the Severity field: a module CR may
+// report a condition as Info severity to signal it is informational only
+// (e.g. an optional dependency is missing). Preserving it lets the
+// DSC-mirrored submodule condition keep its real severity label instead of
+// defaulting to Error.
+func ParseConditions(u *unstructured.Unstructured) ([]common.Condition, error) {
 	rawConditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
 	if err != nil {
 		return nil, err
@@ -522,7 +527,7 @@ func ParseConditions(u *unstructured.Unstructured) ([]metav1.Condition, error) {
 		return nil, nil
 	}
 
-	conditions := make([]metav1.Condition, 0, len(rawConditions))
+	conditions := make([]common.Condition, 0, len(rawConditions))
 
 	for _, raw := range rawConditions {
 		cm, ok := raw.(map[string]any)
@@ -530,7 +535,7 @@ func ParseConditions(u *unstructured.Unstructured) ([]metav1.Condition, error) {
 			continue
 		}
 
-		c := metav1.Condition{}
+		c := common.Condition{}
 
 		if v, ok := cm["type"].(string); ok {
 			c.Type = v
@@ -546,6 +551,10 @@ func ParseConditions(u *unstructured.Unstructured) ([]metav1.Condition, error) {
 
 		if v, ok := cm["message"].(string); ok {
 			c.Message = v
+		}
+
+		if v, ok := cm["severity"].(string); ok {
+			c.Severity = common.ConditionSeverity(v)
 		}
 
 		if v, ok := cm["observedGeneration"].(int64); ok {

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -554,7 +554,7 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 
 		ready := false
 		degraded := false
-		var readyCond *metav1.Condition
+		var readyCond *common.Condition
 
 		for i := range moduleStatus.Conditions {
 			switch moduleStatus.Conditions[i].Type {
@@ -597,7 +597,7 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 			})
 		}
 
-		mirrorSubmoduleConditions(rr, platformCtx, moduleStatus, submodules, &notReadyModules)
+		mirrorSubmoduleConditions(rr, platformCtx, moduleStatus, submodules)
 
 		if platformCtx.DSC != nil {
 			handler.WriteDSCComponentStatus(platformCtx.DSC, enabled, moduleStatus.Releases)
@@ -671,22 +671,22 @@ func submoduleConditionsFor(h ModuleHandler) []SubmoduleCondition {
 }
 
 // mirrorSubmoduleConditions copies declared submodule conditions from the
-// module CR's status onto the DSC conditions. It checks per-submodule
-// enablement: disabled submodules get a Removed condition. Enabled submodules
-// whose condition is not True are appended to notReadyModules so they affect
-// the aggregate.
+// module CR's status onto the DSC conditions, preserving severity. These
+// conditions are informational only: module readiness is defined solely by the
+// module CR's Ready (and Degraded) condition — which the module already
+// aggregates severity-aware internally — so mirrored submodule conditions never
+// gate ModulesReady. Disabled submodules get a Removed condition.
 func mirrorSubmoduleConditions(
 	rr *odhtype.ReconciliationRequest,
 	platformCtx *PlatformContext,
 	moduleStatus *ModuleStatus,
 	submodules []SubmoduleCondition,
-	notReadyModules *[]string,
 ) {
 	if len(submodules) == 0 {
 		return
 	}
 
-	condByType := make(map[string]*metav1.Condition, len(moduleStatus.Conditions))
+	condByType := make(map[string]*common.Condition, len(moduleStatus.Conditions))
 	for i := range moduleStatus.Conditions {
 		condByType[moduleStatus.Conditions[i].Type] = &moduleStatus.Conditions[i]
 	}
@@ -716,21 +716,17 @@ func mirrorSubmoduleConditions(
 				Reason:  status.AwaitingReadinessReason,
 				Message: "Submodule is enabled (Managed) but the module operator has not reported its status yet",
 			})
-			*notReadyModules = append(*notReadyModules, sm.DSCConditionType)
 
 			continue
 		}
 
 		rr.Conditions.SetCondition(common.Condition{
-			Type:    sm.DSCConditionType,
-			Status:  source.Status,
-			Reason:  source.Reason,
-			Message: source.Message,
+			Type:     sm.DSCConditionType,
+			Status:   source.Status,
+			Reason:   source.Reason,
+			Message:  source.Message,
+			Severity: source.Severity,
 		})
-
-		if source.Status != metav1.ConditionTrue {
-			*notReadyModules = append(*notReadyModules, sm.DSCConditionType)
-		}
 	}
 }
 

--- a/internal/controller/modules/modules_controller_actions_status_test.go
+++ b/internal/controller/modules/modules_controller_actions_status_test.go
@@ -6,6 +6,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
 
@@ -79,7 +80,7 @@ func TestStatusMockHandler_ReadyConditionType(t *testing.T) {
 	g := NewWithT(t)
 
 	mock := newStatusMock("testmod", &modules.ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue},
 		},
 	})

--- a/internal/controller/modules/modules_controller_actions_test.go
+++ b/internal/controller/modules/modules_controller_actions_test.go
@@ -110,6 +110,11 @@ type provisioningModuleStub struct {
 	moduleName string
 	enabled    bool
 	status     *ModuleStatus
+	submodules []SubmoduleCondition
+}
+
+func (s provisioningModuleStub) GetSubmoduleConditions() []SubmoduleCondition {
+	return s.submodules
 }
 
 func (s provisioningModuleStub) GetName() string { return s.moduleName }
@@ -268,7 +273,7 @@ func TestProvisionModulesAddsResourcesAndEnvInjection(t *testing.T) {
 		moduleName: testProvisioningModuleName,
 		enabled:    true,
 		status: &ModuleStatus{
-			Conditions: []metav1.Condition{{
+			Conditions: []common.Condition{{
 				Type:   status.ConditionTypeReady,
 				Status: metav1.ConditionTrue,
 			}},
@@ -360,7 +365,7 @@ func TestComputeModulesStatusMarksNotReadyModules(t *testing.T) {
 	readyHandler := provisioningModuleStub{
 		moduleName: "ready-module",
 		enabled:    true,
-		status: &ModuleStatus{Conditions: []metav1.Condition{{
+		status: &ModuleStatus{Conditions: []common.Condition{{
 			Type:   status.ConditionTypeReady,
 			Status: metav1.ConditionTrue,
 		}}},
@@ -442,5 +447,75 @@ func TestComputeModulesStatusPreservesWorkbenchNamespaceOnGetModuleStatusError(t
 
 	if got := dsc.Status.Components.Workbenches.WorkbenchNamespace; got != existingNamespace {
 		t.Fatalf("expected workbench namespace %q to be preserved when module status read fails, got %q", existingNamespace, got)
+	}
+}
+
+// Integration-level guard (ComputeModulesStatus over a fake client) for the
+// reported symptom: a module that is Ready=True but reports an
+// optional-dependency submodule condition as Info-severity False must NOT drag
+// the DSC to Not Ready. The Info condition is surfaced on the DSC (visibility)
+// but does not gate ModulesReady.
+func TestComputeModulesStatusInfoDependencyKeepsModulesReady(t *testing.T) {
+	withTestRegistry(t)
+
+	const depCond = "KserveLLMInferenceServiceDependencies"
+
+	handler := provisioningModuleStub{
+		moduleName: "kserve",
+		enabled:    true,
+		status: &ModuleStatus{Conditions: []common.Condition{
+			{Type: status.ConditionTypeReady, Status: metav1.ConditionTrue, Reason: "AllGood"},
+			{
+				Type:     depCond,
+				Status:   metav1.ConditionFalse,
+				Reason:   "PreConditionFailed",
+				Message:  "Red Hat Connectivity Link not installed; cert-manager operator not installed",
+				Severity: common.ConditionSeverityInfo,
+			},
+		}},
+		submodules: []SubmoduleCondition{
+			{SourceConditionType: depCond, DSCConditionType: depCond},
+		},
+	}
+	DefaultRegistry().Add(handler, WithRunlevel(dag.RL(20)))
+
+	dsc := &dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: testDSCName}}
+	dsci := &dsciv2.DSCInitialization{ObjectMeta: metav1.ObjectMeta{Name: testDSCIName}}
+	dsci.Spec.ApplicationsNamespace = testApplicationsNamespace
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(dsc, dsci))
+	if err != nil {
+		t.Fatalf("create fake client: %v", err)
+	}
+
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   dsc,
+		Conditions: conditions.NewManager(dsc, status.ConditionTypeModulesReady),
+	}
+
+	if err := ComputeModulesStatus(context.Background(), rr); err != nil {
+		t.Fatalf("compute modules status: %v", err)
+	}
+
+	// The dependency condition is surfaced on the DSC, with severity preserved.
+	dep := conditions.FindStatusCondition(dsc.GetStatus(), depCond)
+	if dep == nil {
+		t.Fatalf("expected %s condition to be surfaced on the DSC", depCond)
+	}
+	if dep.Status != metav1.ConditionFalse {
+		t.Fatalf("expected %s=False, got %s", depCond, dep.Status)
+	}
+	if dep.Severity != common.ConditionSeverityInfo {
+		t.Fatalf("expected %s severity=Info to be preserved, got %q", depCond, dep.Severity)
+	}
+
+	// ...but it must not gate readiness: ModulesReady stays True.
+	ready := conditions.FindStatusCondition(dsc.GetStatus(), status.ConditionTypeModulesReady)
+	if ready == nil {
+		t.Fatalf("expected ModulesReady condition to be set")
+	}
+	if ready.Status != metav1.ConditionTrue {
+		t.Fatalf("expected ModulesReady=True (Info dep is non-gating), got %s: %q", ready.Status, ready.Message)
 	}
 }

--- a/internal/controller/modules/readiness_test.go
+++ b/internal/controller/modules/readiness_test.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 
 	. "github.com/onsi/gomega"
@@ -54,7 +55,7 @@ func TestReadinessChecker_ReadyWithMatchingVersion(t *testing.T) {
 
 	reg := &modules.Registry{}
 	reg.Add(newStatusMock("mod-a", &modules.ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue},
 		},
 		ObservedGeneration: 1,
@@ -74,7 +75,7 @@ func TestReadinessChecker_NotReadyVersionMismatch(t *testing.T) {
 
 	reg := &modules.Registry{}
 	reg.Add(newStatusMock("mod-b", &modules.ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue},
 		},
 		ObservedGeneration: 1,
@@ -94,7 +95,7 @@ func TestReadinessChecker_EmptyVersionSkipsCheck(t *testing.T) {
 
 	reg := &modules.Registry{}
 	reg.Add(newStatusMock("mod-c", &modules.ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue},
 		},
 		ObservedGeneration: 1,
@@ -114,7 +115,7 @@ func TestReadinessChecker_StaleGenerationNotReady(t *testing.T) {
 
 	reg := &modules.Registry{}
 	reg.Add(newStatusMock("mod-d", &modules.ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue},
 		},
 		ObservedGeneration: 1,
@@ -134,7 +135,7 @@ func TestReadinessChecker_ReadyFalseNotReady(t *testing.T) {
 
 	reg := &modules.Registry{}
 	reg.Add(newStatusMock("mod-e", &modules.ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionFalse},
 		},
 		ObservedGeneration: 1,
@@ -154,7 +155,7 @@ func TestReadinessChecker_NoPlatformVersionSkipsCheck(t *testing.T) {
 
 	reg := &modules.Registry{}
 	reg.Add(newStatusMock("mod-f", &modules.ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue},
 		},
 		ObservedGeneration: 1,

--- a/internal/controller/modules/registry_test.go
+++ b/internal/controller/modules/registry_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/dag"
 
@@ -247,6 +248,45 @@ func TestParseConditions(t *testing.T) {
 	g.Expect(conditions[1].Status).Should(Equal(metav1.ConditionFalse))
 	g.Expect(conditions[1].ObservedGeneration).Should(Equal(int64(0)))
 	g.Expect(conditions[1].LastTransitionTime.IsZero()).Should(BeTrue())
+}
+
+// ParseConditions must preserve the severity field. A module CR reports an
+// optional dependency as Info severity to signal it is non-gating; if that
+// signal is dropped here, aggregation would treat it as a hard failure (Error
+// == "") and flip the DSC to Not Ready. A condition without a severity field
+// must default to Error ("").
+func TestParseConditionsPreservesSeverity(t *testing.T) {
+	g := NewWithT(t)
+
+	u := &unstructured.Unstructured{
+		Object: map[string]any{
+			"status": map[string]any{
+				"conditions": []any{
+					map[string]any{
+						"type":     "KserveLLMInferenceServiceDependencies",
+						"status":   "False",
+						"reason":   "PreConditionFailed",
+						"severity": "Info",
+					},
+					map[string]any{
+						"type":   "Ready",
+						"status": "True",
+					},
+				},
+			},
+		},
+	}
+
+	conditions, err := modules.ParseConditions(u)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(conditions).Should(HaveLen(2))
+
+	g.Expect(conditions[0].Type).Should(Equal("KserveLLMInferenceServiceDependencies"))
+	g.Expect(conditions[0].Severity).Should(Equal(common.ConditionSeverityInfo))
+
+	// No severity field -> defaults to Error (empty string).
+	g.Expect(conditions[1].Type).Should(Equal("Ready"))
+	g.Expect(conditions[1].Severity).Should(Equal(common.ConditionSeverityError))
 }
 
 func TestParseConditionsNoStatus(t *testing.T) {

--- a/internal/controller/modules/submodule_conditions_test.go
+++ b/internal/controller/modules/submodule_conditions_test.go
@@ -150,7 +150,7 @@ func TestMirrorSubmoduleConditions_ConditionFound_True(t *testing.T) {
 	rr, mgr := newTestRR()
 
 	moduleStatus := &ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "AllGood"},
 			{Type: "ModelsAsServiceReady", Status: metav1.ConditionTrue, Reason: "Deployed", Message: "MaaS is healthy"},
 		},
@@ -160,15 +160,13 @@ func TestMirrorSubmoduleConditions_ConditionFound_True(t *testing.T) {
 		{SourceConditionType: "ModelsAsServiceReady", DSCConditionType: "ModelsAsServiceReady"},
 	}
 
-	var notReady []string
-	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules, &notReady)
+	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules)
 
 	cond := mgr.GetCondition("ModelsAsServiceReady")
 	g.Expect(cond).ShouldNot(BeNil())
 	g.Expect(cond.Status).Should(Equal(metav1.ConditionTrue))
 	g.Expect(cond.Reason).Should(Equal("Deployed"))
 	g.Expect(cond.Message).Should(Equal("MaaS is healthy"))
-	g.Expect(notReady).Should(BeEmpty())
 }
 
 func TestMirrorSubmoduleConditions_ConditionFound_False(t *testing.T) {
@@ -178,7 +176,7 @@ func TestMirrorSubmoduleConditions_ConditionFound_False(t *testing.T) {
 	rr, mgr := newTestRR()
 
 	moduleStatus := &ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "AllGood"},
 			{Type: "BatchGatewayReady", Status: metav1.ConditionFalse, Reason: "Deploying", Message: "waiting for pods"},
 		},
@@ -188,13 +186,50 @@ func TestMirrorSubmoduleConditions_ConditionFound_False(t *testing.T) {
 		{SourceConditionType: "BatchGatewayReady", DSCConditionType: "BatchGatewayReady"},
 	}
 
-	var notReady []string
-	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules, &notReady)
+	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules)
 
 	cond := mgr.GetCondition("BatchGatewayReady")
 	g.Expect(cond).ShouldNot(BeNil())
 	g.Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
-	g.Expect(notReady).Should(ConsistOf("BatchGatewayReady"))
+}
+
+// A submodule condition reported by the module CR with Info severity has its
+// severity carried through to the mirrored DSC condition, so the DSC labels it
+// informational. Non-gating behaviour is verified at the aggregation level in
+// TestComputeModulesStatusInfoDependencyKeepsModulesReady.
+func TestMirrorSubmoduleConditions_InfoSeverityFalse_PreservesSeverity(t *testing.T) {
+	t.Parallel()
+	g := NewWithT(t)
+
+	rr, mgr := newTestRR()
+
+	moduleStatus := &ModuleStatus{
+		Conditions: []common.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "AllGood"},
+			{
+				Type:     "KserveLLMInferenceServiceDependencies",
+				Status:   metav1.ConditionFalse,
+				Reason:   "PreConditionFailed",
+				Message:  "Red Hat Connectivity Link not installed; cert-manager operator not installed",
+				Severity: common.ConditionSeverityInfo,
+			},
+		},
+	}
+
+	submodules := []SubmoduleCondition{
+		{
+			SourceConditionType: "KserveLLMInferenceServiceDependencies",
+			DSCConditionType:    "KserveLLMInferenceServiceDependencies",
+		},
+	}
+
+	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules)
+
+	cond := mgr.GetCondition("KserveLLMInferenceServiceDependencies")
+	g.Expect(cond).ShouldNot(BeNil())
+	g.Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
+	// Severity is carried through so the DSC condition is labeled informational.
+	g.Expect(cond.Severity).Should(Equal(common.ConditionSeverityInfo))
 }
 
 func TestMirrorSubmoduleConditions_ConditionAbsent(t *testing.T) {
@@ -204,7 +239,7 @@ func TestMirrorSubmoduleConditions_ConditionAbsent(t *testing.T) {
 	rr, mgr := newTestRR()
 
 	moduleStatus := &ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "AllGood"},
 		},
 	}
@@ -213,15 +248,13 @@ func TestMirrorSubmoduleConditions_ConditionAbsent(t *testing.T) {
 		{SourceConditionType: "ModelsAsServiceReady", DSCConditionType: "ModelsAsServiceReady"},
 	}
 
-	var notReady []string
-	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules, &notReady)
+	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules)
 
 	cond := mgr.GetCondition("ModelsAsServiceReady")
 	g.Expect(cond).ShouldNot(BeNil())
 	g.Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
 	g.Expect(cond.Reason).Should(Equal(status.AwaitingReadinessReason))
 	g.Expect(cond.Message).Should(ContainSubstring("enabled (Managed)"))
-	g.Expect(notReady).Should(ConsistOf("ModelsAsServiceReady"))
 }
 
 func TestMirrorSubmoduleConditions_MultipleSubmodules(t *testing.T) {
@@ -231,7 +264,7 @@ func TestMirrorSubmoduleConditions_MultipleSubmodules(t *testing.T) {
 	rr, mgr := newTestRR()
 
 	moduleStatus := &ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "AllGood"},
 			{Type: "ModelsAsServiceReady", Status: metav1.ConditionTrue, Reason: "Ready"},
 			{Type: "BatchGatewayReady", Status: metav1.ConditionFalse, Reason: "Pending", Message: "waiting"},
@@ -243,8 +276,7 @@ func TestMirrorSubmoduleConditions_MultipleSubmodules(t *testing.T) {
 		{SourceConditionType: "BatchGatewayReady", DSCConditionType: "BatchGatewayReady"},
 	}
 
-	var notReady []string
-	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules, &notReady)
+	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules)
 
 	maasCond := mgr.GetCondition("ModelsAsServiceReady")
 	g.Expect(maasCond).ShouldNot(BeNil())
@@ -253,8 +285,6 @@ func TestMirrorSubmoduleConditions_MultipleSubmodules(t *testing.T) {
 	batchCond := mgr.GetCondition("BatchGatewayReady")
 	g.Expect(batchCond).ShouldNot(BeNil())
 	g.Expect(batchCond.Status).Should(Equal(metav1.ConditionFalse))
-
-	g.Expect(notReady).Should(ConsistOf("BatchGatewayReady"))
 }
 
 func TestMirrorSubmoduleConditions_EmptySubmodules(t *testing.T) {
@@ -264,16 +294,14 @@ func TestMirrorSubmoduleConditions_EmptySubmodules(t *testing.T) {
 	rr, mgr := newTestRR()
 
 	moduleStatus := &ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue},
 		},
 	}
 
-	var notReady []string
-	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, nil, &notReady)
+	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, nil)
 
 	g.Expect(mgr.GetCondition("ModelsAsServiceReady")).Should(BeNil())
-	g.Expect(notReady).Should(BeEmpty())
 }
 
 func TestMirrorSubmoduleConditions_DifferentSourceAndDSCType(t *testing.T) {
@@ -283,7 +311,7 @@ func TestMirrorSubmoduleConditions_DifferentSourceAndDSCType(t *testing.T) {
 	rr, mgr := newTestRR()
 
 	moduleStatus := &ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "InternalMaaSStatus", Status: metav1.ConditionTrue, Reason: "OK", Message: "all good"},
 		},
 	}
@@ -292,8 +320,7 @@ func TestMirrorSubmoduleConditions_DifferentSourceAndDSCType(t *testing.T) {
 		{SourceConditionType: "InternalMaaSStatus", DSCConditionType: "ModelsAsServiceReady"},
 	}
 
-	var notReady []string
-	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules, &notReady)
+	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules)
 
 	cond := mgr.GetCondition("ModelsAsServiceReady")
 	g.Expect(cond).ShouldNot(BeNil())
@@ -311,7 +338,7 @@ func TestMirrorSubmoduleConditions_DisabledSubmodule_ShowsRemoved(t *testing.T) 
 	rr, mgr := newTestRR()
 
 	moduleStatus := &ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "AllGood"},
 			{Type: "ModelsAsServiceReady", Status: metav1.ConditionTrue, Reason: "Ready"},
 		},
@@ -326,15 +353,13 @@ func TestMirrorSubmoduleConditions_DisabledSubmodule_ShowsRemoved(t *testing.T) 
 		},
 	}
 
-	var notReady []string
-	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules, &notReady)
+	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules)
 
 	cond := mgr.GetCondition("ModelsAsServiceReady")
 	g.Expect(cond).ShouldNot(BeNil())
 	g.Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
 	g.Expect(cond.Reason).Should(Equal(status.RemovedReason))
 	g.Expect(cond.Message).Should(ContainSubstring("Removed"))
-	g.Expect(notReady).Should(BeEmpty(), "disabled submodule should not count as not-ready")
 }
 
 func TestMirrorSubmoduleConditions_NilIsEnabled_AssumedEnabled(t *testing.T) {
@@ -344,7 +369,7 @@ func TestMirrorSubmoduleConditions_NilIsEnabled_AssumedEnabled(t *testing.T) {
 	rr, mgr := newTestRR()
 
 	moduleStatus := &ModuleStatus{
-		Conditions: []metav1.Condition{
+		Conditions: []common.Condition{
 			{Type: "FooReady", Status: metav1.ConditionTrue, Reason: "OK"},
 		},
 	}
@@ -357,13 +382,11 @@ func TestMirrorSubmoduleConditions_NilIsEnabled_AssumedEnabled(t *testing.T) {
 		},
 	}
 
-	var notReady []string
-	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules, &notReady)
+	mirrorSubmoduleConditions(rr, newTestPlatformCtx(), moduleStatus, submodules)
 
 	cond := mgr.GetCondition("FooReady")
 	g.Expect(cond).ShouldNot(BeNil())
 	g.Expect(cond.Status).Should(Equal(metav1.ConditionTrue))
-	g.Expect(notReady).Should(BeEmpty())
 }
 
 func TestWriteSubmoduleComponentStatus_SetsManaged(t *testing.T) {

--- a/internal/controller/modules/types.go
+++ b/internal/controller/modules/types.go
@@ -3,7 +3,6 @@ package modules
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -199,7 +198,7 @@ type ExtraEnvProvider interface {
 // the release version for the platform version handshake.
 type ModuleStatus struct {
 	// Conditions from .status.conditions on the module CR.
-	Conditions []metav1.Condition
+	Conditions []common.Condition
 	// ObservedGeneration from .status.observedGeneration on the module CR.
 	ObservedGeneration int64
 	// Generation from .metadata.generation on the module CR.


### PR DESCRIPTION
## Description
Sync: https://github.com/opendatahub-io/opendatahub-operator/pull/3898

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
