### PR TITLE
fix: add modelsAsService to DSC sample to prevent null validation error

### DIFF
--- a/config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml
+++ b/config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml
@@ -42,7 +42,10 @@ metadata:
               "managementState": "Managed"
             },
             "kserve": {
-              "managementState": "Managed"
+              "managementState": "Managed",
+              "modelsAsService": {
+                "managementState": "Removed"
+              }
             },
             "llamastackoperator": {
               "managementState": "Removed"

--- a/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -14,6 +14,8 @@ spec:
       managementState: "Managed"
       nim:
         managementState: "Managed"
+      modelsAsService:
+        managementState: "Managed"
       wva:
         managementState: "Removed"
     kueue:

--- a/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -15,7 +15,7 @@ spec:
       nim:
         managementState: "Managed"
       modelsAsService:
-        managementState: "Managed"
+        managementState: "Removed"
       wva:
         managementState: "Removed"
     kueue:

--- a/config/samples/datasciencecluster_v2_datasciencecluster.yaml
+++ b/config/samples/datasciencecluster_v2_datasciencecluster.yaml
@@ -14,6 +14,8 @@ spec:
       managementState: "Managed"
       nim:
         managementState: "Managed"
+      modelsAsService:
+        managementState: "Removed"
       rawDeploymentServiceConfig: "Headed"
       wva:
         managementState: "Removed"


### PR DESCRIPTION
## Summary

- Add `modelsAsService: {managementState: "Removed"}` explicitly to all DSC sample and CSV locations on `rhoai-3.4`
- Fixes pre-upgrade tests (3.4 → 3.5) failing with DSC in `Error` state blocking all downstream upgrade tests

## Root Cause

The `rhoai-3.4` DSC sample YAML and CSV initialization-resource were missing `kserve.modelsAsService`. When the operator reconciles the `Kserve` object from a DSC that omits this field, it sends `modelsAsService: null` in the SSA patch. The Kserve CRD defines `modelsAsService` as `type: object` (not nullable) and rejects the patch:

```
spec.modelsAsService: Invalid value: "null": spec.modelsAsService in body must be of type object: "null"
```

This causes `default-kserve` to fail, DSC enters `Error` state, and all downstream upgrade tests fail.

**Why `main` can omit it but `rhoai-3.4` cannot:**
`main` has a `+kubebuilder:default={managementState: "Removed"}` marker on `ModelsAsService`, which is generated into the CRD's OpenAPI schema — Kubernetes fills in the default before the operator ever sees the field. `rhoai-3.4` has no such marker, so omitting the field from any raw manifest leaves it completely unset (null), triggering the validation error.

**Jenkins:** https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/rhoai/job/3.4/job/selfmanaged/job/disconnected/job/aws/job/rhoai-pre-upgrade/2/

## Files changed

```yaml
# All three locations — same fix:
kserve:
  managementState: "Managed"
+ modelsAsService:
+   managementState: "Removed"
```

- `config/rhoai/samples/datasciencecluster_v2_datasciencecluster.yaml`
- `config/samples/datasciencecluster_v2_datasciencecluster.yaml`
- `config/rhoai/manifests/bases/rhods-operator.clusterserviceversion.yaml` (CSV `initialization-resource` annotation)

## Risk analysis

- **Risk rating:** 1
- **Why:** Explicit field values added to sample/CSV manifests only. No operator logic changed. Prevents the pre-upgrade 3.4 → 3.5 test pipeline from failing.