### PR TITLE
fix(cache): scope informer cache to ODH namespaces (RHOAIENG-85104)

### DIFF
--- a/cmd/cache_config_test.go
+++ b/cmd/cache_config_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	ofapiv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+)
+
+func TestNewCacheOptions_DefaultNamespacesSet(t *testing.T) {
+	t.Parallel()
+
+	namespaces := map[string]cache.Config{
+		"test-operator":   {},
+		"test-apps":       {},
+		"test-monitoring": {},
+	}
+
+	opts := newCacheOptions(runtime.NewScheme(), namespaces, nil)
+	assert.Equal(t, namespaces, opts.DefaultNamespaces,
+		"DefaultNamespaces must be set to oDHCache so unscoped types do not watch cluster-wide")
+}
+
+func TestNewCacheOptions_ByObjectNamespaceAssignments(t *testing.T) {
+	t.Parallel()
+
+	oDHCache := map[string]cache.Config{
+		"odh-operator":      {},
+		"odh-apps":          {},
+		"odh-monitoring":    {},
+		"openshift-ingress": {},
+	}
+	secretCache := map[string]cache.Config{
+		"odh-operator":      {},
+		"odh-apps":          {},
+		"odh-monitoring":    {},
+		"openshift-ingress": {},
+		"secret-extra-ns":   {},
+	}
+
+	opts := newCacheOptions(runtime.NewScheme(), oDHCache, secretCache)
+
+	wantSecretCache := []client.Object{
+		&corev1.Secret{},
+	}
+	wantODHCache := []client.Object{
+		&corev1.ConfigMap{},
+		&appsv1.Deployment{},
+		&networkingv1.NetworkPolicy{},
+		&rbacv1.Role{},
+		&rbacv1.RoleBinding{},
+		&corev1.ServiceAccount{},
+		&corev1.Service{},
+		&corev1.PersistentVolumeClaim{},
+	}
+
+	for _, obj := range wantSecretCache {
+		typeName := reflect.TypeOf(obj).Elem().Name()
+		byObj, found := findByObject(opts, obj)
+		require.True(t, found, "%s must be in ByObject", typeName)
+		assert.Equal(t, secretCache, byObj.Namespaces,
+			"%s must use secretCache namespaces, not oDHCache", typeName)
+	}
+
+	for _, obj := range wantODHCache {
+		typeName := reflect.TypeOf(obj).Elem().Name()
+		byObj, found := findByObject(opts, obj)
+		require.True(t, found, "%s must be in ByObject", typeName)
+		assert.Equal(t, oDHCache, byObj.Namespaces,
+			"%s must use oDHCache namespaces, not secretCache", typeName)
+	}
+
+	assert.Len(t, opts.ByObject, len(wantSecretCache)+len(wantODHCache),
+		"ByObject should contain exactly the expected entries (IngressController/Auth/Route added separately by OpenShift setup)")
+}
+
+func findByObject(opts cache.Options, target client.Object) (cache.ByObject, bool) {
+	targetType := reflect.TypeOf(target)
+	for key, byObj := range opts.ByObject {
+		if reflect.TypeOf(key) == targetType {
+			return byObj, true
+		}
+	}
+
+	return cache.ByObject{}, false
+}
+
+func TestCacheDisableFor_ContainsExpectedTypes(t *testing.T) {
+	t.Parallel()
+
+	expectedTyped := []client.Object{
+		&configv1.Infrastructure{},
+		&ofapiv1alpha1.Subscription{},
+		&authorizationv1.SelfSubjectRulesReview{},
+		&corev1.Pod{},
+		&corev1.Node{},
+		&userv1.Group{},
+		&ofapiv1alpha1.CatalogSource{},
+		&ofapiv1alpha1.ClusterServiceVersion{},
+	}
+
+	disabled := cacheDisableFor()
+
+	for _, obj := range expectedTyped {
+		typeName := reflect.TypeOf(obj).Elem().Name()
+		found := false
+		for _, d := range disabled {
+			if reflect.TypeOf(d) == reflect.TypeOf(obj) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "%s must be in DisableFor to avoid implicit cluster-wide informers", typeName)
+	}
+
+	foundIngress := false
+	for _, d := range disabled {
+		if u, ok := d.(*unstructured.Unstructured); ok && u.GetObjectKind().GroupVersionKind() == gvk.OpenshiftIngress {
+			foundIngress = true
+			break
+		}
+	}
+	assert.True(t, foundIngress,
+		"OpenshiftIngress (unstructured) must be in DisableFor to avoid implicit cluster-wide informers")
+}
+
+func TestNewCacheOptions_ByObjectNamespacesNotEmpty(t *testing.T) {
+	t.Parallel()
+
+	oDH := map[string]cache.Config{"odh-ns": {}}
+	secret := map[string]cache.Config{"odh-ns": {}, "ingress-ns": {}}
+	opts := newCacheOptions(runtime.NewScheme(), oDH, secret)
+
+	for key, byObj := range opts.ByObject {
+		typeName := reflect.TypeOf(key).Elem().Name()
+		require.NotEmpty(t, byObj.Namespaces,
+			"%s ByObject entry must have explicit Namespaces to prevent cluster-wide caching", typeName)
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -322,45 +322,14 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		os.Exit(1)
 	}
 
-	cacheOptions := cache.Options{
-		Scheme: scheme,
-		ByObject: map[client.Object]cache.ByObject{
-			// Cannot find a label on various secrets, so we need to watch all secrets
-			// this includes, monitoring, dashboard, trustcabundle default cert etc for these NS
-			&corev1.Secret{}: {
-				Namespaces: secretCache,
-			},
-			// it is hard to find a label can be used for both trustCAbundle configmap and inferenceservice-config and deletionCM
-			&corev1.ConfigMap{}: {
-				Namespaces: oDHCache,
-			},
-			// for prometheus and black-box deployment and ones we owns
-			&appsv1.Deployment{}: {
-				Namespaces: oDHCache,
-			},
-			&networkingv1.NetworkPolicy{}: {
-				Namespaces: oDHCache,
-			},
-			&rbacv1.Role{}: {
-				Namespaces: oDHCache,
-			},
-			&rbacv1.RoleBinding{}: {
-				Namespaces: oDHCache,
-			},
-		},
-		DefaultTransform: func(in any) (any, error) {
-			// Nilcheck managed fields to avoid hitting https://github.com/kubernetes/kubernetes/issues/124337
-			if obj, err := meta.Accessor(in); err == nil && obj.GetManagedFields() != nil {
-				obj.SetManagedFields(nil)
-			}
-
-			return in, nil
-		},
-	}
+	cacheOptions := newCacheOptions(scheme, oDHCache, secretCache)
 
 	// OpenShift-specific cache filters: only register when running on OpenShift
 	if cluster.GetClusterInfo().Type == cluster.ClusterTypeOpenShift {
 		cacheOptions.ByObject[&operatorv1.IngressController{}] = cache.ByObject{
+			Namespaces: map[string]cache.Config{
+				cluster.IngressControllerName.Namespace: {},
+			},
 			Field: fields.Set{"metadata.name": "default"}.AsSelector(),
 		}
 		cacheOptions.ByObject[&configv1.Authentication{}] = cache.ByObject{
@@ -403,16 +372,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		// LeaderElectionReleaseOnCancel: true,
 		Client: client.Options{
 			Cache: &client.CacheOptions{
-				DisableFor: []client.Object{
-					resources.GvkToUnstructured(gvk.OpenshiftIngress),
-					&ofapiv1alpha1.Subscription{},
-					&authorizationv1.SelfSubjectRulesReview{},
-					&corev1.Pod{},
-					&userv1.Group{},
-					&ofapiv1alpha1.CatalogSource{},
-				},
-				// Set it to true so the cache-backed client reads unstructured objects
-				// or lists from the cache instead of a live lookup.
+				DisableFor:   cacheDisableFor(),
 				Unstructured: true,
 			},
 		},
@@ -610,6 +570,63 @@ func createODHGeneralCacheConfig(platform common.Platform) (map[string]cache.Con
 	namespaceConfigs[modelregistry.DefaultModelRegistriesNamespace] = cache.Config{}
 
 	return namespaceConfigs, nil
+}
+
+func newCacheOptions(scheme *runtime.Scheme, oDHCache, secretCache map[string]cache.Config) cache.Options {
+	return cache.Options{
+		Scheme:            scheme,
+		DefaultNamespaces: oDHCache,
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Secret{}: {
+				Namespaces: secretCache,
+			},
+			&corev1.ConfigMap{}: {
+				Namespaces: oDHCache,
+			},
+			&appsv1.Deployment{}: {
+				Namespaces: oDHCache,
+			},
+			&networkingv1.NetworkPolicy{}: {
+				Namespaces: oDHCache,
+			},
+			&rbacv1.Role{}: {
+				Namespaces: oDHCache,
+			},
+			&rbacv1.RoleBinding{}: {
+				Namespaces: oDHCache,
+			},
+			&corev1.ServiceAccount{}: {
+				Namespaces: oDHCache,
+			},
+			&corev1.Service{}: {
+				Namespaces: oDHCache,
+			},
+			&corev1.PersistentVolumeClaim{}: {
+				Namespaces: oDHCache,
+			},
+		},
+		DefaultTransform: func(in any) (any, error) {
+			if obj, err := meta.Accessor(in); err == nil && obj.GetManagedFields() != nil {
+				obj.SetManagedFields(nil)
+			}
+
+			return in, nil
+		},
+	}
+}
+
+func cacheDisableFor() []client.Object {
+	return []client.Object{
+		resources.GvkToUnstructured(gvk.OpenshiftIngress),
+		&configv1.Infrastructure{},
+		&ofapiv1alpha1.Subscription{},
+		&authorizationv1.SelfSubjectRulesReview{},
+		&corev1.Pod{},
+		&corev1.Node{},
+		&userv1.Group{},
+		&ofapiv1alpha1.CatalogSource{},
+		&ofapiv1alpha1.ClusterServiceVersion{},
+	}
 }
 
 // addCacheIfAvailable adds obj to the ByObject cache map only when its API is

--- a/internal/controller/components/modelregistry/modelregistry_controller.go
+++ b/internal/controller/components/modelregistry/modelregistry_controller.go
@@ -64,7 +64,10 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithEventHandler(handlers.ToNamed(componentApi.ModelRegistryInstanceName)),
 			reconciler.WithPredicates(generation.New()),
 		).
-		Watches(&corev1.Namespace{}).
+		Watches(&corev1.Namespace{},
+			reconciler.WithPredicates(
+				component.ForLabelAllEvents(labels.ODH.Component(LegacyComponentName), labels.True)),
+		).
 		Watches(
 			&extv1.CustomResourceDefinition{},
 			reconciler.WithEventHandler(

--- a/internal/controller/components/workbenches/workbenches_controller.go
+++ b/internal/controller/components/workbenches/workbenches_controller.go
@@ -63,7 +63,10 @@ func (s *componentHandler) NewComponentReconciler(ctx context.Context, mgr ctrl.
 			reconciler.WithPredicates(
 				component.ForLabel(labels.ODH.Component(LegacyComponentName), labels.True)),
 		).
-		Watches(&corev1.Namespace{}).
+		Watches(&corev1.Namespace{},
+			reconciler.WithPredicates(
+				component.ForLabelAllEvents(labels.ODH.Component(LegacyComponentName), labels.True)),
+		).
 		Watches(
 			&componentApi.MLflowOperator{},
 			reconciler.WithEventHandler(handlers.ToNamed(componentApi.WorkbenchesInstanceName)),

--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -24,7 +24,10 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +43,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	dsciv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/dscinitialization/v2"
@@ -330,6 +334,11 @@ func getObject(gvk schema.GroupVersionKind) client.Object {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DSCInitializationReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+	monitoringCache, err := managedMonitoringCacheForManager(mgr)
+	if err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		// add predicates prevents meaningless reconciliations from being triggered
 		// not use WithEventFilter() because it conflict with secret and configmap predicate
@@ -341,19 +350,19 @@ func (r *DSCInitializationReconciler) SetupWithManager(ctx context.Context, mgr 
 			getObject(gvk.Namespace),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			getObject(gvk.Secret),
+			&corev1.Secret{},
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			getObject(gvk.ConfigMap),
+			&corev1.ConfigMap{},
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			getObject(gvk.NetworkPolicy),
+			&networkingv1.NetworkPolicy{},
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			getObject(gvk.Role),
+			&rbacv1.Role{},
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			getObject(gvk.RoleBinding),
+			&rbacv1.RoleBinding{},
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
 			getObject(gvk.ClusterRole),
@@ -362,19 +371,19 @@ func (r *DSCInitializationReconciler) SetupWithManager(ctx context.Context, mgr 
 			getObject(gvk.ClusterRoleBinding),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			getObject(gvk.Deployment),
+			&appsv1.Deployment{},
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			getObject(gvk.ServiceAccount),
+			&corev1.ServiceAccount{},
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			getObject(gvk.Service),
+			&corev1.Service{},
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
 			getObject(gvk.Route),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			getObject(gvk.PersistentVolumeClaim),
+			&corev1.PersistentVolumeClaim{},
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns( // ensure always have default one for AcceleratorProfile/HardwareProfile blocking
 			getObject(gvk.ValidatingAdmissionPolicy),
@@ -392,15 +401,21 @@ func (r *DSCInitializationReconciler) SetupWithManager(ctx context.Context, mgr 
 			}),
 			builder.WithPredicates(rp.DSCDeletionPredicate), // TODO: is it needed?
 		).
-		Watches(
-			getObject(gvk.Secret),
-			handler.EnqueueRequestsFromMapFunc(r.watchMonitoringSecretResource),
-			builder.WithPredicates(rp.SecretContentChangedPredicate),
+		WatchesRawSource(
+			source.TypedKind[client.Object](
+				monitoringCache,
+				&corev1.Secret{},
+				handler.EnqueueRequestsFromMapFunc(r.watchMonitoringSecretResource),
+				rp.SecretContentChangedPredicate,
+			),
 		).
-		Watches(
-			getObject(gvk.ConfigMap),
-			handler.EnqueueRequestsFromMapFunc(r.watchMonitoringConfigMapResource),
-			builder.WithPredicates(rp.CMContentChangedPredicate),
+		WatchesRawSource(
+			source.TypedKind[client.Object](
+				monitoringCache,
+				&corev1.ConfigMap{},
+				handler.EnqueueRequestsFromMapFunc(r.watchMonitoringConfigMapResource),
+				rp.CMContentChangedPredicate,
+			),
 		).
 		Watches(
 			getObject(gvk.Auth),
@@ -423,10 +438,13 @@ func (r *DSCInitializationReconciler) SetupWithManager(ctx context.Context, mgr 
 
 func (r *DSCInitializationReconciler) watchMonitoringConfigMapResource(ctx context.Context, a client.Object) []reconcile.Request {
 	log := logf.FromContext(ctx)
-	if a.GetName() == "prometheus" && a.GetNamespace() == "redhat-ods-monitoring" {
+	if a.GetName() == managedMonitoringConfigMapName && a.GetNamespace() == cluster.DefaultMonitoringNamespaceRHOAI {
 		log.Info("Found monitoring configmap has updated, start reconcile")
 
-		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "prometheus", Namespace: "redhat-ods-monitoring"}}}
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{
+			Name:      managedMonitoringConfigMapName,
+			Namespace: cluster.DefaultMonitoringNamespaceRHOAI,
+		}}}
 	}
 	return nil
 }
@@ -438,10 +456,13 @@ func (r *DSCInitializationReconciler) watchMonitoringSecretResource(ctx context.
 		return nil
 	}
 
-	if a.GetName() == "addon-managed-odh-parameters" && a.GetNamespace() == operatorNs {
+	if a.GetName() == managedMonitoringSecretName && a.GetNamespace() == operatorNs {
 		log.Info("Found monitoring secret has updated, start reconcile")
 
-		return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "addon-managed-odh-parameters", Namespace: operatorNs}}}
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{
+			Name:      managedMonitoringSecretName,
+			Namespace: operatorNs,
+		}}}
 	}
 	return nil
 }

--- a/internal/controller/dscinitialization/dscinitialization_controller_watches.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller_watches.go
@@ -1,0 +1,54 @@
+package dscinitialization
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/scopedcache"
+)
+
+const (
+	//nolint:gosec // resource name, not a credential
+	managedMonitoringSecretName    = "addon-managed-odh-parameters"
+	managedMonitoringConfigMapName = "prometheus"
+)
+
+func ManagedMonitoringByObject(operatorNs string) map[client.Object]cache.ByObject {
+	return map[client.Object]cache.ByObject{
+		&corev1.Secret{}: {
+			Namespaces: map[string]cache.Config{
+				operatorNs: {
+					FieldSelector: fields.OneTermEqualSelector("metadata.name", managedMonitoringSecretName),
+				},
+			},
+		},
+		&corev1.ConfigMap{}: {
+			Namespaces: map[string]cache.Config{
+				cluster.DefaultMonitoringNamespaceRHOAI: {
+					FieldSelector: fields.OneTermEqualSelector("metadata.name", managedMonitoringConfigMapName),
+				},
+			},
+		},
+	}
+}
+
+//nolint:ireturn // controller-runtime cache constructors return cache.Cache
+func newManagedMonitoringCache(mgr ctrl.Manager, operatorNs string) (cache.Cache, error) {
+	return scopedcache.NewForManager(mgr, ManagedMonitoringByObject(operatorNs))
+}
+
+//nolint:ireturn // controller-runtime cache constructors return cache.Cache
+func managedMonitoringCacheForManager(mgr ctrl.Manager) (cache.Cache, error) {
+	operatorNs, err := cluster.GetOperatorNamespace()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get operator namespace: %w", err)
+	}
+
+	return newManagedMonitoringCache(mgr, operatorNs)
+}

--- a/internal/controller/dscinitialization/dscinitialization_controller_watches_test.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller_watches_test.go
@@ -1,0 +1,48 @@
+package dscinitialization_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/dscinitialization"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestManagedMonitoringByObjectScopesSingleSecretAndConfigMap(t *testing.T) {
+	const operatorNs = "redhat-ods-operator"
+
+	byObject := dscinitialization.ManagedMonitoringByObject(operatorNs)
+
+	g := NewWithT(t)
+
+	var secretRule, cmRule cache.ByObject
+	foundSecret, foundCM := false, false
+
+	for obj, rule := range byObject {
+		switch obj.(type) {
+		case *corev1.Secret:
+			secretRule = rule
+			foundSecret = true
+		case *corev1.ConfigMap:
+			cmRule = rule
+			foundCM = true
+		default:
+			t.Fatalf("unexpected cache key type %T", obj)
+		}
+	}
+
+	g.Expect(foundSecret).To(BeTrue())
+	g.Expect(secretRule.Namespaces).To(HaveKey(operatorNs))
+	g.Expect(secretRule.Namespaces[operatorNs].FieldSelector.String()).
+		To(Equal(fields.OneTermEqualSelector("metadata.name", "addon-managed-odh-parameters").String()))
+
+	g.Expect(foundCM).To(BeTrue())
+	g.Expect(cmRule.Namespaces).To(HaveKey(cluster.DefaultMonitoringNamespaceRHOAI))
+	g.Expect(cmRule.Namespaces[cluster.DefaultMonitoringNamespaceRHOAI].FieldSelector.String()).
+		To(Equal(fields.OneTermEqualSelector("metadata.name", "prometheus").String()))
+}

--- a/internal/controller/dscinitialization/suite_test.go
+++ b/internal/controller/dscinitialization/suite_test.go
@@ -51,6 +51,7 @@ import (
 	infrav1 "github.com/opendatahub-io/opendatahub-operator/v2/api/infrastructure/v1"
 	serviceApi "github.com/opendatahub-io/opendatahub-operator/v2/api/services/v1alpha1"
 	dscictrl "github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/dscinitialization"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/operatorconfig"
 	"github.com/opendatahub-io/opendatahub-operator/v2/tests/envtestutil"
 
@@ -148,6 +149,17 @@ var _ = BeforeSuite(func() {
 
 	k8sClient = cli
 
+	manifestsBasePath := filepath.Join(rootPath, "config")
+	operatorSettings := operatorconfig.OperatorSettings{
+		OperatorNamespace: "test-operator-ns",
+		PlatformType:      "OpenDataHub",
+		ManifestsBasePath: manifestsBasePath,
+	}
+
+	// Ignore errors from Init as we only care about setting the operator namespace.
+	// Other initialization errors (like missing cluster resources) are expected in tests.
+	_ = cluster.Init(gCtx, k8sClient, operatorSettings)
+
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:         testScheme,
@@ -161,12 +173,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&dscictrl.DSCInitializationReconciler{
-		Client:   k8sClient,
-		Scheme:   testScheme,
-		Recorder: mgr.GetEventRecorder("dscinitialization-controller"),
-		OperatorSettings: operatorconfig.OperatorSettings{
-			ManifestsBasePath: "",
-		},
+		Client:           k8sClient,
+		Scheme:           testScheme,
+		Recorder:         mgr.GetEventRecorder("dscinitialization-controller"),
+		OperatorSettings: operatorSettings,
 	}).SetupWithManager(gCtx, mgr)
 
 	Expect(err).ToNot(HaveOccurred())

--- a/internal/controller/services/setup/setup_controller.go
+++ b/internal/controller/services/setup/setup_controller.go
@@ -5,15 +5,21 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/handlers"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/controller/scopedcache"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
 )
@@ -39,22 +45,44 @@ func (r *SetupControllerReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 func (r *SetupControllerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	operatorNs, err := cluster.GetOperatorNamespace()
-
 	if err != nil {
 		return fmt.Errorf("failed to get operator namespace: %w", err)
 	}
+
+	deleteConfigMapCache, err := scopedcache.NewForManager(mgr, map[client.Object]cache.ByObject{
+		&corev1.ConfigMap{}: {
+			Namespaces: map[string]cache.Config{
+				operatorNs: {},
+			},
+			Label: labels.Set{upgrade.DeleteConfigMapLabel: "true"}.AsSelector(),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
-		For(resources.GvkToUnstructured(gvk.ConfigMap), builder.WithPredicates(r.filterDeleteConfigMap(operatorNs))).
+		Named("setup-controller").
+		WatchesRawSource(
+			source.TypedKind[client.Object](
+				deleteConfigMapCache,
+				resources.GvkToPartial(gvk.ConfigMap),
+				handlers.Fn(func(_ context.Context, _ client.Object) []reconcile.Request {
+					return []reconcile.Request{{
+						NamespacedName: types.NamespacedName{
+							Name:      "uninstall",
+							Namespace: operatorNs,
+						},
+					}}
+				}),
+				r.filterDeleteConfigMap(operatorNs),
+			),
+		).
 		Complete(r)
 }
 
 func (r *SetupControllerReconciler) filterDeleteConfigMap(operatorNs string) predicate.Funcs {
 	filter := func(obj client.Object) bool {
-		_, isCM := obj.(*corev1.ConfigMap)
-		if !isCM && obj.GetObjectKind().GroupVersionKind() != gvk.ConfigMap {
-			return false
-		}
-
 		if obj.GetNamespace() != operatorNs {
 			return false
 		}

--- a/internal/controller/services/setup/setup_controller_test.go
+++ b/internal/controller/services/setup/setup_controller_test.go
@@ -6,8 +6,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
@@ -15,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestFilterDeleteConfigMapPredicateWithTypedAndUnstructured(t *testing.T) {
+func TestFilterDeleteConfigMapPredicate(t *testing.T) {
 	const operatorNs = "test-operator-ns"
 
 	r := &SetupControllerReconciler{}
@@ -23,11 +21,11 @@ func TestFilterDeleteConfigMapPredicateWithTypedAndUnstructured(t *testing.T) {
 
 	tests := []struct {
 		name string
-		obj  client.Object
+		obj  *corev1.ConfigMap
 		want bool
 	}{
 		{
-			name: "typed ConfigMap with correct namespace and label",
+			name: "ConfigMap with correct namespace and label",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "delete-cm",
@@ -38,7 +36,7 @@ func TestFilterDeleteConfigMapPredicateWithTypedAndUnstructured(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "typed ConfigMap wrong namespace",
+			name: "ConfigMap wrong namespace",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "delete-cm",
@@ -49,60 +47,13 @@ func TestFilterDeleteConfigMapPredicateWithTypedAndUnstructured(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "typed ConfigMap missing label",
+			name: "ConfigMap missing label",
 			obj: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "delete-cm",
 					Namespace: operatorNs,
 				},
 			},
-			want: false,
-		},
-		{
-			name: "unstructured ConfigMap with correct namespace and label",
-			obj: func() client.Object {
-				u := &unstructured.Unstructured{}
-				u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
-				u.SetName("delete-cm")
-				u.SetNamespace(operatorNs)
-				u.SetLabels(map[string]string{upgrade.DeleteConfigMapLabel: "true"})
-				return u
-			}(),
-			want: true,
-		},
-		{
-			name: "unstructured ConfigMap wrong namespace",
-			obj: func() client.Object {
-				u := &unstructured.Unstructured{}
-				u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
-				u.SetName("delete-cm")
-				u.SetNamespace("other-ns")
-				u.SetLabels(map[string]string{upgrade.DeleteConfigMapLabel: "true"})
-				return u
-			}(),
-			want: false,
-		},
-		{
-			name: "unstructured ConfigMap missing label",
-			obj: func() client.Object {
-				u := &unstructured.Unstructured{}
-				u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
-				u.SetName("delete-cm")
-				u.SetNamespace(operatorNs)
-				return u
-			}(),
-			want: false,
-		},
-		{
-			name: "unstructured non-ConfigMap with correct namespace and label",
-			obj: func() client.Object {
-				u := &unstructured.Unstructured{}
-				u.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
-				u.SetName("delete-cm")
-				u.SetNamespace(operatorNs)
-				u.SetLabels(map[string]string{upgrade.DeleteConfigMapLabel: "true"})
-				return u
-			}(),
 			want: false,
 		},
 	}

--- a/pkg/controller/scopedcache/scopedcache.go
+++ b/pkg/controller/scopedcache/scopedcache.go
@@ -1,0 +1,40 @@
+package scopedcache
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewForManager creates a dedicated informer cache scoped to specific objects and
+// registers it with the manager. Use this for watches that must not affect the
+// manager's shared cache (see cert-configmap-generator for the reference pattern).
+//
+//nolint:ireturn // controller-runtime cache constructors return cache.Cache
+func NewForManager(mgr ctrl.Manager, byObject map[client.Object]cache.ByObject) (cache.Cache, error) {
+	targetCache, err := cache.New(mgr.GetConfig(), cache.Options{
+		HTTPClient: mgr.GetHTTPClient(),
+		Scheme:     mgr.GetScheme(),
+		Mapper:     mgr.GetRESTMapper(),
+		ByObject:   byObject,
+		DefaultTransform: func(in any) (any, error) {
+			if obj, err := meta.Accessor(in); err == nil && obj.GetManagedFields() != nil {
+				obj.SetManagedFields(nil)
+			}
+
+			return in, nil
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unable to create scoped cache: %w", err)
+	}
+
+	if err := mgr.Add(targetCache); err != nil {
+		return nil, fmt.Errorf("unable to register scoped cache with manager: %w", err)
+	}
+
+	return targetCache, nil
+}


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description

Fixes [RHOAIENG-85104](https://redhat.atlassian.net/browse/RHOAIENG-85104): primary RHOAI 3.4 fix to scope `rhods-operator` informer cache to ODH namespaces, preventing excessive kube-apiserver/etcd memory on high-namespace clusters (e.g. Developer Sandbox with ~2000 namespaces).

Related parent bug: [RHOAIENG-83243](https://redhat.atlassian.net/browse/RHOAIENG-83243)

**This is the primary downstream fix on `rhoai-3.4`.** After merge, the same approach will be ported forward to upstream `main` / 3.5 ([RHOAIENG-85102](https://redhat.atlassian.net/browse/RHOAIENG-85102)) — not a cherry-pick from 3.5.

**Root cause:** DSCI controller registered `Watches(Secret)` and `Watches(ConfigMap)` via **unstructured** objects (`getObject(gvk.ConfigMap)`), bypassing typed `ByObject` namespace scoping and creating a cluster-wide ConfigMap informer (`controller="configmap"` in operator logs). Missing `ByObject` entries for ServiceAccount, Service, and PVC allowed similar cluster-wide caching for those types. Setup controller used unstructured `For(ConfigMap)` on the shared manager cache with the same effect.

**Changes:**
- Add `DefaultNamespaces: oDHCache` and extend `ByObject` for ServiceAccount, Service, PVC
- Scope IngressController cache to `openshift-ingress-operator` namespace
- Extend `DisableFor` for types read but not watched (Infrastructure, Node, CSV, etc.)
- Convert DSCI high-volume **Owns** (CM, Secret, SA, Service, PVC, Deployment, Role, NetPol) to typed objects
- Move DSCI managed-monitoring Secret/ConfigMap watches off the shared cache onto a **dedicated scoped cache** (field selector for `addon-managed-odh-parameters` and `prometheus` only; cert-configmap-generator pattern via `pkg/controller/scopedcache`)
- Refactor setup controller uninstall ConfigMap watch to the same dedicated-cache pattern (controller retained — required for managed-tenant uninstall via `api.openshift.com/addon-managed-odh-delete` label)
- Filter modelregistry and workbenches Namespace watches to ODH component label (reduces reconcile noise)
- Add `cmd/cache_config_test.go` and scoped-cache unit tests

**Related:** opendatahub-io/opendatahub-operator#3965 (similar cache scoping on 3.5; this PR intentionally does **not** include `ReaderFailOnMissingInformer`)

## How Has This Been Tested?

- `go test ./cmd -run 'TestNewCacheOptions|TestCacheDisableFor' -v`
- `go test ./internal/controller/dscinitialization -run TestManagedMonitoring -v`
- `go test ./internal/controller/services/setup -v`
- `make lint` — 0 issues

**Cluster validation instructions (for reviewer / Victor):**
```bash
# Verify no cluster-wide configmap controller
oc logs -n redhat-ods-operator deploy/rhods-operator | grep 'controller="configmap"'
# Expected: empty (or only cert-configmap-generator PartialObjectMetadata)

# Verify Managed RHOAI monitoring watches still work
oc annotate secret addon-managed-odh-parameters -n redhat-ods-operator test=$(date +%s) --overwrite
oc logs -n redhat-ods-operator deploy/rhods-operator | grep "monitoring secret has updated"

# Re-run 2000-user namespace ramp; compare kube-apiserver/etcd memory vs baseline
```

## Screenshot or short clip
N/A — backend operator cache fix.

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This is a cache-scoping hotfix for a production incident (RHOAIENG-85104 / RHOAIENG-83243). No user-facing behavior change is intended beyond fixing cluster-wide informer registration. Validation is via unit tests (`cache_config_test.go`), startup log inspection, and cluster memory profiling on the Sandbox test environment. E2E suite does not cover informer cache scoping.