### PR TITLE
fix(manifests): package odh-observability chart for RHOAI 3.6

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -67,6 +67,12 @@ map:
     type: chart
     git.url: https://github.com/red-hat-data-services/feast-module-operator
     git.commit: 4d34cf1ca9aacc352d50c56074f20b4d72df219a
+  odh-observability:
+    src: charts/odh-observability
+    dest: odh-observability
+    type: chart
+    git.url: https://github.com/red-hat-data-services/odh-observability
+    git.commit: 787c2a434b3a7ca82a665d2027a42f1ea2e3aee4
   odh-ogx-module-operator:
     src: ogx-module/config
     dest: ogx


### PR DESCRIPTION
Summary: This PR adds the odh-observability chart for RHOAI 3.6 ea 1 as it was missing.

Should fix this: 
```
{"level":"error","ts":"2026-09-01T09:32:59Z","msg":"Reconciler error","controller":"modules","controllerGroup":"config.opendatahub.io","controllerKind":"Platform","Platform":{"name":"default"},"namespace":"","name":"default","reconcileID":"2faf9953-92e1-4914-9ebc-1969cb4e5b19","error":"provisioning failed: error rendering helm chart /opt/charts/odh-observability (release: odh-observability): unable to locate chart (repo: , name: /opt/charts/odh-observability, version: ): failed to locate chart \"/opt/charts/odh-observability\": path not found: /opt/charts/odh-observability","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/cachi2/output/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/cachi2/output/deps/gomod/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437\nsig...
```
as seen in the latest 3.6 ea 1 build.

Lines up with the latest commit to RHOAI 3.6 ea 1 branch in odh-observability: https://github.com/red-hat-data-services/odh-observability/tree/rhoai-3.6-ea.1

https://redhat.atlassian.net/browse/RHOAIENG-90091
