### PR TITLE
fix(dashboard): fix dashboard namespaced RBAC on modules architecture

### DIFF
--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -119,7 +119,15 @@ func newDSCModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 			reconciler.WithPredicates(predicate.Or(
 				resources.CreatedOrUpdatedOrDeletedNamed(gates.AcksConfigMap),
 				resources.CreatedOrUpdatedOrDeletedLabeled(gates.UpgradeGateLabel, "true"),
-			)))
+			))).
+		// Namespace events re-trigger reconciliation so that ensureDashboardNamespacedRBAC
+		// can create the notebooks/model-registry Role and RoleBinding when the target
+		// namespace appears after initial reconcile.
+		Watches(
+			&corev1.Namespace{},
+			reconciler.WithEventMapper(func(ctx context.Context, _ client.Object) []reconcile.Request {
+				return cluster.WatchDataScienceClusters(ctx, mgr.GetClient())
+			}))
 
 	b = addModuleCRWatches(b)
 	b = addModuleCRDWatches(b, func(ctx context.Context, _ client.Object) []reconcile.Request {

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac.go
@@ -13,6 +13,7 @@ import (
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	odhtype "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 )
 
 const (
@@ -50,7 +51,7 @@ func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.Reconciliati
 	}
 	if notebooksNS != "" {
 		logger.V(1).Info("ensuring Dashboard RBAC in notebooks namespace", "namespace", notebooksNS)
-		if err := addDashboardNamespacedRBAC(rr, saName, appNamespace, notebooksNS, "notebooks", dashboardNotebooksRBACRules()); err != nil {
+		if err := addDashboardNamespacedRBAC(ctx, rr, saName, appNamespace, notebooksNS, "notebooks", dashboardNotebooksRBACRules()); err != nil {
 			return fmt.Errorf("failed to add notebooks RBAC resources: %w", err)
 		}
 	}
@@ -61,7 +62,7 @@ func ensureDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.Reconciliati
 	}
 	if modelRegistryNS != "" {
 		logger.V(1).Info("ensuring Dashboard RBAC in model-registry namespace", "namespace", modelRegistryNS)
-		if err := addDashboardNamespacedRBAC(rr, saName, appNamespace, modelRegistryNS, "model-registries", dashboardModelRegistryRBACRules()); err != nil {
+		if err := addDashboardNamespacedRBAC(ctx, rr, saName, appNamespace, modelRegistryNS, "model-registries", dashboardModelRegistryRBACRules()); err != nil {
 			return fmt.Errorf("failed to add model-registry RBAC resources: %w", err)
 		}
 	}
@@ -133,7 +134,7 @@ func resolveDashboardModelRegistryNamespace(ctx context.Context, rr *odhtype.Rec
 	return ns, nil
 }
 
-func addDashboardNamespacedRBAC(rr *odhtype.ReconciliationRequest, saName, saNamespace, targetNamespace, roleSuffix string, rules []rbacv1.PolicyRule) error {
+func addDashboardNamespacedRBAC(ctx context.Context, rr *odhtype.ReconciliationRequest, saName, saNamespace, targetNamespace, roleSuffix string, rules []rbacv1.PolicyRule) error {
 	roleName := saName + "-" + roleSuffix
 
 	role := &rbacv1.Role{
@@ -163,7 +164,18 @@ func addDashboardNamespacedRBAC(rr *odhtype.ReconciliationRequest, saName, saNam
 		},
 	}
 
-	return rr.AddResources(role, rb)
+	// Apply directly via SSA instead of rr.AddResources: the deploy action looks
+	// up resources via the informer cache, which does not cover cross-namespace
+	// targets like rhods-notebooks or the model-registry namespace. SSA writes
+	// go directly to the API server and bypass the cache restriction.
+	fieldOwner := client.FieldOwner("odh-operator-dashboard-rbac")
+	if err := resources.Apply(ctx, rr.Client, role, client.ForceOwnership, fieldOwner); err != nil {
+		return fmt.Errorf("failed to apply Role %s/%s: %w", targetNamespace, roleName, err)
+	}
+	if err := resources.Apply(ctx, rr.Client, rb, client.ForceOwnership, fieldOwner); err != nil {
+		return fmt.Errorf("failed to apply RoleBinding %s/%s: %w", targetNamespace, roleName, err)
+	}
+	return nil
 }
 
 func dashboardNotebooksRBACRules() []rbacv1.PolicyRule {

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
@@ -42,9 +42,9 @@ func newDashboardRBACTestRR(t *testing.T, platform common.Platform, dsc *dscv2.D
 	}
 }
 
-// getRoleAndBinding fetches the Role and RoleBinding from the fake client and
-// fails the test if either is missing.
-func getRoleAndBinding(t *testing.T, rr *odhtypes.ReconciliationRequest, name, namespace string) (*rbacv1.Role, *rbacv1.RoleBinding) {
+// getRoleAndBinding asserts that a Role and RoleBinding both exist in the fake
+// client for the given name and namespace, failing the test if either is missing.
+func getRoleAndBinding(t *testing.T, rr *odhtypes.ReconciliationRequest, name, namespace string) {
 	t.Helper()
 
 	role := &rbacv1.Role{}
@@ -56,8 +56,6 @@ func getRoleAndBinding(t *testing.T, rr *odhtypes.ReconciliationRequest, name, n
 	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, rb); err != nil {
 		t.Errorf("expected RoleBinding %s/%s to exist: %v", namespace, name, err)
 	}
-
-	return role, rb
 }
 
 // assertRoleAndBindingAbsent checks that neither a Role nor RoleBinding exists
@@ -227,10 +225,8 @@ func TestEnsureDashboardNamespacedRBAC_ODHSAName(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	role, _ := getRoleAndBinding(t, rr, "odh-dashboard-notebooks", cluster.DefaultNotebooksNamespaceODH)
-	if role != nil && role.Name != "odh-dashboard-notebooks" {
-		t.Errorf("expected ODH SA name in role, got %q", role.Name)
-	}
+	// "odh-dashboard-notebooks" is the expected name: SA prefix is "odh-dashboard", suffix is "notebooks"
+	getRoleAndBinding(t, rr, "odh-dashboard-notebooks", cluster.DefaultNotebooksNamespaceODH)
 }
 
 func TestDashboardModelRegistryRBACRules_ContainsCreateVerb(t *testing.T) {

--- a/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
+++ b/internal/controller/modules/modules_controller_actions_dashboard_rbac_test.go
@@ -10,19 +10,20 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/api/common"
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
-	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
+	odhtypes "github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/types"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
 )
 
 const testModelRegistryNS = "rhoai-model-registries"
 
-func newDashboardRBACTestRR(t *testing.T, platform common.Platform, dsc *dscv2.DataScienceCluster, objects ...client.Object) *types.ReconciliationRequest {
+func newDashboardRBACTestRR(t *testing.T, platform common.Platform, dsc *dscv2.DataScienceCluster, objects ...client.Object) *odhtypes.ReconciliationRequest {
 	t.Helper()
 
 	cli, err := fakeclient.New(fakeclient.WithObjects(objects...))
@@ -34,10 +35,44 @@ func newDashboardRBACTestRR(t *testing.T, platform common.Platform, dsc *dscv2.D
 		dsc = &dscv2.DataScienceCluster{ObjectMeta: metav1.ObjectMeta{Name: "test-dsc"}}
 	}
 
-	return &types.ReconciliationRequest{
+	return &odhtypes.ReconciliationRequest{
 		Client:   cli,
 		Instance: dsc,
 		Release:  common.Release{Name: platform},
+	}
+}
+
+// getRoleAndBinding fetches the Role and RoleBinding from the fake client and
+// fails the test if either is missing.
+func getRoleAndBinding(t *testing.T, rr *odhtypes.ReconciliationRequest, name, namespace string) (*rbacv1.Role, *rbacv1.RoleBinding) {
+	t.Helper()
+
+	role := &rbacv1.Role{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, role); err != nil {
+		t.Errorf("expected Role %s/%s to exist: %v", namespace, name, err)
+	}
+
+	rb := &rbacv1.RoleBinding{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, rb); err != nil {
+		t.Errorf("expected RoleBinding %s/%s to exist: %v", namespace, name, err)
+	}
+
+	return role, rb
+}
+
+// assertRoleAndBindingAbsent checks that neither a Role nor RoleBinding exists
+// for the given name and namespace.
+func assertRoleAndBindingAbsent(t *testing.T, rr *odhtypes.ReconciliationRequest, name, namespace string) {
+	t.Helper()
+
+	role := &rbacv1.Role{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, role); err == nil {
+		t.Errorf("expected Role %s/%s to be absent, but it exists", namespace, name)
+	}
+
+	rb := &rbacv1.RoleBinding{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{Name: name, Namespace: namespace}, rb); err == nil {
+		t.Errorf("expected RoleBinding %s/%s to be absent, but it exists", namespace, name)
 	}
 }
 
@@ -105,39 +140,8 @@ func TestEnsureDashboardNamespacedRBAC_BothNamespacesExist(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 4 {
-		t.Fatalf("expected 4 resources (2 Roles + 2 RoleBindings), got %d", len(rr.Resources))
-	}
-
-	hasRole := func(name, namespace string) bool {
-		for _, res := range rr.Resources {
-			if res.GetKind() == dashboardRoleKind && res.GetName() == name && res.GetNamespace() == namespace {
-				return true
-			}
-		}
-		return false
-	}
-	hasRoleBinding := func(name, namespace string) bool {
-		for _, res := range rr.Resources {
-			if res.GetKind() == "RoleBinding" && res.GetName() == name && res.GetNamespace() == namespace {
-				return true
-			}
-		}
-		return false
-	}
-
-	if !hasRole("rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI) {
-		t.Error("missing notebooks Role")
-	}
-	if !hasRoleBinding("rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI) {
-		t.Error("missing notebooks RoleBinding")
-	}
-	if !hasRole("rhods-dashboard-model-registries", testModelRegistryNS) {
-		t.Error("missing model-registry Role")
-	}
-	if !hasRoleBinding("rhods-dashboard-model-registries", testModelRegistryNS) {
-		t.Error("missing model-registry RoleBinding")
-	}
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+	getRoleAndBinding(t, rr, "rhods-dashboard-model-registries", testModelRegistryNS)
 }
 
 func TestEnsureDashboardNamespacedRBAC_DashboardDisabled(t *testing.T) {
@@ -150,9 +154,8 @@ func TestEnsureDashboardNamespacedRBAC_DashboardDisabled(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 0 {
-		t.Fatalf("expected 0 resources when dashboard disabled, got %d", len(rr.Resources))
-	}
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-model-registries", testModelRegistryNS)
 }
 
 func TestEnsureDashboardNamespacedRBAC_NotebooksMissing(t *testing.T) {
@@ -175,9 +178,10 @@ func TestEnsureDashboardNamespacedRBAC_NotebooksMissing(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 2 {
-		t.Fatalf("expected 2 resources (model-registry only), got %d", len(rr.Resources))
-	}
+	// notebooks namespace doesn't exist — no RBAC there
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+	// model-registry namespace exists — RBAC should be created
+	getRoleAndBinding(t, rr, "rhods-dashboard-model-registries", testModelRegistryNS)
 }
 
 func TestEnsureDashboardNamespacedRBAC_ModelRegistryMissing(t *testing.T) {
@@ -192,9 +196,10 @@ func TestEnsureDashboardNamespacedRBAC_ModelRegistryMissing(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 2 {
-		t.Fatalf("expected 2 resources (notebooks only), got %d", len(rr.Resources))
-	}
+	// notebooks namespace exists — RBAC should be created
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
+	// no ModelRegistry CR — no model-registry RBAC
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-model-registries", testModelRegistryNS)
 }
 
 func TestEnsureDashboardNamespacedRBAC_WorkbenchesDisabled(t *testing.T) {
@@ -207,9 +212,7 @@ func TestEnsureDashboardNamespacedRBAC_WorkbenchesDisabled(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 0 {
-		t.Fatalf("expected 0 resources when workbenches disabled, got %d", len(rr.Resources))
-	}
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
 }
 
 func TestEnsureDashboardNamespacedRBAC_ODHSAName(t *testing.T) {
@@ -224,14 +227,9 @@ func TestEnsureDashboardNamespacedRBAC_ODHSAName(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 2 {
-		t.Fatalf("expected 2 resources, got %d", len(rr.Resources))
-	}
-
-	for _, res := range rr.Resources {
-		if res.GetKind() == dashboardRoleKind && res.GetName() != "odh-dashboard-notebooks" {
-			t.Errorf("expected ODH SA name in role, got %q", res.GetName())
-		}
+	role, _ := getRoleAndBinding(t, rr, "odh-dashboard-notebooks", cluster.DefaultNotebooksNamespaceODH)
+	if role != nil && role.Name != "odh-dashboard-notebooks" {
+		t.Errorf("expected ODH SA name in role, got %q", role.Name)
 	}
 }
 
@@ -264,27 +262,24 @@ func TestEnsureDashboardNamespacedRBAC_RoleBindingSubject(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	for _, res := range rr.Resources {
-		if res.GetKind() != "RoleBinding" {
-			continue
-		}
+	rb := &rbacv1.RoleBinding{}
+	if err := rr.Client.Get(context.Background(), k8stypes.NamespacedName{
+		Name:      "rhods-dashboard-notebooks",
+		Namespace: cluster.DefaultNotebooksNamespaceRHOAI,
+	}, rb); err != nil {
+		t.Fatalf("expected RoleBinding to exist: %v", err)
+	}
 
-		subjects, ok, _ := unstructured.NestedSlice(res.Object, "subjects")
-		if !ok || len(subjects) != 1 {
-			t.Fatalf("expected exactly 1 subject in RoleBinding, got %d", len(subjects))
-		}
+	if len(rb.Subjects) != 1 {
+		t.Fatalf("expected exactly 1 subject in RoleBinding, got %d", len(rb.Subjects))
+	}
 
-		subj, ok := subjects[0].(map[string]interface{})
-		if !ok {
-			t.Fatal("subject is not a map")
-		}
-
-		if subj["kind"] != string(rbacv1.ServiceAccountKind) {
-			t.Errorf("expected ServiceAccount kind, got %v", subj["kind"])
-		}
-		if subj["name"] != dashboardSANameRHOAI {
-			t.Errorf("expected SA name %q, got %v", dashboardSANameRHOAI, subj["name"])
-		}
+	subj := rb.Subjects[0]
+	if subj.Kind != rbacv1.ServiceAccountKind {
+		t.Errorf("expected ServiceAccount kind, got %q", subj.Kind)
+	}
+	if subj.Name != dashboardSANameRHOAI {
+		t.Errorf("expected SA name %q, got %q", dashboardSANameRHOAI, subj.Name)
 	}
 }
 
@@ -314,13 +309,7 @@ func TestEnsureDashboardNamespacedRBAC_CustomWorkbenchNamespace(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(rr.Resources) != 2 {
-		t.Fatalf("expected 2 resources (notebooks only), got %d", len(rr.Resources))
-	}
-
-	for _, res := range rr.Resources {
-		if res.GetNamespace() != customNS {
-			t.Errorf("expected namespace %q, got %q", customNS, res.GetNamespace())
-		}
-	}
+	// RBAC should land in the custom namespace, not the default one
+	getRoleAndBinding(t, rr, "rhods-dashboard-notebooks", customNS)
+	assertRoleAndBindingAbsent(t, rr, "rhods-dashboard-notebooks", cluster.DefaultNotebooksNamespaceRHOAI)
 }


### PR DESCRIPTION
## Problem

On the rhoai-3.5 modules architecture, the dashboard SA was never getting Role/RoleBinding created in `rhods-notebooks` or the model-registry namespace. Anish Surti confirmed on a live cluster: Role and RoleBinding were missing, and a forced reconcile still didn't create them.

Root cause (confirmed from controller logs):

```
unknown namespace for the cache
```

The modules controller's informer cache only covers a fixed set of namespaces defined in `createODHGeneralCacheConfig`. `rhods-notebooks` and `rhoai-model-registries` are not in that list. When `addDashboardNamespacedRBAC` used `rr.AddResources`, the deploy action tried to look up the Role/RoleBinding through the cached client before applying — and failed for those uncached namespaces.

Secondary issue: without a `Watches(&corev1.Namespace{})`, the modules controller never re-reconciled when `rhods-notebooks` appeared after the initial DSC reconcile. So even if the cache issue were fixed, a late-arriving namespace would never trigger RBAC creation.

## Changes

**Primary fix:** Switch `addDashboardNamespacedRBAC` from `rr.AddResources` (buffered deploy action path) to `resources.Apply` (SSA). SSA writes directly to the API server, bypassing the informer cache restriction entirely. Field owner is set to `odh-operator-dashboard-rbac`.

**Secondary fix:** Add `Watches(&corev1.Namespace{})` to `newDSCModuleReconciler`. Namespace create/update/delete events re-trigger reconciliation of all DataScienceClusters via `WatchDataScienceClusters`, so `ensureDashboardNamespacedRBAC` gets another chance when the notebooks or model-registry namespace appears after initial reconcile.

**Test update:** Tests previously asserted on `rr.Resources` length (which is now always 0 since we no longer buffer these objects). Rewrote them to use the fake client to verify actual Role/RoleBinding existence in the target namespace, which is the correct behavior to test.

## Testing

- All 8 `TestEnsureDashboardNamespacedRBAC_*` tests pass
- Full `go build ./...` clean
- Confirmed by Anish Surti on a live rhoai-3.5 cluster that RBAC was missing — this is the fix for what he observed