### PR TITLE
fix(dashboard): watch Namespace events to ensure namespaced RBAC is reconciled

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,7 @@ import (
 	featurev1 "github.com/opendatahub-io/opendatahub-operator/v2/api/features/v1"
 	infrastructurev1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1alpha1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
+	modelregistryctrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelregistry"
 	cr "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/registry"
 	dscctrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/datasciencecluster"
 	dscictrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/dscinitialization"
@@ -91,7 +92,6 @@ import (
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/llamastackoperator"
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelcontroller"
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelmeshserving"
-	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/modelregistry"
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/ray"
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/trainingoperator"
 	_ "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components/trustyai"
@@ -539,6 +539,15 @@ func createODHGeneralCacheConfig(ctx context.Context, cli client.Client, platfor
 
 	namespaceConfigs["istio-system"] = cache.Config{}        // for serivcemonitor: data-science-smcp-pilot-monitor
 	namespaceConfigs["openshift-operators"] = cache.Config{} // for dependent operators installed namespace
+
+	switch platform {
+	case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+		namespaceConfigs[cluster.DefaultNotebooksNamespaceRHOAI] = cache.Config{}
+		namespaceConfigs[modelregistryctrl.DefaultModelRegistriesNamespace] = cache.Config{}
+	case cluster.OpenDataHub:
+		namespaceConfigs[cluster.DefaultNotebooksNamespaceODH] = cache.Config{}
+		namespaceConfigs["odh-model-registries"] = cache.Config{}
+	}
 
 	return namespaceConfigs, nil
 }

--- a/internal/controller/components/dashboard/dashboard_controller.go
+++ b/internal/controller/components/dashboard/dashboard_controller.go
@@ -95,6 +95,10 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			GenericFunc: func(tge event.TypedGenericEvent[client.Object]) bool { return false },
 			DeleteFunc:  func(tde event.TypedDeleteEvent[client.Object]) bool { return false },
 		}), reconciler.Dynamic(reconciler.CrdExists(gvk.DashboardHardwareProfile))).
+		// Namespace events re-trigger reconciliation so that ensureNamespacedRBAC
+		// can create or remove the notebooks/model-registry Role and RoleBinding
+		// when the target namespace appears or disappears after initial reconcile.
+		Watches(&corev1.Namespace{}).
 		WithAction(initialize).
 		WithAction(devFlags).
 		WithAction(setKustomizedParams).

--- a/internal/controller/components/dashboard/dashboard_controller.go
+++ b/internal/controller/components/dashboard/dashboard_controller.go
@@ -99,6 +99,7 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 		WithAction(devFlags).
 		WithAction(setKustomizedParams).
 		WithAction(configureDependencies).
+		WithAction(ensureNamespacedRBAC).
 		WithAction(kustomize.NewAction(
 			// Those are the default labels added by the legacy deploy method
 			// and should be preserved as the original plugin were affecting

--- a/internal/controller/components/dashboard/dashboard_controller_actions.go
+++ b/internal/controller/components/dashboard/dashboard_controller_actions.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -273,4 +274,185 @@ func updateInfraHWP(ctx context.Context, rr *odhtypes.ReconciliationRequest, log
 
 	logger.Info("successfully updated infrastructure hardware profile", "name", infrahwp.GetName())
 	return nil
+}
+
+func ensureNamespacedRBAC(ctx context.Context, rr *odhtypes.ReconciliationRequest) error {
+	logger := log.FromContext(ctx)
+
+	appNamespace := rr.DSCI.Spec.ApplicationsNamespace
+
+	saName := ServiceAccountNameODH
+	if rr.Release.Name == cluster.SelfManagedRhoai || rr.Release.Name == cluster.ManagedRhoai {
+		saName = ServiceAccountNameRHOAI
+	}
+
+	notebooksNS, err := resolveNotebooksNamespace(ctx, rr)
+	if err != nil {
+		return fmt.Errorf("failed to resolve notebooks namespace: %w", err)
+	}
+	if notebooksNS != "" {
+		logger.V(1).Info("ensuring Dashboard RBAC in notebooks namespace", "namespace", notebooksNS)
+		if err := addNamespacedRBAC(rr, saName, appNamespace, notebooksNS, "notebooks", notebooksRBACRules()); err != nil {
+			return fmt.Errorf("failed to add notebooks RBAC resources: %w", err)
+		}
+	}
+
+	modelRegistryNS, err := resolveModelRegistryNamespace(ctx, rr)
+	if err != nil {
+		return fmt.Errorf("failed to resolve model-registry namespace: %w", err)
+	}
+	if modelRegistryNS != "" {
+		logger.V(1).Info("ensuring Dashboard RBAC in model-registry namespace", "namespace", modelRegistryNS)
+		if err := addNamespacedRBAC(rr, saName, appNamespace, modelRegistryNS, "model-registries", modelRegistryRBACRules()); err != nil {
+			return fmt.Errorf("failed to add model-registry RBAC resources: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func resolveNotebooksNamespace(ctx context.Context, rr *odhtypes.ReconciliationRequest) (string, error) {
+	logger := log.FromContext(ctx)
+
+	wb := &componentApi.Workbenches{}
+	err := rr.Client.Get(ctx, client.ObjectKey{Name: componentApi.WorkbenchesInstanceName}, wb)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			logger.V(1).Info("Workbenches CR not found, skipping notebooks RBAC")
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get Workbenches CR: %w", err)
+	}
+
+	ns := wb.Spec.WorkbenchNamespace
+	if ns == "" {
+		switch rr.Release.Name {
+		case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+			ns = cluster.DefaultNotebooksNamespaceRHOAI
+		case cluster.OpenDataHub:
+			ns = cluster.DefaultNotebooksNamespaceODH
+		}
+	}
+
+	exists, err := namespaceExists(ctx, rr.Client, ns)
+	if err != nil {
+		return "", fmt.Errorf("failed to check notebooks namespace %q: %w", ns, err)
+	}
+	if !exists {
+		logger.V(1).Info("notebooks namespace not found, skipping RBAC", "namespace", ns)
+		return "", nil
+	}
+
+	return ns, nil
+}
+
+func resolveModelRegistryNamespace(ctx context.Context, rr *odhtypes.ReconciliationRequest) (string, error) {
+	logger := log.FromContext(ctx)
+
+	mr := &componentApi.ModelRegistry{}
+	err := rr.Client.Get(ctx, client.ObjectKey{Name: componentApi.ModelRegistryInstanceName}, mr)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			logger.V(1).Info("ModelRegistry CR not found, skipping model-registry RBAC")
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get ModelRegistry CR: %w", err)
+	}
+
+	ns := mr.Spec.RegistriesNamespace
+	if ns == "" {
+		logger.V(1).Info("ModelRegistry registriesNamespace is empty, skipping RBAC")
+		return "", nil
+	}
+
+	exists, err := namespaceExists(ctx, rr.Client, ns)
+	if err != nil {
+		return "", fmt.Errorf("failed to check model-registry namespace %q: %w", ns, err)
+	}
+	if !exists {
+		logger.V(1).Info("model-registry namespace not found, skipping RBAC", "namespace", ns)
+		return "", nil
+	}
+
+	return ns, nil
+}
+
+func addNamespacedRBAC(rr *odhtypes.ReconciliationRequest, saName, saNamespace, targetNamespace, roleSuffix string, rules []rbacv1.PolicyRule) error {
+	roleName := saName + "-" + roleSuffix
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: targetNamespace,
+		},
+		Rules: rules,
+	}
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleName,
+			Namespace: targetNamespace,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "Role",
+			Name:     roleName,
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      saName,
+				Namespace: saNamespace,
+			},
+		},
+	}
+
+	return rr.AddResources(role, rb)
+}
+
+func notebooksRBACRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"persistentvolumeclaims"},
+			Verbs:     []string{"create", "get"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"create", "get", "update"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"create", "get", "update"},
+		},
+	}
+}
+
+func modelRegistryRBACRules() []rbacv1.PolicyRule {
+	return []rbacv1.PolicyRule{
+		{
+			APIGroups: []string{""},
+			Resources: []string{"secrets"},
+			Verbs:     []string{"create", "delete", "get", "list", "patch"},
+		},
+		{
+			APIGroups: []string{""},
+			Resources: []string{"configmaps"},
+			Verbs:     []string{"create", "list"},
+		},
+	}
+}
+
+func namespaceExists(ctx context.Context, c client.Client, name string) (bool, error) {
+	ns := &corev1.Namespace{}
+	err := c.Get(ctx, client.ObjectKey{Name: name}, ns)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/internal/controller/components/dashboard/dashboard_controller_actions_rbac_test.go
+++ b/internal/controller/components/dashboard/dashboard_controller_actions_rbac_test.go
@@ -1,0 +1,544 @@
+//nolint:testpackage
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dsciv1 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+func newDSCI(appNS string) *dsciv1.DSCInitialization {
+	return &dsciv1.DSCInitialization{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-dsci"},
+		Spec: dsciv1.DSCInitializationSpec{
+			ApplicationsNamespace: appNS,
+		},
+	}
+}
+
+func newNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+func newWorkbenches(ns string) *componentApi.Workbenches {
+	return &componentApi.Workbenches{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.WorkbenchesInstanceName},
+		Spec: componentApi.WorkbenchesSpec{
+			WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+				WorkbenchNamespace: ns,
+			},
+		},
+	}
+}
+
+func newModelRegistry(ns string) *componentApi.ModelRegistry {
+	return &componentApi.ModelRegistry{
+		ObjectMeta: metav1.ObjectMeta{Name: componentApi.ModelRegistryInstanceName},
+		Spec: componentApi.ModelRegistrySpec{
+			ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+				RegistriesNamespace: ns,
+			},
+		},
+	}
+}
+
+func TestEnsureNamespacedRBAC(t *testing.T) {
+	tests := []struct {
+		name              string
+		platform          common.Platform
+		objects           []client.Object
+		expectedCount     int
+		expectedRoleNames []string
+	}{
+		{
+			name:     "both components enabled with namespaces present",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newDSCI("redhat-ods-applications"),
+				newNamespace("redhat-ods-applications"),
+				newNamespace("rhods-notebooks"),
+				newNamespace("rhoai-model-registries"),
+				newWorkbenches("rhods-notebooks"),
+				newModelRegistry("rhoai-model-registries"),
+			},
+			expectedCount:     4,
+			expectedRoleNames: []string{"rhods-dashboard-notebooks", "rhods-dashboard-model-registries"},
+		},
+		{
+			name:     "only workbenches enabled",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newDSCI("redhat-ods-applications"),
+				newNamespace("redhat-ods-applications"),
+				newNamespace("rhods-notebooks"),
+				newWorkbenches("rhods-notebooks"),
+			},
+			expectedCount:     2,
+			expectedRoleNames: []string{"rhods-dashboard-notebooks"},
+		},
+		{
+			name:     "only model-registry enabled",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newDSCI("redhat-ods-applications"),
+				newNamespace("redhat-ods-applications"),
+				newNamespace("rhoai-model-registries"),
+				newModelRegistry("rhoai-model-registries"),
+			},
+			expectedCount:     2,
+			expectedRoleNames: []string{"rhods-dashboard-model-registries"},
+		},
+		{
+			name:     "neither component enabled",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newDSCI("redhat-ods-applications"),
+				newNamespace("redhat-ods-applications"),
+			},
+			expectedCount: 0,
+		},
+		{
+			name:     "ODH platform uses correct SA name",
+			platform: cluster.OpenDataHub,
+			objects: []client.Object{
+				newDSCI("opendatahub"),
+				newNamespace("opendatahub"),
+				newNamespace("odh-notebooks"),
+				newWorkbenches("odh-notebooks"),
+			},
+			expectedCount:     2,
+			expectedRoleNames: []string{"odh-dashboard-notebooks"},
+		},
+		{
+			name:     "workbenches namespace does not exist",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newDSCI("redhat-ods-applications"),
+				newNamespace("redhat-ods-applications"),
+				newWorkbenches("rhods-notebooks"),
+			},
+			expectedCount: 0,
+		},
+		{
+			name:     "model-registry namespace does not exist",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newDSCI("redhat-ods-applications"),
+				newNamespace("redhat-ods-applications"),
+				newModelRegistry("rhoai-model-registries"),
+			},
+			expectedCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			cli, err := fakeclient.New(fakeclient.WithObjects(tt.objects...))
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			var dsci *dsciv1.DSCInitialization
+			for _, obj := range tt.objects {
+				if d, ok := obj.(*dsciv1.DSCInitialization); ok {
+					dsci = d
+					break
+				}
+			}
+
+			rr := &odhtypes.ReconciliationRequest{
+				Client:    cli,
+				Instance:  &componentApi.Dashboard{},
+				Release:   common.Release{Name: tt.platform},
+				Resources: []unstructured.Unstructured{},
+				DSCI:      dsci,
+			}
+
+			err = ensureNamespacedRBAC(ctx, rr)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(rr.Resources).To(HaveLen(tt.expectedCount))
+
+			for _, expectedName := range tt.expectedRoleNames {
+				foundRole := false
+				foundRoleBinding := false
+				for _, res := range rr.Resources {
+					if res.GetName() == expectedName {
+						switch res.GetKind() {
+						case "Role":
+							foundRole = true
+						case "RoleBinding":
+							foundRoleBinding = true
+						}
+					}
+				}
+				g.Expect(foundRole).To(BeTrue(), "expected Role %q not found", expectedName)
+				g.Expect(foundRoleBinding).To(BeTrue(), "expected RoleBinding %q not found", expectedName)
+			}
+		})
+	}
+}
+
+func TestEnsureNamespacedRBAC_RoleBindingSubjects(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsci := newDSCI("redhat-ods-applications")
+	cli, err := fakeclient.New(fakeclient.WithObjects(
+		dsci,
+		newNamespace("redhat-ods-applications"),
+		newNamespace("rhods-notebooks"),
+		newWorkbenches("rhods-notebooks"),
+	))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client:    cli,
+		Instance:  &componentApi.Dashboard{},
+		Release:   common.Release{Name: cluster.SelfManagedRhoai},
+		Resources: []unstructured.Unstructured{},
+		DSCI:      dsci,
+	}
+
+	err = ensureNamespacedRBAC(ctx, rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	for _, res := range rr.Resources {
+		if res.GetKind() != "RoleBinding" {
+			continue
+		}
+
+		g.Expect(res.GetNamespace()).To(Equal("rhods-notebooks"))
+
+		subjects, _, _ := unstructured.NestedSlice(res.Object, "subjects")
+		g.Expect(subjects).To(HaveLen(1))
+
+		subject, ok := subjects[0].(map[string]any)
+		g.Expect(ok).To(BeTrue(), "subject should be a map")
+		g.Expect(subject["kind"]).To(Equal("ServiceAccount"))
+		g.Expect(subject["name"]).To(Equal("rhods-dashboard"))
+		g.Expect(subject["namespace"]).To(Equal("redhat-ods-applications"))
+
+		roleRef, _, _ := unstructured.NestedMap(res.Object, "roleRef")
+		g.Expect(roleRef["kind"]).To(Equal("Role"))
+		g.Expect(roleRef["name"]).To(Equal("rhods-dashboard-notebooks"))
+	}
+}
+
+func TestEnsureNamespacedRBAC_RoleRules(t *testing.T) {
+	g := NewWithT(t)
+	ctx := t.Context()
+
+	dsci := newDSCI("redhat-ods-applications")
+	cli, err := fakeclient.New(fakeclient.WithObjects(
+		dsci,
+		newNamespace("redhat-ods-applications"),
+		newNamespace("rhods-notebooks"),
+		newNamespace("rhoai-model-registries"),
+		newWorkbenches("rhods-notebooks"),
+		newModelRegistry("rhoai-model-registries"),
+	))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	rr := &odhtypes.ReconciliationRequest{
+		Client:    cli,
+		Instance:  &componentApi.Dashboard{},
+		Release:   common.Release{Name: cluster.SelfManagedRhoai},
+		Resources: []unstructured.Unstructured{},
+		DSCI:      dsci,
+	}
+
+	err = ensureNamespacedRBAC(ctx, rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	for _, res := range rr.Resources {
+		if res.GetKind() != "Role" {
+			continue
+		}
+
+		rules, _, _ := unstructured.NestedSlice(res.Object, "rules")
+		g.Expect(rules).NotTo(BeEmpty(), "Role %q should have rules", res.GetName())
+
+		switch res.GetName() {
+		case "rhods-dashboard-notebooks":
+			g.Expect(res.GetNamespace()).To(Equal("rhods-notebooks"))
+			g.Expect(rules).To(HaveLen(3))
+
+			resourceNames := extractResourceNames(rules)
+			g.Expect(resourceNames).To(ContainElements("persistentvolumeclaims", "configmaps", "secrets"))
+
+		case "rhods-dashboard-model-registries":
+			g.Expect(res.GetNamespace()).To(Equal("rhoai-model-registries"))
+			g.Expect(rules).To(HaveLen(2))
+
+			resourceNames := extractResourceNames(rules)
+			g.Expect(resourceNames).To(ContainElements("secrets", "configmaps"))
+		}
+	}
+}
+
+func extractResourceNames(rules []any) []string {
+	var names []string
+	for _, r := range rules {
+		rule, ok := r.(map[string]any)
+		if !ok {
+			continue
+		}
+		resources, _, _ := unstructured.NestedStringSlice(rule, "resources")
+		names = append(names, resources...)
+	}
+	return names
+}
+
+func TestResolveNotebooksNamespace(t *testing.T) {
+	tests := []struct {
+		name        string
+		platform    common.Platform
+		objects     []client.Object
+		interceptor *interceptor.Funcs
+		expectedNS  string
+		expectErr   bool
+	}{
+		{
+			name:     "returns custom namespace from Workbenches CR",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newWorkbenches("custom-notebooks"),
+				newNamespace("custom-notebooks"),
+			},
+			expectedNS: "custom-notebooks",
+		},
+		{
+			name:     "falls back to RHOAI default when namespace field is empty",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newWorkbenches(""),
+				newNamespace(cluster.DefaultNotebooksNamespaceRHOAI),
+			},
+			expectedNS: cluster.DefaultNotebooksNamespaceRHOAI,
+		},
+		{
+			name:     "falls back to ODH default when namespace field is empty",
+			platform: cluster.OpenDataHub,
+			objects: []client.Object{
+				newWorkbenches(""),
+				newNamespace(cluster.DefaultNotebooksNamespaceODH),
+			},
+			expectedNS: cluster.DefaultNotebooksNamespaceODH,
+		},
+		{
+			name:       "returns empty when Workbenches CR not found",
+			platform:   cluster.SelfManagedRhoai,
+			objects:    []client.Object{},
+			expectedNS: "",
+		},
+		{
+			name:     "returns empty when namespace does not exist",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newWorkbenches("nonexistent-ns"),
+			},
+			expectedNS: "",
+		},
+		{
+			name:     "returns error on non-NotFound Get failure",
+			platform: cluster.SelfManagedRhoai,
+			objects:  []client.Object{},
+			interceptor: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*componentApi.Workbenches); ok {
+						return errors.New("forbidden")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:     "returns error on NamespaceExists failure",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newWorkbenches("some-ns"),
+			},
+			interceptor: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if ns, ok := obj.(*corev1.Namespace); ok && ns.Name == "" && key.Name == "some-ns" {
+						return errors.New("connection refused")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests { //nolint:dupl
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			opts := []fakeclient.ClientOpts{fakeclient.WithObjects(tt.objects...)}
+			if tt.interceptor != nil {
+				opts = append(opts, fakeclient.WithInterceptorFuncs(*tt.interceptor))
+			}
+
+			cli, err := fakeclient.New(opts...)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			rr := &odhtypes.ReconciliationRequest{
+				Client:  cli,
+				Release: common.Release{Name: tt.platform},
+			}
+
+			ns, err := resolveNotebooksNamespace(ctx, rr)
+			if tt.expectErr {
+				g.Expect(err).Should(HaveOccurred())
+			} else {
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(ns).To(Equal(tt.expectedNS))
+			}
+		})
+	}
+}
+
+func TestResolveModelRegistryNamespace(t *testing.T) {
+	tests := []struct {
+		name        string
+		platform    common.Platform
+		objects     []client.Object
+		interceptor *interceptor.Funcs
+		expectedNS  string
+		expectErr   bool
+	}{
+		{
+			name:     "returns namespace from ModelRegistry CR",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newModelRegistry("rhoai-model-registries"),
+				newNamespace("rhoai-model-registries"),
+			},
+			expectedNS: "rhoai-model-registries",
+		},
+		{
+			name:       "returns empty when ModelRegistry CR not found",
+			platform:   cluster.SelfManagedRhoai,
+			objects:    []client.Object{},
+			expectedNS: "",
+		},
+		{
+			name:     "returns empty when registriesNamespace is empty",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newModelRegistry(""),
+			},
+			expectedNS: "",
+		},
+		{
+			name:     "returns empty when namespace does not exist",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newModelRegistry("nonexistent-ns"),
+			},
+			expectedNS: "",
+		},
+		{
+			name:     "returns error on non-NotFound Get failure",
+			platform: cluster.SelfManagedRhoai,
+			objects:  []client.Object{},
+			interceptor: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*componentApi.ModelRegistry); ok {
+						return errors.New("forbidden")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			expectErr: true,
+		},
+		{
+			name:     "returns error on NamespaceExists failure",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newModelRegistry("some-ns"),
+			},
+			interceptor: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if ns, ok := obj.(*corev1.Namespace); ok && ns.Name == "" && key.Name == "some-ns" {
+						return errors.New("connection refused")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests { //nolint:dupl
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			ctx := t.Context()
+
+			opts := []fakeclient.ClientOpts{fakeclient.WithObjects(tt.objects...)}
+			if tt.interceptor != nil {
+				opts = append(opts, fakeclient.WithInterceptorFuncs(*tt.interceptor))
+			}
+
+			cli, err := fakeclient.New(opts...)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			rr := &odhtypes.ReconciliationRequest{
+				Client:  cli,
+				Release: common.Release{Name: tt.platform},
+			}
+
+			ns, err := resolveModelRegistryNamespace(ctx, rr)
+			if tt.expectErr {
+				g.Expect(err).Should(HaveOccurred())
+			} else {
+				g.Expect(err).ShouldNot(HaveOccurred())
+				g.Expect(ns).To(Equal(tt.expectedNS))
+			}
+		})
+	}
+}
+
+func TestNotebooksRBACRules(t *testing.T) {
+	g := NewWithT(t)
+	rules := notebooksRBACRules()
+
+	g.Expect(rules).To(HaveLen(3))
+	g.Expect(rules[0].Resources).To(ConsistOf("persistentvolumeclaims"))
+	g.Expect(rules[0].Verbs).To(ConsistOf("create", "get"))
+	g.Expect(rules[1].Resources).To(ConsistOf("configmaps"))
+	g.Expect(rules[1].Verbs).To(ConsistOf("create", "get", "update"))
+	g.Expect(rules[2].Resources).To(ConsistOf("secrets"))
+	g.Expect(rules[2].Verbs).To(ConsistOf("create", "get", "update"))
+}
+
+func TestModelRegistryRBACRules(t *testing.T) {
+	g := NewWithT(t)
+	rules := modelRegistryRBACRules()
+
+	g.Expect(rules).To(HaveLen(2))
+	g.Expect(rules[0].Resources).To(ConsistOf("secrets"))
+	g.Expect(rules[0].Verbs).To(ConsistOf("create", "delete", "get", "list", "patch"))
+	g.Expect(rules[1].Resources).To(ConsistOf("configmaps"))
+	g.Expect(rules[1].Verbs).To(ConsistOf("create", "list"))
+}

--- a/internal/controller/components/dashboard/dashboard_support.go
+++ b/internal/controller/components/dashboard/dashboard_support.go
@@ -26,6 +26,9 @@ const (
 
 	LegacyComponentNameUpstream   = "dashboard"
 	LegacyComponentNameDownstream = "rhods-dashboard"
+
+	ServiceAccountNameODH   = "odh-dashboard"
+	ServiceAccountNameRHOAI = "rhods-dashboard"
 )
 
 var (


### PR DESCRIPTION
## Problem

`ensureNamespacedRBAC` creates a namespaced Role and RoleBinding in the notebooks
and model-registry namespaces so the dashboard SA can manage PVCs, ConfigMaps,
and Secrets there. If either namespace doesn't exist yet when the Dashboard
controller first reconciles, `resolveNotebooksNamespace`/`resolveModelRegistryNamespace`
returns `""` and the function silently skips creating those resources.

Without a Namespace watch, the controller never re-reconciles when those namespaces
appear later — so the RoleBinding is never created, and subsequent requests from
the dashboard SA fail with `403 Forbidden` (e.g. PVC operations from workbenches).

## Fix

Add `Watches(&corev1.Namespace{})` to the dashboard controller setup chain. Any
Namespace create/update/delete event now re-triggers Dashboard reconciliation,
allowing `ensureNamespacedRBAC` to create or clean up the Role and RoleBinding
once the target namespace exists.

This mirrors the existing pattern in the workbenches controller
(`workbenches_controller.go:64`), which uses the same `Watches(&corev1.Namespace{})`
for the same reason.

## Testing

Reproduce by installing the operator when the notebooks namespace doesn't exist
yet, then creating the namespace — the RoleBinding should appear automatically
without requiring a manual Dashboard CR touch.

Co-Authored-By: Claude claude-sonnet-4-6 <noreply@anthropic.com>