### PR TITLE
Revert "chore: Update SHA for feast module operator"

### DIFF
--- a/manifests-config.yaml
+++ b/manifests-config.yaml
@@ -164,11 +164,11 @@ componentCharts:
   feastoperator:
     odh:
       repo: opendatahub-io/feast-module-operator
-      ref: main@d80713b6278b838e1d3b5b8cd172ae8f0a0ba75c
+      ref: main@dcd8099577492bf1869c7ea1122420c71b31c780
       sourcePath: config/chart
     rhoai:
       repo: red-hat-data-services/feast-module-operator
-      ref: rhoai-3.5@fed297ac7ee9d5ecff112216538c89e87df87f5c
+      ref: rhoai-3.5@804bef32fad14cb6a33fe4a6b3dbf8f41cb3aee7
       sourcePath: config/chart
 # Image overrides — pinned operator image digests, keyed by RELATED_IMAGE_* env var name.
 # Local directories symlinked into opt/manifests/ during development.


### PR DESCRIPTION
Reverts red-hat-data-services/rhods-operator#41031 since auto sync CI is failing.