### PR TITLE
Sync PR 3982 project notebooksNamespace and modelRegistryNamespace into Dashboard CR

### DIFF
--- a/internal/controller/modules/dashboard/handler.go
+++ b/internal/controller/modules/dashboard/handler.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -83,32 +84,27 @@ func (h *handler) IsEnabled(modules *configv1alpha1.PlatformModules) bool {
 
 // BuildModuleCR projects user-facing DSC dashboard configuration and platform
 // fields from DSCContext and ModuleCRConfig onto the module CR.
-// When dscCtx or dscCtx.DSC is nil (e.g. Dashboard module created directly
-// without a DSC, as on XKS), the CR is built with defaults only — no DSC
-// component state, no namespace projection.
+// When dscCtx or dscCtx.DSC is nil, returns an error.
 func (h *handler) BuildModuleCR(
 	_ context.Context,
 	_ client.Client,
 	dscCtx *modules.DSCContext,
 	cfg *modules.ModuleCRConfig,
 ) (*unstructured.Unstructured, error) {
-	var spec map[string]any
+	if dscCtx == nil || dscCtx.DSC == nil {
+		return nil, errors.New("DSC is nil, cannot build Dashboard CR")
+	}
 
-	if dscCtx != nil && dscCtx.DSC != nil {
-		var err error
-		spec, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&dscCtx.DSC.Spec.Components.Dashboard)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert DSCDashboard to unstructured: %w", err)
-		}
-		spec["components"] = buildComponentsMap(dscCtx)
-		if ns := resolveNotebooksNamespace(dscCtx, cfg); ns != "" {
-			spec["notebooksNamespace"] = ns
-		}
-		if ns := resolveModelRegistryNamespace(dscCtx); ns != "" {
-			spec["modelRegistryNamespace"] = ns
-		}
-	} else {
-		spec = map[string]any{}
+	spec, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&dscCtx.DSC.Spec.Components.Dashboard)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert DSCDashboard to unstructured: %w", err)
+	}
+	spec["components"] = buildComponentsMap(dscCtx)
+	if ns := resolveNotebooksNamespace(dscCtx, cfg); ns != "" {
+		spec["notebooksNamespace"] = ns
+	}
+	if ns := resolveModelRegistryNamespace(dscCtx); ns != "" {
+		spec["modelRegistryNamespace"] = ns
 	}
 
 	spec["deploymentMode"] = deploymentModeStandalone

--- a/internal/controller/modules/dashboard/handler.go
+++ b/internal/controller/modules/dashboard/handler.go
@@ -2,7 +2,6 @@ package dashboard
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -12,7 +11,9 @@ import (
 
 	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
 	configv1alpha1 "github.com/opendatahub-io/opendatahub-operator/v2/api/config/v1alpha1"
+	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/components"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
 )
 
@@ -20,6 +21,14 @@ const (
 	moduleName = componentApi.DashboardComponentName
 	// crName must match dashboard-operator CRD CEL (default-dashboard); see odh-dashboard#8093.
 	crName = componentApi.DashboardInstanceName
+
+	// deploymentModeStandalone signals the dashboard-operator that the platform operator
+	// manages its lifecycle. Must match the dashboard-operator's expected deploymentMode values.
+	deploymentModeStandalone = "Standalone"
+
+	// dashboardAIPipelinesName is the key used in the Dashboard CR components map for
+	// AI Pipelines. Keep in sync with dashboard-operator's component name for DSP.
+	dashboardAIPipelinesName = "aipipelines"
 )
 
 type handler struct {
@@ -74,27 +83,35 @@ func (h *handler) IsEnabled(modules *configv1alpha1.PlatformModules) bool {
 
 // BuildModuleCR projects user-facing DSC dashboard configuration and platform
 // fields from DSCContext and ModuleCRConfig onto the module CR.
+// When dscCtx or dscCtx.DSC is nil (e.g. Dashboard module created directly
+// without a DSC, as on XKS), the CR is built with defaults only — no DSC
+// component state, no namespace projection.
 func (h *handler) BuildModuleCR(
 	_ context.Context,
 	_ client.Client,
 	dscCtx *modules.DSCContext,
 	cfg *modules.ModuleCRConfig,
 ) (*unstructured.Unstructured, error) {
-	if dscCtx == nil {
-		return nil, errors.New("DSC context is nil, cannot build dashboard CR")
-	}
-	if dscCtx.DSC == nil {
-		return nil, errors.New("DSC is nil, cannot build dashboard CR")
+	var spec map[string]any
+
+	if dscCtx != nil && dscCtx.DSC != nil {
+		var err error
+		spec, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&dscCtx.DSC.Spec.Components.Dashboard)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert DSCDashboard to unstructured: %w", err)
+		}
+		spec["components"] = buildComponentsMap(dscCtx)
+		if ns := resolveNotebooksNamespace(dscCtx, cfg); ns != "" {
+			spec["notebooksNamespace"] = ns
+		}
+		if ns := resolveModelRegistryNamespace(dscCtx); ns != "" {
+			spec["modelRegistryNamespace"] = ns
+		}
+	} else {
+		spec = map[string]any{}
 	}
 
-	spec, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&dscCtx.DSC.Spec.Components.Dashboard)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert DSCDashboard to unstructured: %w", err)
-	}
-
-	spec["deploymentMode"] = "Standalone"
-
-	spec["components"] = buildComponentsMap(dscCtx)
+	spec["deploymentMode"] = deploymentModeStandalone
 
 	if cfg != nil && cfg.GatewayDomain != "" {
 		spec["gateway"] = map[string]any{
@@ -122,23 +139,52 @@ func buildComponentsMap(dscCtx *modules.DSCContext) map[string]any {
 		name  string
 		state operatorv1.ManagementState
 	}{
-		{"modelregistry", c.ModelRegistry.ManagementState},
-		{"mlflowoperator", c.MLflowOperator.ManagementState},
-		{"trustyai", c.TrustyAI.ManagementState},
-		{"aipipelines", c.AIPipelines.ManagementState},
+		{componentApi.ModelRegistryComponentName, c.ModelRegistry.ManagementState},
+		{componentApi.MLflowOperatorComponentName, c.MLflowOperator.ManagementState},
+		{componentApi.TrustyAIComponentName, c.TrustyAI.ManagementState},
+		{dashboardAIPipelinesName, c.AIPipelines.ManagementState},
 	}
 
 	result := make(map[string]any, len(refs))
 	for _, ref := range refs {
-		state := string(ref.state)
-		if state == "" {
-			state = string(operatorv1.Removed)
-		}
-
 		result[ref.name] = map[string]any{
-			"managementState": state,
+			"managementState": string(components.NormalizeManagementState(ref.state)),
 		}
 	}
 
 	return result
+}
+
+// resolveNotebooksNamespace returns the notebooks namespace to project into the Dashboard CR.
+// Returns empty string if workbenches is not Managed, so the dashboard-operator skips
+// cross-namespace RBAC for notebooks when the component is absent.
+func resolveNotebooksNamespace(dscCtx *modules.DSCContext, cfg *modules.ModuleCRConfig) string {
+	if dscCtx == nil || dscCtx.DSC == nil {
+		return ""
+	}
+	if dscCtx.DSC.Spec.Components.Workbenches.ManagementState != operatorv1.Managed {
+		return ""
+	}
+	if ns := dscCtx.DSC.Spec.Components.Workbenches.WorkbenchNamespace; ns != "" {
+		return ns
+	}
+	if cfg != nil {
+		switch cfg.Release.Name {
+		case cluster.SelfManagedRhoai, cluster.ManagedRhoai:
+			return cluster.DefaultNotebooksNamespaceRHOAI
+		}
+	}
+	return cluster.DefaultNotebooksNamespaceODH
+}
+
+// resolveModelRegistryNamespace returns the model-registry namespace to project into the
+// Dashboard CR. Returns empty string if ModelRegistry is not Managed.
+func resolveModelRegistryNamespace(dscCtx *modules.DSCContext) string {
+	if dscCtx == nil || dscCtx.DSC == nil {
+		return ""
+	}
+	if dscCtx.DSC.Spec.Components.ModelRegistry.ManagementState != operatorv1.Managed {
+		return ""
+	}
+	return dscCtx.DSC.Spec.Components.ModelRegistry.RegistriesNamespace
 }

--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -213,34 +213,20 @@ func TestBuildModuleCR_ComponentsDefaultToRemovedWhenEmpty(t *testing.T) {
 	g.Expect(pipComp["managementState"]).Should(Equal("Removed"))
 }
 
-func TestBuildModuleCR_NilDSCContextReturnsMinimalCR(t *testing.T) {
+func TestBuildModuleCR_NilDSCContextReturnsError(t *testing.T) {
 	g := NewWithT(t)
 	h := dashboard.NewHandler()
 	// nil dscCtx is valid for DSC-less deployments (e.g. XKS direct CR creation).
-	u, err := h.BuildModuleCR(context.Background(), nil, nil, nil)
-	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(u).ShouldNot(BeNil())
-	spec, ok := u.Object["spec"].(map[string]any)
-	g.Expect(ok).Should(BeTrue())
-	g.Expect(spec["deploymentMode"]).Should(Equal("Standalone"))
-	g.Expect(spec).ShouldNot(HaveKey("notebooksNamespace"))
-	g.Expect(spec).ShouldNot(HaveKey("modelRegistryNamespace"))
-	g.Expect(spec).ShouldNot(HaveKey("components"))
+	_, err := h.BuildModuleCR(context.Background(), nil, nil, nil)
+	g.Expect(err.Error()).Should(ContainSubstring("DSC is nil, cannot build Dashboard CR"))
 }
 
-func TestBuildModuleCR_NilDSCReturnsMinimalCR(t *testing.T) {
+func TestBuildModuleCR_NilDSCReturnsError(t *testing.T) {
 	g := NewWithT(t)
 	h := dashboard.NewHandler()
 	// DSCContext with nil DSC is valid for DSC-less deployments.
-	u, err := h.BuildModuleCR(context.Background(), nil, &modules.DSCContext{}, nil)
-	g.Expect(err).ShouldNot(HaveOccurred())
-	g.Expect(u).ShouldNot(BeNil())
-	spec, ok := u.Object["spec"].(map[string]any)
-	g.Expect(ok).Should(BeTrue())
-	g.Expect(spec["deploymentMode"]).Should(Equal("Standalone"))
-	g.Expect(spec).ShouldNot(HaveKey("notebooksNamespace"))
-	g.Expect(spec).ShouldNot(HaveKey("modelRegistryNamespace"))
-	g.Expect(spec).ShouldNot(HaveKey("components"))
+	_, err := h.BuildModuleCR(context.Background(), nil, &modules.DSCContext{}, nil)
+	g.Expect(err.Error()).Should(ContainSubstring("DSC is nil, cannot build Dashboard CR"))
 }
 
 func TestGetOperatorManifests(t *testing.T) {

--- a/internal/controller/modules/dashboard/handler_test.go
+++ b/internal/controller/modules/dashboard/handler_test.go
@@ -13,6 +13,7 @@ import (
 	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules"
 	"github.com/opendatahub-io/opendatahub-operator/v2/internal/controller/modules/dashboard"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
 
 	. "github.com/onsi/gomega"
 )
@@ -212,19 +213,34 @@ func TestBuildModuleCR_ComponentsDefaultToRemovedWhenEmpty(t *testing.T) {
 	g.Expect(pipComp["managementState"]).Should(Equal("Removed"))
 }
 
-func TestBuildModuleCR_NilDSCContextReturnsError(t *testing.T) {
+func TestBuildModuleCR_NilDSCContextReturnsMinimalCR(t *testing.T) {
 	g := NewWithT(t)
 	h := dashboard.NewHandler()
-	_, err := h.BuildModuleCR(context.Background(), nil, nil, nil)
-	g.Expect(err).Should(HaveOccurred())
+	// nil dscCtx is valid for DSC-less deployments (e.g. XKS direct CR creation).
+	u, err := h.BuildModuleCR(context.Background(), nil, nil, nil)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(u).ShouldNot(BeNil())
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(spec["deploymentMode"]).Should(Equal("Standalone"))
+	g.Expect(spec).ShouldNot(HaveKey("notebooksNamespace"))
+	g.Expect(spec).ShouldNot(HaveKey("modelRegistryNamespace"))
+	g.Expect(spec).ShouldNot(HaveKey("components"))
 }
 
-func TestBuildModuleCR_NilDSCReturnsError(t *testing.T) {
+func TestBuildModuleCR_NilDSCReturnsMinimalCR(t *testing.T) {
 	g := NewWithT(t)
 	h := dashboard.NewHandler()
-
-	_, err := h.BuildModuleCR(context.Background(), nil, &modules.DSCContext{}, nil)
-	g.Expect(err).Should(HaveOccurred())
+	// DSCContext with nil DSC is valid for DSC-less deployments.
+	u, err := h.BuildModuleCR(context.Background(), nil, &modules.DSCContext{}, nil)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(u).ShouldNot(BeNil())
+	spec, ok := u.Object["spec"].(map[string]any)
+	g.Expect(ok).Should(BeTrue())
+	g.Expect(spec["deploymentMode"]).Should(Equal("Standalone"))
+	g.Expect(spec).ShouldNot(HaveKey("notebooksNamespace"))
+	g.Expect(spec).ShouldNot(HaveKey("modelRegistryNamespace"))
+	g.Expect(spec).ShouldNot(HaveKey("components"))
 }
 
 func TestGetOperatorManifests(t *testing.T) {
@@ -256,6 +272,165 @@ func TestGetOperatorManifests(t *testing.T) {
 	for k, v := range relatedImages {
 		g.Expect(v).Should(Equal(""), "relatedImages[%s] should be empty string, got %v", k, v)
 	}
+}
+
+func newDSCCtxWithNamespaces(
+	mgmtState operatorv1.ManagementState,
+	workbenchMgmt operatorv1.ManagementState,
+	workbenchNamespace string,
+	mrMgmt operatorv1.ManagementState,
+	registriesNamespace string,
+) *modules.DSCContext {
+	ctx := newDSCCtx(mgmtState)
+	ctx.DSC.Spec.Components.Workbenches = componentApi.DSCWorkbenches{
+		ManagementSpec: common.ManagementSpec{ManagementState: workbenchMgmt},
+		WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+			WorkbenchNamespace: workbenchNamespace,
+		},
+	}
+	ctx.DSC.Spec.Components.ModelRegistry = componentApi.DSCModelRegistry{
+		ManagementSpec: common.ManagementSpec{ManagementState: mrMgmt},
+		ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+			RegistriesNamespace: registriesNamespace,
+		},
+	}
+	return ctx
+}
+
+func newModuleCRConfigWithRelease(releaseName common.Platform) *modules.ModuleCRConfig {
+	return &modules.ModuleCRConfig{
+		Release: common.Release{Name: releaseName},
+	}
+}
+
+func TestBuildModuleCR_ProjectsNotebooksNamespace_RHOAI(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(operatorv1.Managed, operatorv1.Managed, "", operatorv1.Removed, "")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, newModuleCRConfigWithRelease(cluster.SelfManagedRhoai))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec["notebooksNamespace"]).Should(Equal(cluster.DefaultNotebooksNamespaceRHOAI))
+	g.Expect(spec).ShouldNot(HaveKey("modelRegistryNamespace"))
+}
+
+func TestBuildModuleCR_ProjectsNotebooksNamespace_ODH(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(operatorv1.Managed, operatorv1.Managed, "", operatorv1.Removed, "")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, newModuleCRConfigWithRelease(cluster.OpenDataHub))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec["notebooksNamespace"]).Should(Equal(cluster.DefaultNotebooksNamespaceODH))
+}
+
+func TestBuildModuleCR_ProjectsCustomNotebooksNamespace(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(operatorv1.Managed, operatorv1.Managed, "custom-notebooks", operatorv1.Removed, "")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, newModuleCRConfigWithRelease(cluster.SelfManagedRhoai))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec["notebooksNamespace"]).Should(Equal("custom-notebooks"))
+}
+
+func TestBuildModuleCR_OmitsNotebooksNamespaceWhenWorkbenchesNotManaged(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(operatorv1.Managed, operatorv1.Removed, "", operatorv1.Removed, "")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, newModuleCRConfigWithRelease(cluster.SelfManagedRhoai))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec).ShouldNot(HaveKey("notebooksNamespace"))
+}
+
+func TestBuildModuleCR_ProjectsModelRegistryNamespace(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(operatorv1.Managed, operatorv1.Removed, "", operatorv1.Managed, "rhoai-model-registries")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, newModuleCRConfigWithRelease(cluster.SelfManagedRhoai))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec["modelRegistryNamespace"]).Should(Equal("rhoai-model-registries"))
+	g.Expect(spec).ShouldNot(HaveKey("notebooksNamespace"))
+}
+
+func TestBuildModuleCR_OmitsModelRegistryNamespaceWhenNotManaged(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(operatorv1.Managed, operatorv1.Removed, "", operatorv1.Removed, "rhoai-model-registries")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, newModuleCRConfigWithRelease(cluster.SelfManagedRhoai))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec).ShouldNot(HaveKey("modelRegistryNamespace"))
+}
+
+func TestBuildModuleCR_OmitsModelRegistryNamespaceWhenEmpty(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(operatorv1.Managed, operatorv1.Removed, "", operatorv1.Managed, "")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, newModuleCRConfigWithRelease(cluster.SelfManagedRhoai))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec).ShouldNot(HaveKey("modelRegistryNamespace"),
+		"empty RegistriesNamespace with Managed ModelRegistry should not project a namespace field")
+}
+
+func TestBuildModuleCR_ProjectsNotebooksNamespace_ManagedRhoai(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(operatorv1.Managed, operatorv1.Managed, "", operatorv1.Removed, "")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, newModuleCRConfigWithRelease(cluster.ManagedRhoai))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec["notebooksNamespace"]).Should(Equal(cluster.DefaultNotebooksNamespaceRHOAI),
+		"ManagedRhoai should use the same RHOAI default notebook namespace as SelfManagedRhoai")
+}
+
+func TestBuildModuleCR_ProjectsBothNamespaces(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(
+		operatorv1.Managed,
+		operatorv1.Managed, "rhods-notebooks",
+		operatorv1.Managed, "rhoai-model-registries",
+	)
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, newModuleCRConfigWithRelease(cluster.SelfManagedRhoai))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec["notebooksNamespace"]).Should(Equal("rhods-notebooks"))
+	g.Expect(spec["modelRegistryNamespace"]).Should(Equal("rhoai-model-registries"))
+}
+
+func TestBuildModuleCR_NilCfgWithWorkbenchesManaged_DefaultsToODH(t *testing.T) {
+	g := NewWithT(t)
+	h := dashboard.NewHandler()
+	dscCtx := newDSCCtxWithNamespaces(operatorv1.Managed, operatorv1.Managed, "", operatorv1.Removed, "")
+
+	u, err := h.BuildModuleCR(context.Background(), nil, dscCtx, nil)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	spec, _ := u.Object["spec"].(map[string]any)
+	g.Expect(spec["notebooksNamespace"]).Should(Equal(cluster.DefaultNotebooksNamespaceODH),
+		"nil cfg means no release info — should fall back to ODH default")
 }
 
 func TestGetControllerImage(t *testing.T) {

--- a/manifests-config.yaml
+++ b/manifests-config.yaml
@@ -146,11 +146,11 @@ componentCharts:
   dashboard-operator:
     odh:
       repo: opendatahub-io/odh-dashboard
-      ref: main@35c5e8e75bb33b6d9a525bf807f87f1b62e7a65f
+      ref: main@591f1fc7486a1ad2f7f9a857e134473957dae06a
       sourcePath: dashboard-operator/charts/dashboard
     rhoai:
       repo: red-hat-data-services/odh-dashboard
-      ref: rhoai-3.6-ea.1@6b3bf053889ad95e9fd1c5914042ab2ca3ee310c
+      ref: rhoai-3.6-ea.1@0c280d2c9206510dbc5189f0c8e96cf3a1aff4b0
       sourcePath: dashboard-operator/charts/dashboard
   workbenches:
     odh:
@@ -338,21 +338,21 @@ imageOverrides:
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/odh-dashboard-operator"
-      digest: "sha256:8f71493c7526f7009a47deaa5ac7aa04151701d77dcc83edcb841480d054ee0f"
+      digest: "sha256:329cf5781e876989ebfb37bc631ad1c6d57865308f8c07b7ad77f0181cf58646"
     rhoai:
       shaFrom: odh
       base: "quay.io/opendatahub/odh-dashboard-operator"
-      digest: "sha256:8f71493c7526f7009a47deaa5ac7aa04151701d77dcc83edcb841480d054ee0f"
+      digest: "sha256:329cf5781e876989ebfb37bc631ad1c6d57865308f8c07b7ad77f0181cf58646"
   RELATED_IMAGE_ODH_DASHBOARD_IMAGE:
     component: dashboard-operator
     tagTemplate: "{SHA}"
     odh:
       base: "quay.io/opendatahub/odh-dashboard"
-      digest: "sha256:7c55c99946f5921a83d0ffdf72f6b41c778436e7368fad5d7791fa419a3c2b9c"
+      digest: "sha256:558cb8337f521031f11debc1e094973b80be45736f9c481b8f35a74a83de1253"
     rhoai:
       shaFrom: odh
       base: "quay.io/opendatahub/odh-dashboard"
-      digest: "sha256:7c55c99946f5921a83d0ffdf72f6b41c778436e7368fad5d7791fa419a3c2b9c"
+      digest: "sha256:558cb8337f521031f11debc1e094973b80be45736f9c481b8f35a74a83de1253"
   RELATED_IMAGE_ODH_WORKBENCHES_OPERATOR_IMAGE:
     component: workbenches
     tagTemplate: "{SHA}"


### PR DESCRIPTION
<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
Sync PR https://github.com/opendatahub-io/opendatahub-operator/pull/3982

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira:


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
