### PR TITLE
Sync 4016

### DIFF
--- a/internal/controller/modules/modules_controller.go
+++ b/internal/controller/modules/modules_controller.go
@@ -125,10 +125,15 @@ func NewModuleReconciler(ctx context.Context, mgr ctrl.Manager) error {
 		b = b.WithAction(a)
 	}
 
-	_, err := b.WithConditions(
-		status.ConditionTypeModulesReady,
-		status.ConditionTypeProvisioningProgress,
-	).Build(ctx)
+	// Hold the Platform CR until every module CR is gone so module-operator
+	// Deployments (owned by Platform) stay up to process their CR finalizers.
+	// This is the uninstall/cascade path; per-module disable uses
+	// cleanupDisabledModules on the apply path instead.
+	_, err := b.WithFinalizer(waitForModuleCRDeletion).
+		WithConditions(
+			status.ConditionTypeModulesReady,
+			status.ConditionTypeProvisioningProgress,
+		).Build(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create platform controller: %w", err)
 	}

--- a/internal/controller/modules/modules_controller_actions.go
+++ b/internal/controller/modules/modules_controller_actions.go
@@ -217,6 +217,59 @@ func cleanupDisabledModules(ctx context.Context, rr *odhtype.ReconciliationReque
 	return nil
 }
 
+// waitForModuleCRDeletion is the Platform CR finalizer. While it runs, the
+// Platform object stays in etcd, so module-operator Deployments owned by
+// Platform are not garbage-collected. Module operators can then process
+// their CR finalizers — the module contract — during DSC cascade deletion
+// (the documented addon uninstall path).
+//
+// A regular error is returned while CRs remain so the reconciler requeues.
+// Do not wrap the wait in a StopError: the framework treats StopError in a
+// finalizer as success and will not requeue.
+func waitForModuleCRDeletion(ctx context.Context, rr *odhtype.ReconciliationRequest) error {
+	reg := DefaultRegistry()
+	if !reg.HasEntries() {
+		return nil
+	}
+
+	log := logf.FromContext(ctx)
+	var pending []string
+
+	err := reg.ForAll(func(handler ModuleHandler, _ bool) error {
+		name := handler.GetName()
+
+		state, stateErr := handler.GetModuleCRState(ctx, rr.Client)
+		if stateErr != nil {
+			return fmt.Errorf("getting module CR state for %s: %w", name, stateErr)
+		}
+
+		switch state {
+		case CRStateAbsent:
+			return nil
+		case CRStateAlive:
+			log.Info("deleting module CR so its operator can process finalizers", "module", name)
+			if delErr := handler.DeleteModuleCR(ctx, rr.Client); delErr != nil {
+				return fmt.Errorf("deleting module CR %s: %w", name, delErr)
+			}
+			pending = append(pending, name)
+		case CRStateDeleting:
+			log.Info("waiting for module operator to process finalizers", "module", name)
+			pending = append(pending, name)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(pending) > 0 {
+		return fmt.Errorf("waiting for module CRs to be deleted: %s", strings.Join(pending, ", "))
+	}
+
+	return nil
+}
+
 // provisionModules iterates over the unified DAG batches (which contain
 // both components and modules) but only provisions entries of KindModule.
 // Readiness gating uses a CompositeChecker that spans both registries, so

--- a/internal/controller/modules/modules_controller_actions_cleanup_test.go
+++ b/internal/controller/modules/modules_controller_actions_cleanup_test.go
@@ -29,6 +29,8 @@ type cleanupMockHandler struct {
 
 	crState            CRState
 	crStateErr         error
+	deletedCR          bool
+	crDeleteErr        error
 	deletedOperatorRes bool
 	operatorDeleteErr  error
 	operatorManifests  OperatorManifests
@@ -48,6 +50,11 @@ func (m *cleanupMockHandler) GetModuleCRState(_ context.Context, _ client.Client
 
 func (m *cleanupMockHandler) GetOperatorManifests(_ *PlatformContext) OperatorManifests {
 	return m.operatorManifests
+}
+
+func (m *cleanupMockHandler) DeleteModuleCR(_ context.Context, _ client.Client) error {
+	m.deletedCR = true
+	return m.crDeleteErr
 }
 
 func (m *cleanupMockHandler) DeleteOperatorResources(_ context.Context, _ client.Client, _ *PlatformContext) error {
@@ -157,4 +164,89 @@ func TestCleanupDisabledModules_CRDeleting_NoPerModuleCondition(t *testing.T) {
 
 	cond := rr.Conditions.GetCondition("TestModuleReady")
 	g.Expect(cond).Should(BeNil(), "cleanup should not set per-module conditions on Platform")
+}
+
+func TestWaitForModuleCRDeletion_NoModules(t *testing.T) {
+	g := NewWithT(t)
+
+	oldR := r
+	r = &Registry{}
+	defer func() { r = oldR }()
+
+	err := waitForModuleCRDeletion(t.Context(), &odhtype.ReconciliationRequest{})
+	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestWaitForModuleCRDeletion_CRAbsent_Succeeds(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newCleanupMock("test-mod", CRStateAbsent)
+	rr, cleanup := setupCleanupTest(t, handler)
+	defer cleanup()
+
+	err := waitForModuleCRDeletion(t.Context(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(handler.deletedCR).Should(BeFalse())
+}
+
+func TestWaitForModuleCRDeletion_CRAlive_DeletesAndWaits(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newCleanupMock("test-mod", CRStateAlive)
+	rr, cleanup := setupCleanupTest(t, handler)
+	defer cleanup()
+
+	err := waitForModuleCRDeletion(t.Context(), rr)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring("waiting for module CRs to be deleted"))
+	g.Expect(err.Error()).Should(ContainSubstring("test-mod"))
+	g.Expect(handler.deletedCR).Should(BeTrue())
+}
+
+func TestWaitForModuleCRDeletion_CRDeleting_WaitsWithoutDelete(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newCleanupMock("test-mod", CRStateDeleting)
+	rr, cleanup := setupCleanupTest(t, handler)
+	defer cleanup()
+
+	err := waitForModuleCRDeletion(t.Context(), rr)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring("waiting for module CRs to be deleted"))
+	g.Expect(err.Error()).Should(ContainSubstring("test-mod"))
+	g.Expect(handler.deletedCR).Should(BeFalse())
+}
+
+func TestWaitForModuleCRDeletion_StateError_IsReturned(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newCleanupMock("test-mod", CRStateAlive)
+	handler.crStateErr = context.DeadlineExceeded
+	rr, cleanup := setupCleanupTest(t, handler)
+	defer cleanup()
+
+	err := waitForModuleCRDeletion(t.Context(), rr)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring("getting module CR state for test-mod"))
+	g.Expect(handler.deletedCR).Should(BeFalse())
+}
+
+func TestWaitForModuleCRDeletion_MultipleModules_ListsPending(t *testing.T) {
+	g := NewWithT(t)
+
+	absent := newCleanupMock("absent-mod", CRStateAbsent)
+	deleting := newCleanupMock("deleting-mod", CRStateDeleting)
+
+	oldR := r
+	r = &Registry{}
+	r.Add(absent)
+	r.Add(deleting)
+	defer func() { r = oldR }()
+
+	err := waitForModuleCRDeletion(t.Context(), &odhtype.ReconciliationRequest{})
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring("deleting-mod"))
+	g.Expect(err.Error()).ShouldNot(ContainSubstring("absent-mod"))
+	g.Expect(absent.deletedCR).Should(BeFalse())
+	g.Expect(deleting.deletedCR).Should(BeFalse())
 }

--- a/internal/controller/modules/modules_controller_actions_cleanup_test.go
+++ b/internal/controller/modules/modules_controller_actions_cleanup_test.go
@@ -29,6 +29,7 @@ type cleanupMockHandler struct {
 
 	crState            CRState
 	crStateErr         error
+	useRealCRState     bool
 	deletedCR          bool
 	crDeleteErr        error
 	deletedOperatorRes bool
@@ -44,7 +45,10 @@ func (m *cleanupMockHandler) BuildModuleCR(_ context.Context, _ client.Client, _
 	return nil, nil
 }
 
-func (m *cleanupMockHandler) GetModuleCRState(_ context.Context, _ client.Client) (CRState, error) {
+func (m *cleanupMockHandler) GetModuleCRState(ctx context.Context, cli client.Client) (CRState, error) {
+	if m.useRealCRState {
+		return m.BaseHandler.GetModuleCRState(ctx, cli)
+	}
 	return m.crState, m.crStateErr
 }
 
@@ -175,6 +179,20 @@ func TestWaitForModuleCRDeletion_NoModules(t *testing.T) {
 
 	err := waitForModuleCRDeletion(t.Context(), &odhtype.ReconciliationRequest{})
 	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestWaitForModuleCRDeletion_MissingCRD_Succeeds(t *testing.T) {
+	g := NewWithT(t)
+
+	handler := newCleanupMock("crd-missing-mod", CRStateAbsent)
+	// Fake client has no TestModule GVK, so GetModuleCRState sees NoKindMatchError.
+	handler.useRealCRState = true
+	rr, cleanup := setupCleanupTest(t, handler)
+	defer cleanup()
+
+	err := waitForModuleCRDeletion(t.Context(), rr)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(handler.deletedCR).Should(BeFalse())
 }
 
 func TestWaitForModuleCRDeletion_CRAbsent_Succeeds(t *testing.T) {

--- a/pkg/upgrade/uninstallation.go
+++ b/pkg/upgrade/uninstallation.go
@@ -107,6 +107,11 @@ func removeDSC(ctx context.Context, cli client.Client) error {
 	log := logf.FromContext(ctx)
 	instance := &dscv2.DataScienceCluster{}
 
+	// Foreground waits for DSC-owned objects, including module CRs whose
+	// finalizers are processed by out-of-tree module operators. Those
+	// operators stay up because the Platform CR finalizer
+	// (waitForModuleCRDeletion) blocks Platform deletion — and therefore
+	// GC of module-operator Deployments — until every module CR is gone.
 	if err := cli.DeleteAllOf(ctx, instance, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil {
 		return fmt.Errorf("failure deleting DSC: %w", err)
 	}


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->
Sync of [4016](https://github.com/opendatahub-io/opendatahub-operator/pull/4016)
JIRA: [RHOAIENG-83822](https://redhat.atlassian.net/browse/RHOAIENG-83822)
<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [x] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
Sync PR