### PR TITLE
fix(modules): requeue and watch CRDs when module CRD is not yet available (RHOAIENG-80362)

### DIFF
--- a/internal/controller/datasciencecluster/datasciencecluster_controller.go
+++ b/internal/controller/datasciencecluster/datasciencecluster_controller.go
@@ -90,6 +90,10 @@ func NewDataScienceClusterReconciler(ctx context.Context, mgr ctrl.Manager) erro
 				resources.CreatedOrUpdatedOrDeletedNamed(gates.AcksConfigMap),
 			))
 
+	b = modules.AddModuleCRDWatches(b, func(ctx context.Context, _ client.Object) []reconcile.Request {
+		return watchDataScienceClusters(ctx, mgr.GetClient())
+	})
+
 	_, err := b.
 		WithAction(initialize).
 		WithAction(checkPreConditions).

--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -3,8 +3,10 @@ package modules
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -119,6 +121,9 @@ func newDSCModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 			)))
 
 	b = addModuleCRWatches(b)
+	b = addModuleCRDWatches(b, func(ctx context.Context, _ client.Object) []reconcile.Request {
+		return cluster.WatchDataScienceClusters(ctx, mgr.GetClient())
+	})
 
 	for _, a := range commonActions() {
 		b = b.WithAction(a)
@@ -161,6 +166,10 @@ func newPlatformModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		}
 	}
 
+	b = addModuleCRDWatches(b, func(ctx context.Context, _ client.Object) []reconcile.Request {
+		return cluster.WatchPlatforms(ctx, mgr.GetClient())
+	})
+
 	for _, a := range commonActions() {
 		b = b.WithAction(a)
 	}
@@ -174,6 +183,46 @@ func newPlatformModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 	}
 	registerModuleCROwnedTypes(rec)
 	return nil
+}
+
+// addModuleCRDWatches registers a non-dynamic watch on CustomResourceDefinition
+// resources filtered to the API groups used by registered modules. When a module
+// CRD is created, this triggers a reconcile so the controller can register the
+// dynamic module CR watch and read the module's status — resolving the race
+// where the controller reconciles before a module CRD is available.
+func addModuleCRDWatches[T common.PlatformObject](
+	b *reconciler.ReconcilerBuilder[T],
+	mapper func(ctx context.Context, obj client.Object) []reconcile.Request,
+) *reconciler.ReconcilerBuilder[T] {
+	reg := DefaultRegistry()
+	if !reg.HasEntries() {
+		return b
+	}
+
+	groupSet := make(map[string]bool)
+	_ = reg.ForAll(func(h ModuleHandler, _ bool) error {
+		groupSet[h.GetGVK().Group] = true
+		return nil
+	})
+
+	groups := make([]string, 0, len(groupSet))
+	for g := range groupSet {
+		groups = append(groups, g)
+	}
+	sort.Strings(groups)
+
+	crdPredicates := make([]predicate.Predicate, 0, len(groups))
+	for _, g := range groups {
+		crdPredicates = append(crdPredicates, resources.CreatedOrUpdatedOrDeletedNameSuffixed("."+g))
+	}
+
+	b.Watches(
+		&apiextensionsv1.CustomResourceDefinition{},
+		reconciler.WithEventMapper(mapper),
+		reconciler.WithPredicates(predicate.Or(crdPredicates...)),
+	)
+
+	return b
 }
 
 func addModuleCRWatches[T common.PlatformObject](b *reconciler.ReconcilerBuilder[T]) *reconciler.ReconcilerBuilder[T] {
@@ -192,6 +241,15 @@ func addModuleCRWatches[T common.PlatformObject](b *reconciler.ReconcilerBuilder
 	})
 
 	return b
+}
+
+// AddModuleCRDWatches registers a non-dynamic CRD watch so that module CRD
+// creation triggers a reconcile. Exported for use by the DSC controller.
+func AddModuleCRDWatches[T common.PlatformObject](
+	b *reconciler.ReconcilerBuilder[T],
+	mapper func(ctx context.Context, obj client.Object) []reconcile.Request,
+) *reconciler.ReconcilerBuilder[T] {
+	return addModuleCRDWatches(b, mapper)
 }
 
 // AddDSCCompatibilityProjectorWatches registers watches for module CR status

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -475,6 +476,7 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 
 	var notReadyModules []string
 	var degradedModules []string
+	var crdAbsentModules []string
 	var enabledCount int
 
 	err = reg.ForEach(func(handler ModuleHandler) error {
@@ -513,6 +515,10 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 		if err != nil {
 			log.V(1).Info("failed to get module status", "module", name, "error", err)
 			notReadyModules = append(notReadyModules, name)
+
+			if meta.IsNoMatchError(err) {
+				crdAbsentModules = append(crdAbsentModules, name)
+			}
 
 			rr.Conditions.SetCondition(common.Condition{
 				Type:    condType,
@@ -642,6 +648,12 @@ func ComputeModulesStatus(ctx context.Context, rr *odhtype.ReconciliationRequest
 		})
 	default:
 		rr.Conditions.MarkTrue(status.ConditionTypeModulesReady)
+	}
+
+	if len(crdAbsentModules) > 0 {
+		log.Info("module CRDs not yet available, requesting requeue",
+			"modules", strings.Join(crdAbsentModules, ", "))
+		return odherrors.NewRequeueAfterError(30 * time.Second)
 	}
 
 	return nil

--- a/internal/controller/modules/modules_controller_actions_test.go
+++ b/internal/controller/modules/modules_controller_actions_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	semver "github.com/blang/semver/v4"
 	ofversion "github.com/operator-framework/api/pkg/lib/version"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,6 +20,7 @@ import (
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/status"
+	odherrors "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/actions/errors"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/conditions"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/dag"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/provision"
@@ -517,5 +520,111 @@ func TestComputeModulesStatusInfoDependencyKeepsModulesReady(t *testing.T) {
 	}
 	if ready.Status != metav1.ConditionTrue {
 		t.Fatalf("expected ModulesReady=True (Info dep is non-gating), got %s: %q", ready.Status, ready.Message)
+	}
+}
+
+// noMatchErrorModuleStub is a ModuleHandler whose GetModuleStatus returns a
+// NoKindMatchError, simulating a missing CRD.
+type noMatchErrorModuleStub struct {
+	provisioningModuleStub
+}
+
+func (s noMatchErrorModuleStub) GetModuleStatus(_ context.Context, _ client.Client) (*ModuleStatus, error) {
+	return nil, &meta.NoKindMatchError{
+		GroupKind: schema.GroupKind{
+			Group: testProvisioningModuleGroup,
+			Kind:  testProvisioningModuleKind,
+		},
+	}
+}
+
+func TestComputeModulesStatusRequeuesOnCRDAbsent(t *testing.T) {
+	withTestRegistry(t)
+
+	handler := noMatchErrorModuleStub{
+		provisioningModuleStub: provisioningModuleStub{
+			moduleName: "crd-absent-module",
+			enabled:    true,
+		},
+	}
+	DefaultRegistry().Add(handler, WithRunlevel(dag.RL(20)))
+
+	dsc := &dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: testDSCName}}
+	dsci := &dsciv2.DSCInitialization{ObjectMeta: metav1.ObjectMeta{Name: testDSCIName}}
+	dsci.Spec.ApplicationsNamespace = testApplicationsNamespace
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(dsc, dsci))
+	if err != nil {
+		t.Fatalf("create fake client: %v", err)
+	}
+
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   dsc,
+		Conditions: conditions.NewManager(dsc, status.ConditionTypeModulesReady),
+	}
+
+	err = ComputeModulesStatus(context.Background(), rr)
+
+	// Must return a RequeueAfterError so the controller retries.
+	var requeueErr odherrors.RequeueAfterError
+	if !errors.As(err, &requeueErr) {
+		t.Fatalf("expected RequeueAfterError when module CRD is absent, got: %v", err)
+	}
+	if requeueErr.After != 30*time.Second {
+		t.Fatalf("expected 30s requeue delay, got %v", requeueErr.After)
+	}
+
+	// ModulesReady condition must still be set (aggregation ran despite the requeue).
+	modulesReady := conditions.FindStatusCondition(dsc.GetStatus(), status.ConditionTypeModulesReady)
+	if modulesReady == nil {
+		t.Fatalf("expected ModulesReady condition to be set even when CRD is absent")
+	}
+	if modulesReady.Status != metav1.ConditionFalse {
+		t.Fatalf("expected ModulesReady=False, got %s", modulesReady.Status)
+	}
+
+	// Per-module condition must mention the missing CRD.
+	moduleCond := conditions.FindStatusCondition(dsc.GetStatus(), testProvisioningModuleKind+status.ReadySuffix)
+	if moduleCond == nil {
+		t.Fatalf("expected per-module condition to be set")
+	}
+	if moduleCond.Status != metav1.ConditionFalse {
+		t.Fatalf("expected per-module condition=False, got %s", moduleCond.Status)
+	}
+}
+
+func TestComputeModulesStatusNoRequeueOnRegularError(t *testing.T) {
+	withTestRegistry(t)
+
+	handler := legacyStatusFieldsWriterStub{
+		provisioningModuleStub: provisioningModuleStub{
+			moduleName: "error-module",
+			enabled:    true,
+		},
+		getStatusErr: errors.New("some transient API error"),
+	}
+	DefaultRegistry().Add(handler, WithRunlevel(dag.RL(20)))
+
+	dsc := &dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: testDSCName}}
+	dsci := &dsciv2.DSCInitialization{ObjectMeta: metav1.ObjectMeta{Name: testDSCIName}}
+	dsci.Spec.ApplicationsNamespace = testApplicationsNamespace
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(dsc, dsci))
+	if err != nil {
+		t.Fatalf("create fake client: %v", err)
+	}
+
+	rr := &types.ReconciliationRequest{
+		Client:     cli,
+		Instance:   dsc,
+		Conditions: conditions.NewManager(dsc, status.ConditionTypeModulesReady),
+	}
+
+	err = ComputeModulesStatus(context.Background(), rr)
+
+	// Regular errors should NOT trigger a requeue.
+	if err != nil {
+		t.Fatalf("expected nil error for regular GetModuleStatus failures, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Cherry-pick of opendatahub-io/opendatahub-operator#3914

Cherry-pick of the merged fix from upstream `main` into the `rhoai-3.5` release branch.

**Release Blocker:** [RHOAIENG-80362](https://redhat.atlassian.net/browse/RHOAIENG-80362) — Approved by release delivery team ([comment](https://redhat.atlassian.net/browse/RHOAIENG-80362?focusedCommentId=17855805))

**Upstream PR:** https://github.com/opendatahub-io/opendatahub-operator/pull/3914

## Description

Fix DSC controller permanently stuck in NotReady when a module CRD is not yet available (race condition). Two complementary changes:

1. **Requeue on CRD-absent**: When `GetModuleStatus` returns `NoKindMatchError`, track the module as CRD-absent, complete all condition aggregation (including `ModulesReady`), then return `RequeueAfterError(30s)` so the controller retries.

2. **CRD watch**: Add a non-dynamic watch on `CustomResourceDefinition` objects filtered by module API group suffix, so CRD creation triggers reconciliation automatically — providing event-driven recovery.

## Testing

Unit tests included:
- `TestComputeModulesStatusRequeuesOnCRDAbsent` — verifies `NoKindMatchError` triggers `RequeueAfterError(30s)` with conditions still aggregated
- `TestComputeModulesStatusNoRequeueOnRegularError` — verifies regular errors preserve existing behavior (no requeue)

## Files changed (4, all additive — 183 additions, 0 deletions)

- `internal/controller/datasciencecluster/datasciencecluster_controller.go`
- `internal/controller/modules/modules_controller.go`
- `internal/controller/modules/modules_controller_actions.go`
- `internal/controller/modules/modules_controller_actions_test.go`

RHOAIENG-80362