### PR TITLE
fix(cache): revert DSCI Owns() to unstructured to avoid double informer cache (RHOAIENG-87674)

### DIFF
--- a/internal/controller/dscinitialization/dscinitialization_controller.go
+++ b/internal/controller/dscinitialization/dscinitialization_controller.go
@@ -24,10 +24,7 @@ import (
 	"time"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	networkingv1 "k8s.io/api/networking/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -350,19 +347,19 @@ func (r *DSCInitializationReconciler) SetupWithManager(ctx context.Context, mgr 
 			getObject(gvk.Namespace),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			&corev1.Secret{},
+			getObject(gvk.Secret),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			&corev1.ConfigMap{},
+			getObject(gvk.ConfigMap),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			&networkingv1.NetworkPolicy{},
+			getObject(gvk.NetworkPolicy),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			&rbacv1.Role{},
+			getObject(gvk.Role),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			&rbacv1.RoleBinding{},
+			getObject(gvk.RoleBinding),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
 			getObject(gvk.ClusterRole),
@@ -371,19 +368,19 @@ func (r *DSCInitializationReconciler) SetupWithManager(ctx context.Context, mgr 
 			getObject(gvk.ClusterRoleBinding),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			&appsv1.Deployment{},
+			getObject(gvk.Deployment),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			&corev1.ServiceAccount{},
+			getObject(gvk.ServiceAccount),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			&corev1.Service{},
+			getObject(gvk.Service),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
 			getObject(gvk.Route),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns(
-			&corev1.PersistentVolumeClaim{},
+			getObject(gvk.PersistentVolumeClaim),
 			builder.WithPredicates(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}))).
 		Owns( // ensure always have default one for AcceleratorProfile/HardwareProfile blocking
 			getObject(gvk.ValidatingAdmissionPolicy),


### PR DESCRIPTION
## Description

Fixes [RHOAIENG-87674](https://redhat.atlassian.net/browse/RHOAIENG-87674) / [RHOAIENG-87671](https://redhat.atlassian.net/browse/RHOAIENG-87671): PR #40490 converted DSCI controller `Owns()` calls from `getObject(gvk.X)` (unstructured) to typed objects (`&corev1.Secret{}`, etc.), which creates **two separate informer caches** per resource type -- one typed (from the Owns registration, matched by ByObject) and one unstructured (from `client.Get()` calls in `pkg/deploy/deploy.go` which use `*unstructured.Unstructured`).

This reverts the 9 affected `Owns()` calls back to `getObject(gvk.X)` so there is only one unstructured informer per type, scoped by `DefaultNamespaces`. Removes unused typed imports (`appsv1`, `networkingv1`, `rbacv1`).

Identified by Luca Burgazzoli during review of the 3.5 backport (PR #41035). The same fix was already applied to rhoai-3.5 in commit `cd38d65`.

## Related

- [RHOAIENG-87674](https://redhat.atlassian.net/browse/RHOAIENG-87674) -- this bug
- [RHOAIENG-87671](https://redhat.atlassian.net/browse/RHOAIENG-87671) -- parent ticket
- [RHOAIENG-85104](https://redhat.atlassian.net/browse/RHOAIENG-85104) -- PR #40490 (introduced the typed Owns)
- PR #41035 (3.5 backport, already has the fix)

## How Has This Been Tested?

- `go build ./cmd/...` -- clean build
- `go test ./cmd/... -run TestNewCacheOptions|TestCacheDisableFor` -- PASS
- Verified on live cluster (ods-qe-psi-04) that reverting to unstructured Owns produces a single informer per type scoped by DefaultNamespaces

## Merge criteria

- [x] Commit messages are meaningful
- [x] Pull Request contains a description and links to JIRA
- [x] Skip E2E test suite update (informer-only change, no user-facing behavior change)
