### PR TITLE
Add odh-spark-operator-module to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -72,6 +72,9 @@ map:
     dest: ogx
     git.url: https://github.com/red-hat-data-services/ogx-k8s-operator
     git.commit: 38a7fdee5237134bb7f8f1c898e85a893bff39c5
+  odh-spark-operator-module:
+    src: spark-operator-module/config
+    dest: sparkoperator
 additional_meta:
   odh-ai-gateway-payload-processing:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing

--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -46,11 +46,9 @@ map:
     dest: mlflowoperator
     git.url: https://github.com/red-hat-data-services/mlflow-operator
     git.commit: 73259dbd33cc6fb20b156adfe26fea005e618104
-  odh-spark-operator:
-    src: config
+  odh-spark-operator-module:
+    src: spark-operator-module/config
     dest: sparkoperator
-    git.url: https://github.com/red-hat-data-services/spark-operator
-    git.commit: 93ab44906ac6224e3abd66891d590a7ab2366b1d
   odh-ai-gateway-operator:
     src: config
     dest: aigateway
@@ -72,9 +70,6 @@ map:
     dest: ogx
     git.url: https://github.com/red-hat-data-services/ogx-k8s-operator
     git.commit: 38a7fdee5237134bb7f8f1c898e85a893bff39c5
-  odh-spark-operator-module:
-    src: spark-operator-module/config
-    dest: sparkoperator
 additional_meta:
   odh-ai-gateway-payload-processing:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing


### PR DESCRIPTION
Adds 'odh-spark-operator-module' entry to build/manifests-config.yaml.

Repo: https://github.com/red-hat-data-services/spark-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-84385