### PR TITLE
fix(build): use explicit yq eval subcommand in bundle target (RHOAIENG-87671)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -511,7 +511,7 @@ bundle: prepare operator-sdk ## Generate bundle manifests and metadata, then val
 	# unreachable webhook -> 404 -> failed upgrade. Non-OLM installs (config/crd) keep their
 	# static conversion, so xKS/self-managed deployments are unaffected.
 	for f in $(BUNDLE_DIR)/manifests/datasciencecluster.opendatahub.io_datascienceclusters.yaml $(BUNDLE_DIR)/manifests/dscinitialization.opendatahub.io_dscinitializations.yaml; do \
-		[ -f "$$f" ] && $(YQ) -i 'del(.spec.conversion)' "$$f"; \
+		[ -f "$$f" ] && $(YQ) eval -i 'del(.spec.conversion)' "$$f"; \
 	done
 CLEANFILES += rhoai-bundle odh-bundle
 


### PR DESCRIPTION
## Description

Uses the explicit `yq eval -i` subcommand instead of `yq -i` for the `del(.spec.conversion)` call in the `bundle` target, making it consistent with all other `yq` invocations in the Makefile (e.g. line 671).

Without the explicit `eval` subcommand, some `yq` versions/implementations parse `del(.spec.conversion)` as an unknown command rather than an expression, causing `make bundle` to fail with:

```
Error: unknown command "del(.spec.conversion)" for "yq"
```

## How Has This Been Tested?

- Verified all other `$(YQ)` calls in the Makefile already use `eval` explicitly
- `yq eval -i 'del(.spec.conversion)'` is the documented form for mikefarah/yq v4+

## Merge criteria

- [x] Commit messages are meaningful
- [ ] Pull Request contains a description and links to JIRA
- [ ] Skip E2E test suite update (build tooling change only)
