### PR TITLE
feat(kserve): inject ModelRegistry state into Kserve module CR

### DIFF
--- a/get_all_manifests.sh
+++ b/get_all_manifests.sh
@@ -15,7 +15,7 @@ DST_CHARTS_DIR="./opt/charts"
 
 # ODH Component Manifests
 declare -A ODH_COMPONENT_MANIFESTS=(
-    ["kserve-module-operator"]="opendatahub-io:kserve:release-v0.17@01e23b511968fc14de87b9c252154bbfbd0fe79e:kserve-module/config"
+    ["kserve-module-operator"]="opendatahub-io:kserve:release-v0.17@a0ecb0d58041c8c9a1ad1aa344fb420f59c0f0e7:kserve-module/config"
     ["ray"]="opendatahub-io:kuberay:dev@ad425f7febc4039f2378747f2a0ea5dcf5a2263f:ray-operator/config"
     ["trustyai"]="opendatahub-io:trustyai-service-operator:incubation@f79b197393d44e6a5e70e478a913de0e9ab2d78e:config"
     ["modelregistry"]="opendatahub-io:model-registry-operator:main@0f6ed5b41207652873238b62716abb2167266c23:config"
@@ -31,7 +31,7 @@ declare -A ODH_COMPONENT_MANIFESTS=(
 
 # RHOAI Component Manifests
 declare -A RHOAI_COMPONENT_MANIFESTS=(
-    ["kserve-module-operator"]="red-hat-data-services:kserve:rhoai-3.5@4a182d44b97c29692d15dd07c856781ea36026c4:kserve-module/config"
+    ["kserve-module-operator"]="red-hat-data-services:kserve:rhoai-3.5@ca4a57f8300033eaac5ccb8acee034bf2d86096b:kserve-module/config"
     ["ray"]="red-hat-data-services:kuberay:rhoai-3.5@b6e2cb5afb65f14562a3d2821dfaa7b14366c1e4:ray-operator/config"
     ["trustyai"]="red-hat-data-services:trustyai-service-operator:rhoai-3.5@b76913c12d8fc6864b52a3f000a781182f5cf5cc:config"
     ["modelregistry"]="red-hat-data-services:model-registry-operator:rhoai-3.5@4918619c6baf437f9f3052a5daf8bd4aee008f44:config"

--- a/internal/controller/modules/kserve/handler.go
+++ b/internal/controller/modules/kserve/handler.go
@@ -157,6 +157,18 @@ func (h *handler) BuildModuleCR(
 			return nil, fmt.Errorf("failed to convert KserveCommonSpec to unstructured: %w", err)
 		}
 		delete(spec, "modelsAsService")
+
+		// Inject cross-component ModelRegistry state.
+		// ModelRegistry is a separate DSC component, not a Kserve sub-component.
+		// We forward its management state so kserve-module can propagate it
+		// to odh-model-controller's params.env as "modelregistry-state".
+		mrState := string(platform.DSC.Spec.Components.ModelRegistry.ManagementState)
+		if mrState == "" {
+			mrState = string(operatorv1.Removed)
+		}
+		spec["modelRegistry"] = map[string]any{
+			"managementState": mrState,
+		}
 	case platform.Platform != nil:
 		return nil, nil
 	default:

--- a/internal/controller/modules/kserve/handler_modelregistry_test.go
+++ b/internal/controller/modules/kserve/handler_modelregistry_test.go
@@ -1,0 +1,63 @@
+package kserve_test
+
+import (
+	"context"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules/kserve"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestBuildModuleCR_ModelRegistryStateManaged(t *testing.T) {
+	g := NewWithT(t)
+	h := kserve.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+	platform.DSC.Spec.Components.ModelRegistry.ManagementState = operatorv1.Managed
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec is not a map")
+
+	mr, ok := spec["modelRegistry"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec.modelRegistry missing")
+	g.Expect(mr["managementState"]).Should(Equal("Managed"))
+}
+
+func TestBuildModuleCR_ModelRegistryStateRemoved(t *testing.T) {
+	g := NewWithT(t)
+	h := kserve.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+	platform.DSC.Spec.Components.ModelRegistry.ManagementState = operatorv1.Removed
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+
+	mr, ok := spec["modelRegistry"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(mr["managementState"]).Should(Equal("Removed"))
+}
+
+func TestBuildModuleCR_ModelRegistryStateDefaultsToRemoved(t *testing.T) {
+	g := NewWithT(t)
+	h := kserve.NewHandler()
+	platform := newPlatformCtx(operatorv1.Managed)
+	// ModelRegistry management state not set (empty string)
+
+	u, err := h.BuildModuleCR(context.Background(), nil, platform)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+
+	mr, ok := spec["modelRegistry"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec.modelRegistry must be present even when DSC MR state is empty")
+	g.Expect(mr["managementState"]).Should(Equal("Removed"))
+}

--- a/internal/controller/modules/kserve/handler_test.go
+++ b/internal/controller/modules/kserve/handler_test.go
@@ -146,6 +146,10 @@ func TestBuildModuleCR_BasicProjection(t *testing.T) {
 	wva, ok := spec["wva"].(map[string]any)
 	g.Expect(ok).Should(BeTrue(), "spec.wva missing")
 	g.Expect(wva["managementState"]).Should(Equal("Removed"))
+
+	mr, ok := spec["modelRegistry"].(map[string]any)
+	g.Expect(ok).Should(BeTrue(), "spec.modelRegistry missing")
+	g.Expect(mr["managementState"]).Should(Equal("Removed"))
 }
 
 func TestBuildModuleCR_PlatformMode_ReturnsNil(t *testing.T) {

--- a/tests/e2e/controller_test.go
+++ b/tests/e2e/controller_test.go
@@ -142,7 +142,6 @@ var (
 			{
 				componentApi.DashboardComponentName:            dashboardTestSuite,
 				componentApi.RayComponentName:                  rayTestSuite,
-				componentApi.ModelRegistryComponentName:        modelRegistryTestSuite,
 				componentApi.TrainingOperatorComponentName:     trainingOperatorTestSuite,
 				componentApi.TrainerComponentName:              trainerTestSuite,
 				componentApi.DataSciencePipelinesComponentName: dataSciencePipelinesTestSuite,
@@ -157,6 +156,8 @@ var (
 			{
 				// Kueue tests depends on Workbenches, so must not run with Workbenches tests in parallel
 				componentApi.KueueComponentName: kueueTestSuite,
+				// ModelRegistry and Kserve are coupled, so must not run with Kserve tests in parallel
+				componentApi.ModelRegistryComponentName: modelRegistryTestSuite,
 			},
 			{
 				// TrustyAI tests depends on KServe, so must not run with Kserve or ModelsAsService tests in parallel

--- a/tests/e2e/kserve_modelregistry_test.go
+++ b/tests/e2e/kserve_modelregistry_test.go
@@ -1,0 +1,108 @@
+package e2e_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/matchers/jq"
+)
+
+// ValidateModelRegistryStatePropagation verifies that ModelRegistry management state
+// from the DSC is correctly injected into the Kserve module CR spec.
+// This tests the cross-component state injection implemented in handler.go BuildModuleCR.
+func (tc *KserveTestCtx) ValidateModelRegistryStatePropagation(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Tier1)
+
+	tc.SkipIfXKSCluster(t)
+
+	kserveNN := types.NamespacedName{Name: componentApi.KserveInstanceName}
+
+	// Test 1: ModelRegistry Managed → Kserve CR should have modelRegistry.managementState = Managed
+	t.Log("Setting DSC ModelRegistry to Managed")
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, "Managed", "spec", "components", "modelregistry", "managementState")
+		}),
+		WithCondition(
+			jq.Match(`.spec.components.modelregistry.managementState == "Managed"`),
+		),
+	)
+
+	t.Log("Verifying Kserve CR has modelRegistry.managementState = Managed")
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Kserve, kserveNN),
+		WithCondition(
+			jq.Match(`.spec.modelRegistry.managementState == "Managed"`),
+		),
+		WithCustomErrorMsg("Expected Kserve CR to have spec.modelRegistry.managementState = Managed when DSC ModelRegistry is Managed"),
+	)
+
+	// Test 2: ModelRegistry Removed → Kserve CR should have modelRegistry.managementState = Removed
+	t.Log("Setting DSC ModelRegistry to Removed")
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, "Removed", "spec", "components", "modelregistry", "managementState")
+		}),
+		WithCondition(
+			jq.Match(`.spec.components.modelregistry.managementState == "Removed"`),
+		),
+	)
+
+	t.Log("Verifying Kserve CR has modelRegistry.managementState = Removed")
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Kserve, kserveNN),
+		WithCondition(
+			jq.Match(`.spec.modelRegistry.managementState == "Removed"`),
+		),
+		WithCustomErrorMsg("Expected Kserve CR to have spec.modelRegistry.managementState = Removed when DSC ModelRegistry is Removed"),
+	)
+
+	// Test 3: ModelRegistry empty → Kserve CR should default to Removed
+	t.Log("Unsetting DSC ModelRegistry managementState (empty)")
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(func(obj *unstructured.Unstructured) error {
+			// Remove the managementState field entirely
+			components, found, err := unstructured.NestedMap(obj.Object, "spec", "components", "modelregistry")
+			if err != nil || !found {
+				return err
+			}
+			delete(components, "managementState")
+			return unstructured.SetNestedMap(obj.Object, components, "spec", "components", "modelregistry")
+		}),
+		WithCondition(
+			jq.Match(`.spec.components.modelregistry.managementState // "" == ""`),
+		),
+	)
+
+	t.Log("Verifying Kserve CR has modelRegistry.managementState = Removed (default when empty)")
+	tc.EnsureResourceExists(
+		WithMinimalObject(gvk.Kserve, kserveNN),
+		WithCondition(
+			jq.Match(`.spec.modelRegistry.managementState == "Removed"`),
+		),
+		WithCustomErrorMsg("Expected Kserve CR to have spec.modelRegistry.managementState = Removed (default) when DSC ModelRegistry state is empty"),
+	)
+
+	// Restore to Removed for subsequent tests
+	t.Log("Restoring DSC ModelRegistry to Removed")
+	tc.EventuallyResourcePatched(
+		WithMinimalObject(gvk.DataScienceCluster, tc.DataScienceClusterNamespacedName),
+		WithMutateFunc(func(obj *unstructured.Unstructured) error {
+			return unstructured.SetNestedField(obj.Object, "Removed", "spec", "components", "modelregistry", "managementState")
+		}),
+		WithCondition(
+			jq.Match(`.spec.components.modelregistry.managementState == "Removed"`),
+		),
+	)
+
+	t.Log("ModelRegistry state propagation validation passed")
+}

--- a/tests/e2e/kserve_test.go
+++ b/tests/e2e/kserve_test.go
@@ -87,6 +87,7 @@ func kserveTestSuite(t *testing.T) {
 
 	testCases = append(testCases,
 		TestCase{"Validate platform config ConfigMap", componentCtx.ValidatePlatformConfigMap},
+		TestCase{"Validate ModelRegistry state propagation", componentCtx.ValidateModelRegistryStatePropagation},
 		TestCase{"Validate resource deletion recovery", componentCtx.ValidateAllDeletionRecovery},
 		TestCase{"Validate component disabled", componentCtx.ValidateComponentDisabled},
 	)
@@ -142,6 +143,14 @@ func (tc *KserveTestCtx) ValidateSpec(t *testing.T) {
 		WithCondition(And(
 			// Validate management states of NIM and serving components.
 			jq.Match(`.spec.nim.managementState == "%s"`, dsc.Spec.Components.Kserve.NIM.ManagementState),
+			// Validate ModelRegistry state is injected from DSC
+			jq.Match(`.spec.modelRegistry.managementState == "%s"`,
+				func() string {
+					if dsc.Spec.Components.ModelRegistry.ManagementState == "" {
+						return "Removed"
+					}
+					return string(dsc.Spec.Components.ModelRegistry.ManagementState)
+				}()),
 		),
 		),
 	)


### PR DESCRIPTION
Inject the ModelRegistry component's management state into the Kserve module CR spec. This allows the Kserve module operator to configure itself based on whether ModelRegistry is enabled in the platform.

Assisted-by: Claude Code (claude.ai/code)

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- These fields are mandatory - CI will block merging unless they are set -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: rhoai-3.5
<!-- Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-80111


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
