### PR TITLE
fix(trustyai): update RELATED_IMAGE for odh-trustyai-service-py

### DIFF
--- a/build/operands-map.yaml
+++ b/build/operands-map.yaml
@@ -9,8 +9,8 @@ relatedImages:
   value: "quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9@sha256:78b6e29c66a425b9f097cba92240f96d32f756d379b779ed37ef51e8625364b5"
 - name: RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE
   value: "quay.io/rhoai/odh-model-controller-rhel9@sha256:f5b70a687fef130c35bdeb108d7aab4a0eadf6182d379b6c517e9d1157713108"
-- name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
-  value: "quay.io/rhoai/odh-trustyai-service-rhel9@sha256:1431c04ecb88387a9e15566ba8105d19c7fbceecf65eb5731fe69cccbeb09cf5"
+- name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE
+  value: "quay.io/rhoai/odh-trustyai-service-py-rhel9@sha256:6e2dbd96e6df66ab795400071a846c587f53ba32bcad4426f655f26b194699e1"
 - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE
   value: "quay.io/rhoai/odh-trustyai-service-operator-rhel9@sha256:3617ae4fba7499bf17ef591df2e787b353d6ec7962bbcf14c4c8b3edf045f314"
 - name: RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE

--- a/build/operator-nudging.yaml
+++ b/build/operator-nudging.yaml
@@ -9,8 +9,8 @@ relatedImages:
   value: "quay.io/rhoai/odh-data-science-pipelines-operator-controller-rhel9@sha256:57285a17166210186ab8140417adeb2755d7dba789c5e7eb8fefcf7587d852c1"
 - name: RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE
   value: "quay.io/rhoai/odh-model-controller-rhel9@sha256:c4c9ef4c110994481cf9a2ee2bf32440df011a50c59571c20ad2f8d518929a20"
-- name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE
-  value: "quay.io/rhoai/odh-trustyai-service-rhel9@sha256:5023b8bd93a6bda98967f01c8bee534fc1c66aa6e52490bb5382a5214fee6e9d"
+- name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE
+  value: "quay.io/rhoai/odh-trustyai-service-py-rhel9@sha256:6e2dbd96e6df66ab795400071a846c587f53ba32bcad4426f655f26b194699e1"
 - name: RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE
   value: "quay.io/rhoai/odh-trustyai-service-operator-rhel9@sha256:d4fae05531a06016112624e40f9a4b8bb374495d665206c5a325f80f78781746"
 - name: RELATED_IMAGE_ODH_KUBERAY_OPERATOR_CONTROLLER_IMAGE

--- a/internal/controller/components/trustyai/trustyai_support.go
+++ b/internal/controller/components/trustyai/trustyai_support.go
@@ -21,7 +21,7 @@ const (
 
 var (
 	imageParamMap = map[string]string{
-		"trustyaiServiceImage":               "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE",
+		"trustyaiServiceImage":               "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE",
 		"trustyaiOperatorImage":              "RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_OPERATOR_IMAGE",
 		"lmes-driver-image":                  "RELATED_IMAGE_ODH_TA_LMES_DRIVER_IMAGE",
 		"lmes-pod-image":                     "RELATED_IMAGE_ODH_TA_LMES_JOB_IMAGE",

--- a/manifests-config.yaml
+++ b/manifests-config.yaml
@@ -1170,14 +1170,6 @@ imageOverrides:
     rhoai:
       base: "quay.io/opendatahub/llama-stack-provider-ragas"
       digest: "sha256:fa46ce6a3dd16b0eb8e06c71f99b761d742599e569ed91f7b727149bc1085520"
-  RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE:
-    source: "csv"
-    odh:
-      base: "quay.io/opendatahub/odh-trustyai-service"
-      digest: "sha256:300889737a1c33e2a4b2883b707b9ebd141d1669dc904b06a0564428341b1abf"
-    rhoai:
-      base: "quay.io/opendatahub/odh-trustyai-service"
-      digest: "sha256:300889737a1c33e2a4b2883b707b9ebd141d1669dc904b06a0564428341b1abf"
   RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE:
     source: "csv"
     odh:


### PR DESCRIPTION
## Description

Rename `RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_IMAGE` to `RELATED_IMAGE_ODH_TRUSTYAI_SERVICE_PY_IMAGE` across all references to align with the image name used in [RHOAI-Build-Config](https://github.com/red-hat-data-services/RHOAI-Build-Config/blob/2aa1a0f37e3cc2c58d8e38807aa1947fb76d60f1/bundle/bundle-patch.yaml#L230).

Changes:
- `internal/controller/components/trustyai/trustyai_support.go`: update `imageParamMap` key to use the new env var name
- `build/operands-map.yaml` and `build/operator-nudging.yaml`: rename env var and update image reference to `odh-trustyai-service-py-rhel9`
- `manifests-config.yaml`: rename image override entry accordingly

## Release tracking

Release: rhoai-3.6-EA1

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

This PR only renames an environment variable reference and updates image digests — no operator logic or behavior changes. No E2E test updates are required.