### PR TITLE
fix(build): add missing scoperules module manifests to Dockerfile.konflux

### DIFF
--- a/Dockerfiles/Dockerfile.konflux
+++ b/Dockerfiles/Dockerfile.konflux
@@ -23,6 +23,8 @@ COPY pkg/clusterhealth/go.mod pkg/clusterhealth/go.mod
 COPY pkg/clusterhealth/go.sum pkg/clusterhealth/go.sum
 COPY pkg/failureclassifier/go.mod pkg/failureclassifier/go.mod
 COPY pkg/failureclassifier/go.sum pkg/failureclassifier/go.sum
+COPY pkg/scoperules/go.mod pkg/scoperules/go.mod
+COPY pkg/scoperules/go.sum pkg/scoperules/go.sum
 
 # Copy segment.io config (dashboard telemetry dependency)
 RUN rm -f /opt/manifests/segment


### PR DESCRIPTION
Dockerfile.konflux was missing COPY statements for pkg/scoperules/go.mod and go.sum, causing go mod download to fail because the local replace directive couldn't be resolved.

All other Dockerfiles already had these lines — this one was missed in the original commit (6249cdb).

Build failure logs below:
`STEP 18/29: RUN go mod download"
time="2026-08-17T08:24:39Z" level=info msg="buildah [stderr] go: github.com/opendatahub-io/opendatahub-operator/pkg/scoperules@v0.0.0 (replaced by ./pkg/scoperules): reading pkg/scoperules/go.mod: open /workspace/pkg/scoperules/go.mod: no such file or directory"`