### PR TITLE
fix(dashboard): sync namespace-scoped RBAC from private repo [rhoai-3.5]

### DIFF
--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -48,6 +48,7 @@ func commonActions() []actions.Fn {
 		initializeModules,
 		cleanupDisabledModules,
 		provisionModules,
+		ensureDashboardNamespacedRBAC,
 		helmrender.NewAction(),
 		kustomizerender.NewAction(),
 		provision.ExtractUpgradeGates,

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
@@ -1,0 +1,202 @@
+package modules
+
+import (
+	"context"
+	"fmt"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+)
+
+const (
+	dashboardSANameODH   = "odh-dashboard"
+	dashboardSANameRHOAI = "rhods-dashboard"
+	dashboardRoleKind    = "Role"
+	rbacVerbCreate       = "create"
+	rbacVerbGet          = "get"
+	rbacVerbUpdate       = "update"
+	rbacVerbDelete       = "delete"
+	rbacVerbList         = "list"
+	rbacVerbPatch        = "patch"
+	rbacResourceSecrets  = "secrets"
+	rbacResourceCMs      = "configmaps"
+	rbacResourcePVCs     = "persistentvolumeclaims"
+)
+
+func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
+	if !DefaultRegistry().IsEnabled(componentApi.DashboardComponentName) {
+		return nil
+	}
+
+	logger := logf.FromContext(ctx)
+
+	saName := dashboardSANameODH
+	if rr.Release.Name == cluster.SelfManagedRhoai || rr.Release.Name == cluster.ManagedRhoai {
+		saName = dashboardSANameRHOAI
+	}
+
+	appNamespace := cluster.GetApplicationNamespace()
+
+	notebooksNS, err := resolveDashboardNotebooksNamespace(ctx, rr)
+	if err != nil {
+		return fmt.Errorf("failed to resolve notebooks namespace: %w", err)
+	}
+	if notebooksNS != "" {
+		logger.V(1).Info("ensuring Dashboard RBAC in notebooks namespace", "namespace", notebooksNS)
+		if err := addDashboardNamespacedRBAC(rr, saName, appNamespace, notebooksNS, "notebooks", dashboardNotebooksRBACRules()); err != nil {
+			return fmt.Errorf("failed to add notebooks RBAC resources: %w", err)
+		}
+	}
+
+	modelRegistryNS, err := resolveDashboardModelRegistryNamespace(ctx, rr)
+	if err != nil {
+		return fmt.Errorf("failed to resolve model-registry namespace: %w", err)
+	}
+	if modelRegistryNS != "" {
+		logger.V(1).Info("ensuring Dashboard RBAC in model-registry namespace", "namespace", modelRegistryNS)
+		if err := addDashboardNamespacedRBAC(rr, saName, appNamespace, modelRegistryNS, "model-registries", dashboardModelRegistryRBACRules()); err != nil {
+			return fmt.Errorf("failed to add model-registry RBAC resources: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func resolveDashboardNotebooksNamespace(ctx context.Context, rr *odhtype.ReconciliationRequest) (string, error) {
+	logger := logf.FromContext(ctx)
+
+	if !DefaultRegistry().IsEnabled(componentApi.WorkbenchesComponentName) {
+		logger.V(1).Info("Workbenches not enabled, skipping notebooks RBAC")
+		return "", nil
+	}
+
+	var ns string
+	if dsc := dscFromInstance(rr); dsc != nil {
+		ns = dsc.Spec.Components.Workbenches.WorkbenchNamespace
+	}
+	if ns == "" {
+		switch rr.Release.Name {
+		case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+			ns = cluster.DefaultNotebooksNamespaceRHOAI
+		case cluster.OpenDataHub:
+			ns = cluster.DefaultNotebooksNamespaceODH
+		}
+	}
+
+	exists, err := cluster.NamespaceExists(ctx, rr.Client, ns)
+	if err != nil {
+		return "", fmt.Errorf("failed to check notebooks namespace %q: %w", ns, err)
+	}
+	if !exists {
+		logger.V(1).Info("notebooks namespace not found, skipping RBAC", "namespace", ns)
+		return "", nil
+	}
+
+	return ns, nil
+}
+
+func resolveDashboardModelRegistryNamespace(ctx context.Context, rr *odhtype.ReconciliationRequest) (string, error) {
+	logger := logf.FromContext(ctx)
+
+	mr := &componentApi.ModelRegistry{}
+	err := rr.Client.Get(ctx, client.ObjectKey{Name: componentApi.ModelRegistryInstanceName}, mr)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			logger.V(1).Info("ModelRegistry CR not found, skipping model-registry RBAC")
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get ModelRegistry CR: %w", err)
+	}
+
+	ns := mr.Spec.RegistriesNamespace
+	if ns == "" {
+		logger.V(1).Info("ModelRegistry registriesNamespace is empty, skipping RBAC")
+		return "", nil
+	}
+
+	exists, err := cluster.NamespaceExists(ctx, rr.Client, ns)
+	if err != nil {
+		return "", fmt.Errorf("failed to check model-registry namespace %q: %w", ns, err)
+	}
+	if !exists {
+		logger.V(1).Info("model-registry namespace not found, skipping RBAC", "namespace", ns)
+		return "", nil
+	}
+
+	return ns, nil
+}
+
+func addDashboardNamespacedRBAC(rr *odhtype.ReconciliationRequest, saName, saNamespace, targetNamespace, roleSuffix string, rules []rbacv1.PolicyRule) error {
+	roleName := saName + "-" + roleSuffix
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: targetNamespace,
+		},
+		Rules: rules,
+	}
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: targetNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     dashboardRoleKind,
+			Name:     roleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      saName,
+				Namespace: saNamespace,
+			},
+		},
+	}
+
+	return rr.AddResources(role, rb)
+}
+
+func dashboardNotebooksRBACRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourcePVCs},
+			Verbs:     []string{rbacVerbCreate, rbacVerbGet},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourceCMs},
+			Verbs:     []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourceSecrets},
+			Verbs:     []string{rbacVerbCreate, rbacVerbGet, rbacVerbUpdate},
+		},
+	}
+}
+
+func dashboardModelRegistryRBACRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourceSecrets},
+			Verbs:     []string{rbacVerbCreate, rbacVerbDelete, rbacVerbGet, rbacVerbList, rbacVerbPatch},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{rbacResourceCMs},
+			Verbs:     []string{rbacVerbCreate, rbacVerbList},
+		},
+	}
+}

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
@@ -1,0 +1,326 @@
+//nolint:testpackage // Needs package access for unexported functions and registry helpers.
+package modules
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+)
+
+const testModelRegistryNS = "rhoai-model-registries"
+
+func newDashboardRBACTestRR(t *testing.T, platform common.Platform, dsc *dscv2.DataScienceCluster, objects ...client.Object) *types.ReconciliationRequest {
+	t.Helper()
+
+	cli, err := fakeclient.New(fakeclient.WithObjects(objects...))
+	if err != nil {
+		t.Fatalf("create fake client: %v", err)
+	}
+
+	if dsc == nil {
+		dsc = &dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"}}
+	}
+
+	return &types.ReconciliationRequest{
+		Client:   cli,
+		Instance: dsc,
+		Release:  common.Release{Name: platform},
+	}
+}
+
+func enableDashboardInRegistry(t *testing.T) {
+	t.Helper()
+	withTestRegistry(t)
+	DefaultRegistry().Add(&dashboardStub{enabled: true})
+}
+
+func enableWorkbenchesInRegistry(t *testing.T) {
+	t.Helper()
+	DefaultRegistry().Add(&workbenchesStub{enabled: true})
+}
+
+type dashboardStub struct {
+	BaseHandler
+
+	enabled bool
+}
+
+func (s *dashboardStub) GetName() string {
+	return componentApi.DashboardComponentName
+}
+func (s *dashboardStub) IsEnabled(_ *PlatformContext) bool {
+	return s.enabled
+}
+func (s *dashboardStub) BuildModuleCR(_ context.Context, _ client.Client, _ *PlatformContext) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+type workbenchesStub struct {
+	BaseHandler
+
+	enabled bool
+}
+
+func (s *workbenchesStub) GetName() string {
+	return componentApi.WorkbenchesComponentName
+}
+func (s *workbenchesStub) IsEnabled(_ *PlatformContext) bool {
+	return s.enabled
+}
+func (s *workbenchesStub) BuildModuleCR(_ context.Context, _ client.Client, _ *PlatformContext) (*unstructured.Unstructured, error) {
+	return nil, nil
+}
+
+func TestEnsureDashboardNamespacedRBAC_BothNamespacesExist(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+	modelRegNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testModelRegistryNS}}
+	mr := &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.ModelRegistryInstanceName},
+		Spec: componentApi.ModelRegistrySpec{
+			ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+				RegistriesNamespace: testModelRegistryNS,
+			},
+		},
+	}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, notebooksNS, modelRegNS, mr)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 4 {
+		t.Fatalf("expected 4 resources (2 Roles + 2 RoleBindings), got %d", len(rr.Resources))
+	}
+
+	hasRole := func(name, namespace string) bool {
+		for _, res := range rr.Resources {
+			if res.GetKind() == dashboardRoleKind && res.GetName() == name && res.GetNamespace() == namespace {
+				return true
+			}
+		}
+		return false
+	}
+	hasRoleBinding := func(name, namespace string) bool {
+		for _, res := range rr.Resources {
+			if res.GetKind() == "RoleBinding" && res.GetName() == name && res.GetNamespace() == namespace {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !hasRole("rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI) {
+		t.Error("missing notebooks Role")
+	}
+	if !hasRoleBinding("rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI) {
+		t.Error("missing notebooks RoleBinding")
+	}
+	if !hasRole("rhods-dashboard-model-registries", testModelRegistryNS) {
+		t.Error("missing model-registry Role")
+	}
+	if !hasRoleBinding("rhods-dashboard-model-registries", testModelRegistryNS) {
+		t.Error("missing model-registry RoleBinding")
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_DashboardDisabled(t *testing.T) {
+	withTestRegistry(t)
+	DefaultRegistry().Add(&dashboardStub{enabled: false})
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 0 {
+		t.Fatalf("expected 0 resources when dashboard disabled, got %d", len(rr.Resources))
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_NotebooksMissing(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	modelRegNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testModelRegistryNS}}
+	mr := &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.ModelRegistryInstanceName},
+		Spec: componentApi.ModelRegistrySpec{
+			ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+				RegistriesNamespace: testModelRegistryNS,
+			},
+		},
+	}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, modelRegNS, mr)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 2 {
+		t.Fatalf("expected 2 resources (model-registry only), got %d", len(rr.Resources))
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_ModelRegistryMissing(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, notebooksNS)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 2 {
+		t.Fatalf("expected 2 resources (notebooks only), got %d", len(rr.Resources))
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_WorkbenchesDisabled(t *testing.T) {
+	enableDashboardInRegistry(t)
+	DefaultRegistry().Add(&workbenchesStub{enabled: false})
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 0 {
+		t.Fatalf("expected 0 resources when workbenches disabled, got %d", len(rr.Resources))
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_ODHSAName(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceODH}}
+
+	rr := newDashboardRBACTestRR(t, cluster.OpenDataHub, nil, notebooksNS)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 2 {
+		t.Fatalf("expected 2 resources, got %d", len(rr.Resources))
+	}
+
+	for _, res := range rr.Resources {
+		if res.GetKind() == dashboardRoleKind && res.GetName() != "odh-dashboard-notebooks" {
+			t.Errorf("expected ODH SA name in role, got %q", res.GetName())
+		}
+	}
+}
+
+func TestDashboardModelRegistryRBACRules_ContainsCreateVerb(t *testing.T) {
+	rules := dashboardModelRegistryRBACRules()
+
+	for _, rule := range rules {
+		if len(rule.Resources) == 1 && rule.Resources[0] == rbacResourceSecrets {
+			if !slices.Contains(rule.Verbs, rbacVerbCreate) {
+				t.Error("model-registry secrets rule missing 'create' verb")
+			}
+			if !slices.Contains(rule.Verbs, rbacVerbGet) {
+				t.Error("model-registry secrets rule missing 'get' verb")
+			}
+			return
+		}
+	}
+	t.Error("no secrets rule found in model-registry RBAC rules")
+}
+
+func TestEnsureDashboardNamespacedRBAC_RoleBindingSubject(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cluster.DefaultNotebooksNamespaceRHOAI}}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, nil, notebooksNS)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, res := range rr.Resources {
+		if res.GetKind() != "RoleBinding" {
+			continue
+		}
+
+		subjects, ok, _ := unstructured.NestedSlice(res.Object, "subjects")
+		if !ok || len(subjects) != 1 {
+			t.Fatalf("expected exactly 1 subject in RoleBinding, got %d", len(subjects))
+		}
+
+		subj, ok := subjects[0].(map[string]interface{})
+		if !ok {
+			t.Fatal("subject is not a map")
+		}
+
+		if subj["kind"] != string(rbacv1.ServiceAccountKind) {
+			t.Errorf("expected ServiceAccount kind, got %v", subj["kind"])
+		}
+		if subj["name"] != dashboardSANameRHOAI {
+			t.Errorf("expected SA name %q, got %v", dashboardSANameRHOAI, subj["name"])
+		}
+	}
+}
+
+func TestEnsureDashboardNamespacedRBAC_CustomWorkbenchNamespace(t *testing.T) {
+	enableDashboardInRegistry(t)
+	enableWorkbenchesInRegistry(t)
+
+	customNS := "custom-notebooks"
+	notebooksNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: customNS}}
+
+	dsc := &dscv2.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"},
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				Workbenches: componentApi.DSCWorkbenches{
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: customNS,
+					},
+				},
+			},
+		},
+	}
+
+	rr := newDashboardRBACTestRR(t, cluster.SelfManagedRhoai, dsc, notebooksNS)
+
+	if err := ensureDashboardNamespacedRBAC(context.Background(), rr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rr.Resources) != 2 {
+		t.Fatalf("expected 2 resources (notebooks only), got %d", len(rr.Resources))
+	}
+
+	for _, res := range rr.Resources {
+		if res.GetNamespace() != customNS {
+			t.Errorf("expected namespace %q, got %q", customNS, res.GetNamespace())
+		}
+	}
+}


### PR DESCRIPTION
## Description

Ports the dashboard namespace-scoped RBAC fix to the rhoai-3.5 (modules architecture) branch.

The 3.5 branch uses `internal/controller/modules/` instead of `internal/controller/components/dashboard/`, so this is a full new implementation adapted for the modules pattern:

- `modules_controller_actions_dashboard_rbac.go`: `ensureDashboardNamespacedRBAC` creates per-namespace Roles and RoleBindings for the dashboard SA in the notebooks and model-registry namespaces
- `modules_controller_actions_dashboard_rbac_test.go`: unit tests covering all scenarios
- `modules_controller.go`: wires `ensureDashboardNamespacedRBAC` into the common actions chain

**3.5-specific adaptation**: the `Workbenches` CRD was removed in the 3.5 modules refactor. Workbenches enablement is read via `DefaultRegistry().IsEnabled(WorkbenchesComponentName)` and the notebooks namespace from `DSC.Spec.Components.Workbenches.WorkbenchNamespace` with a fallback to the platform-default constant.

Related: RHOAIENG-80335 / RHOAIENG-75953

## How Has This Been Tested?

Unit tests in `modules_controller_actions_dashboard_rbac_test.go` cover:
- Both namespaces exist: 4 resources created (2 Roles + 2 RoleBindings)
- Dashboard disabled: 0 resources
- Workbenches disabled: 0 notebooks resources
- Notebooks namespace missing: only model-registry RBAC
- ModelRegistry CR missing: only notebooks RBAC
- ODH platform: correct SA name (`odh-dashboard`)
- Custom `WorkbenchNamespace` from DSC spec
- RoleBinding subject points to the correct SA

## Merge criteria

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This is a backport of a security fix introducing namespace-scoped RBAC. The functionality is covered by unit tests in this PR. E2E test coverage for this specific RBAC pattern will be tracked separately.