### PR TITLE
Add odh-workbenches-controller to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -72,6 +72,9 @@ map:
     dest: ogx
     git.url: https://github.com/red-hat-data-services/ogx-k8s-operator
     git.commit: 38a7fdee5237134bb7f8f1c898e85a893bff39c5
+  odh-workbenches-controller:
+    src: ./workspaces/controller/manifests/kustomize
+    dest: workbenches/odh-workbenches-controller
 additional_meta:
   odh-ai-gateway-payload-processing:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing


### PR DESCRIPTION
Adds 'odh-workbenches-controller' entry to build/manifests-config.yaml.

Repo: https://github.com/red-hat-data-services/workbenches
Jira: https://redhat.atlassian.net/browse/RHOAIENG-84638