### PR TITLE
fix: use digest-pinned postgresql-15 image in MaaS E2E test

### DIFF
--- a/tests/e2e/modelsasservice_test.go
+++ b/tests/e2e/modelsasservice_test.go
@@ -40,7 +40,7 @@ const (
 	// PostgreSQL constants for the MaaS database dependency.
 	// Reference: https://github.com/opendatahub-io/models-as-a-service/blob/main/scripts/deploy.sh
 	maasPostgresName     = "maas-postgres"
-	maasPostgresImage    = "registry.redhat.io/rhel9/postgresql-15:latest"
+	maasPostgresImage    = "registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"
 	maasPostgresUser     = "maas"
 	maasPostgresPassword = "maas-e2e-test" //nolint:gosec // test-only credential, not a real secret
 	maasPostgresDB       = "maas"


### PR DESCRIPTION
## Summary

- Replace `registry.redhat.io/rhel9/postgresql-15:latest` with a digest-pinned image in the MaaS E2E test (`tests/e2e/modelsasservice_test.go`)
- Tag-based pulls fail on disconnected clusters because `registry.redhat.io` is blocked and IDMS only mirrors by digest
- `maas-postgres` going `ImagePullBackOff` causes `maas-api` to `CrashLoopBackOff` (can't connect to DB), blocking all MaaS E2E tests on disconnected clusters

## Root Cause

`createMaaSPostgres()` in `modelsasservice_test.go` hardcodes `registry.redhat.io/rhel9/postgresql-15:latest` as the postgres image. On disconnected clusters, `:latest` tag pulls are blocked — IDMS rules only redirect digest-based pulls to the bastion registry.

## Fix

```go
// Before
maasPostgresImage = "registry.redhat.io/rhel9/postgresql-15:latest"

// After
maasPostgresImage = "registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"
```

## Validation

Tested on disconnected cluster `api.ods-dis-35-fresh.aws.rh-ods.com:6443` (RHOAI 3.5, OCP 4.21):
- Deleted `maas-postgres` and recreated with digest image
- Pod reached `1/1 Running` in ~5 seconds — digest correctly mirrored to bastion via IDMS
- `maas-api` remained healthy throughout

## Risk analysis

- **Risk rating:** 1
- **Why:** Single-line change replacing a floating tag with a pinned digest. No logic change. Fixes a disconnected cluster failure with no impact on connected clusters.

> **Note:** This file has been removed on `main` (3.6 development) so this fix is specific to the `rhoai-3.5` branch.

Related to - https://redhat.atlassian.net/browse/RHOAIENG-88004