### PR TITLE
fix: cache DSC workbench and model-registry namespaces (RHOAIENG-89623)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -316,7 +316,7 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		os.Exit(1)
 	}
 
-	oDHCache, err := createODHGeneralCacheConfig(platform)
+	oDHCache, err := createODHGeneralCacheConfig(ctx, setupClient, platform)
 	if err != nil {
 		setupLog.Error(err, "unable to get application namespace into cache")
 		os.Exit(1)
@@ -589,7 +589,7 @@ func createSecretCacheConfig(platform common.Platform) (map[string]cache.Config,
 	return namespaceConfigs, nil
 }
 
-func createODHGeneralCacheConfig(platform common.Platform) (map[string]cache.Config, error) {
+func createODHGeneralCacheConfig(ctx context.Context, cli client.Client, platform common.Platform) (map[string]cache.Config, error) {
 	namespaceConfigs, err := getCommonCache(platform)
 	if err != nil {
 		return nil, err
@@ -608,6 +608,16 @@ func createODHGeneralCacheConfig(platform common.Platform) (map[string]cache.Con
 		namespaceConfigs[cluster.DefaultNotebooksNamespaceODH] = cache.Config{}
 	}
 	namespaceConfigs[modelregistry.DefaultModelRegistriesNamespace] = cache.Config{}
+
+	// Include configured (possibly non-default) workbench and model-registry
+	// namespaces from the existing DSC. Defaults above are not sufficient when
+	// spec.components.workbenches.workbenchNamespace or
+	// spec.components.modelregistry.registriesNamespace differ from the
+	// platform defaults (RHOAIENG-89623).
+	for _, ns := range cluster.ConfiguredComponentCacheNamespaces(ctx, cli) {
+		setupLog.Info("adding configured component namespace to cache", "namespace", ns)
+		namespaceConfigs[ns] = cache.Config{}
+	}
 
 	return namespaceConfigs, nil
 }

--- a/internal/controller/components/dashboard/dashboard_controller_actions_rbac_test.go
+++ b/internal/controller/components/dashboard/dashboard_controller_actions_rbac_test.go
@@ -61,11 +61,12 @@ func newModelRegistry(ns string) *componentApi.ModelRegistry {
 
 func TestEnsureNamespacedRBAC(t *testing.T) {
 	tests := []struct {
-		name              string
-		platform          common.Platform
-		objects           []client.Object
-		expectedCount     int
-		expectedRoleNames []string
+		name               string
+		platform           common.Platform
+		objects            []client.Object
+		expectedCount      int
+		expectedRoleNames  []string
+		expectedNamespaces map[string]string
 	}{
 		{
 			name:     "both components enabled with namespaces present",
@@ -80,6 +81,28 @@ func TestEnsureNamespacedRBAC(t *testing.T) {
 			},
 			expectedCount:     4,
 			expectedRoleNames: []string{"rhods-dashboard-notebooks", "rhods-dashboard-model-registries"},
+			expectedNamespaces: map[string]string{
+				"rhods-dashboard-notebooks":        "rhods-notebooks",
+				"rhods-dashboard-model-registries": "rhoai-model-registries",
+			},
+		},
+		{
+			name:     "custom workbench and model-registry namespaces",
+			platform: cluster.SelfManagedRhoai,
+			objects: []client.Object{
+				newDSCI("redhat-ods-applications"),
+				newNamespace("redhat-ods-applications"),
+				newNamespace("custom-notebooks"),
+				newNamespace("custom-model-registries"),
+				newWorkbenches("custom-notebooks"),
+				newModelRegistry("custom-model-registries"),
+			},
+			expectedCount:     4,
+			expectedRoleNames: []string{"rhods-dashboard-notebooks", "rhods-dashboard-model-registries"},
+			expectedNamespaces: map[string]string{
+				"rhods-dashboard-notebooks":        "custom-notebooks",
+				"rhods-dashboard-model-registries": "custom-model-registries",
+			},
 		},
 		{
 			name:     "only workbenches enabled",
@@ -172,6 +195,9 @@ func TestEnsureNamespacedRBAC(t *testing.T) {
 				foundRoleBinding := false
 				for _, res := range rr.Resources {
 					if res.GetName() == expectedName {
+						if ns, ok := tt.expectedNamespaces[expectedName]; ok {
+							g.Expect(res.GetNamespace()).To(Equal(ns), "resource %s/%s is in unexpected namespace", res.GetKind(), res.GetName())
+						}
 						switch res.GetKind() {
 						case "Role":
 							foundRole = true

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -18,11 +19,20 @@ import (
 // This ensures a unified caching strategy where all non-exempted resources
 // go through the unstructured cache path.
 type Client struct {
-	inner client.Client
+	inner    client.Client
+	uncached client.Reader
 }
 
 // Option configures the UnstructuredClient.
 type Option func(*Client)
+
+// WithUncachedReader sets a reader used when the cache-backed client rejects a
+// Get/List because the object's namespace is not in the informer cache.
+func WithUncachedReader(r client.Reader) Option {
+	return func(c *Client) {
+		c.uncached = r
+	}
+}
 
 // New creates a new Client that wraps the given client.
 // By default, all Get/List operations use unstructured resources unless the GVK
@@ -58,7 +68,7 @@ func (c *Client) Get(ctx context.Context, key client.ObjectKey, obj client.Objec
 			"gvk", gvk, "key", key, "inputType", "typed", "cacheType", "unstructured", "converted", true)
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(gvk)
-		if err := c.inner.Get(ctx, key, u, opts...); err != nil {
+		if err := c.get(ctx, key, u, gvk, opts...); err != nil {
 			return err
 		}
 		// Convert unstructured result back to typed
@@ -72,7 +82,7 @@ func (c *Client) Get(ctx context.Context, key client.ObjectKey, obj client.Objec
 		// No conversion needed - input type matches cache type
 		log.V(1).Info("Client.Get: no conversion needed - input type matches cache type",
 			"gvk", gvk, "key", key, "isUnstructured", isUnstructured, "converted", false)
-		return c.inner.Get(ctx, key, obj, opts...)
+		return c.get(ctx, key, obj, gvk, opts...)
 	}
 }
 
@@ -97,7 +107,7 @@ func (c *Client) List(ctx context.Context, list client.ObjectList, opts ...clien
 			"gvk", gvk, "inputType", "typed", "cacheType", "unstructured", "converted", true)
 		ul := &unstructured.UnstructuredList{}
 		ul.SetGroupVersionKind(gvk)
-		if err := c.inner.List(ctx, ul, opts...); err != nil {
+		if err := c.list(ctx, ul, gvk, opts...); err != nil {
 			return err
 		}
 		// Convert unstructured result back to typed
@@ -111,8 +121,41 @@ func (c *Client) List(ctx context.Context, list client.ObjectList, opts ...clien
 		// No conversion needed - input type matches cache type
 		log.V(1).Info("Client.List: no conversion needed - input type matches cache type",
 			"gvk", gvk, "isUnstructuredList", isUnstructuredList, "converted", false)
-		return c.inner.List(ctx, list, opts...)
+		return c.list(ctx, list, gvk, opts...)
 	}
+}
+
+func (c *Client) get(ctx context.Context, key client.ObjectKey, obj client.Object, gvk schema.GroupVersionKind, opts ...client.GetOption) error {
+	err := c.inner.Get(ctx, key, obj, opts...)
+	if err == nil || c.uncached == nil || !isUnknownNamespaceForCache(err) {
+		return err
+	}
+
+	logf.FromContext(ctx).Info("cache does not include namespace, retrying with uncached client",
+		"namespace", key.Namespace,
+		"name", key.Name,
+		"gvk", gvk,
+	)
+	return c.uncached.Get(ctx, key, obj, opts...)
+}
+
+func (c *Client) list(ctx context.Context, list client.ObjectList, gvk schema.GroupVersionKind, opts ...client.ListOption) error {
+	err := c.inner.List(ctx, list, opts...)
+	if err == nil || c.uncached == nil || !isUnknownNamespaceForCache(err) {
+		return err
+	}
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+	logf.FromContext(ctx).Info("cache does not include namespace, retrying with uncached client",
+		"namespace", listOpts.Namespace,
+		"gvk", gvk,
+	)
+	return c.uncached.List(ctx, list, opts...)
+}
+
+func isUnknownNamespaceForCache(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "unknown namespace for the cache")
 }
 
 // Create saves the object in the Kubernetes cluster.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -2,6 +2,7 @@ package client_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -10,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	opclient "github.com/opendatahub-io/opendatahub-operator/v2/pkg/client"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster/gvk"
@@ -349,4 +351,84 @@ func TestClient_Scheme(t *testing.T) {
 func TestClient_ImplementsClientInterface(t *testing.T) {
 	// Compile-time check that UnstructuredClient implements client.Client
 	var _ client.Client = (*opclient.Client)(nil)
+}
+
+func TestClient_Get_UnknownNamespaceFallsBackToUncached(t *testing.T) {
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhods-dashboard-notebooks",
+			Namespace: "custom-notebooks",
+		},
+		Data: map[string]string{"key": "value"},
+	}
+
+	cacheErr := fmt.Errorf("unable to get: %s/%s because of unknown namespace for the cache", cm.Namespace, cm.Name)
+
+	cached, err := fakeclient.New(fakeclient.WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			return cacheErr
+		},
+	}))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	uncached, err := fakeclient.New(fakeclient.WithObjects(cm))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	wrappedClient := opclient.New(cached, opclient.WithUncachedReader(uncached))
+
+	result := &corev1.ConfigMap{}
+	err = wrappedClient.Get(t.Context(), types.NamespacedName{Name: cm.Name, Namespace: cm.Namespace}, result)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(result.Data["key"]).Should(Equal("value"))
+}
+
+func TestClient_Get_UnknownNamespaceWithoutUncachedReader(t *testing.T) {
+	g := NewWithT(t)
+
+	cacheErr := fmt.Errorf("unable to get: custom/rhods-dashboard-notebooks because of unknown namespace for the cache")
+	cached, err := fakeclient.New(fakeclient.WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+			return cacheErr
+		},
+	}))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	wrappedClient := opclient.New(cached)
+
+	result := &corev1.ConfigMap{}
+	err = wrappedClient.Get(t.Context(), types.NamespacedName{Name: "rhods-dashboard-notebooks", Namespace: "custom"}, result)
+	g.Expect(err).Should(MatchError(ContainSubstring("unknown namespace for the cache")))
+}
+
+func TestClient_List_UnknownNamespaceFallsBackToUncached(t *testing.T) {
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhods-dashboard-model-registries",
+			Namespace: "custom-model-registries",
+		},
+	}
+
+	cacheErr := fmt.Errorf("unable to list: %s because of unknown namespace for the cache", cm.Namespace)
+
+	cached, err := fakeclient.New(fakeclient.WithInterceptorFuncs(interceptor.Funcs{
+		List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+			return cacheErr
+		},
+	}))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	uncached, err := fakeclient.New(fakeclient.WithObjects(cm))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	wrappedClient := opclient.New(cached, opclient.WithUncachedReader(uncached))
+
+	list := &corev1.ConfigMapList{}
+	err = wrappedClient.List(t.Context(), list, client.InNamespace(cm.Namespace))
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(list.Items).To(HaveLen(1))
+	g.Expect(list.Items[0].Name).To(Equal(cm.Name))
 }

--- a/pkg/cluster/cache_namespaces.go
+++ b/pkg/cluster/cache_namespaces.go
@@ -1,0 +1,46 @@
+package cluster
+
+import (
+	"context"
+
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ConfiguredComponentCacheNamespaces returns the workbench and model-registry
+// namespaces configured on the DataScienceCluster, if one exists.
+//
+// Dashboard ensureNamespacedRBAC (and other operands) Get/Apply Role and
+// RoleBinding objects in these namespaces. The operator informer cache is
+// built at manager start and must include them; otherwise controller-runtime
+// rejects the cached GET with "unknown namespace for the cache" and the
+// Dashboard / ModelRegistry components stay Not Ready.
+//
+// Returns an empty slice when no DSC exists or the fields are unset. Errors
+// other than NotFound are logged and treated as empty so operator startup
+// still succeeds with platform defaults (an uncached client is the fallback
+// for namespaces that are not in the cache).
+func ConfiguredComponentCacheNamespaces(ctx context.Context, cli client.Reader) []string {
+	if cli == nil {
+		return nil
+	}
+
+	dsc, err := GetDSC(ctx, cli)
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			logf.FromContext(ctx).Error(err, "unable to read DataScienceCluster for cache namespaces; using defaults only")
+		}
+		return nil
+	}
+
+	var namespaces []string
+	if ns := dsc.Spec.Components.Workbenches.WorkbenchNamespace; ns != "" {
+		namespaces = append(namespaces, ns)
+	}
+	if ns := dsc.Spec.Components.ModelRegistry.RegistriesNamespace; ns != "" {
+		namespaces = append(namespaces, ns)
+	}
+
+	return namespaces
+}

--- a/pkg/cluster/cache_namespaces_test.go
+++ b/pkg/cluster/cache_namespaces_test.go
@@ -1,0 +1,108 @@
+package cluster_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	componentApi "github.com/opendatahub-io/opendatahub-operator/v2/api/components/v1alpha1"
+	dscv2 "github.com/opendatahub-io/opendatahub-operator/v2/api/datasciencecluster/v2"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/cluster"
+	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/utils/test/fakeclient"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestConfiguredComponentCacheNamespaces(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		objects     []client.Object
+		interceptor *interceptor.Funcs
+		expected    []string
+	}{
+		{
+			name:     "includes custom workbench and model-registry namespaces",
+			objects:  []client.Object{newDSCWithComponentNamespaces("custom-notebooks", "custom-model-registries")},
+			expected: []string{"custom-notebooks", "custom-model-registries"},
+		},
+		{
+			name:     "includes only custom workbench namespace",
+			objects:  []client.Object{newDSCWithComponentNamespaces("custom-notebooks", "")},
+			expected: []string{"custom-notebooks"},
+		},
+		{
+			name:     "includes only custom model-registry namespace",
+			objects:  []client.Object{newDSCWithComponentNamespaces("", "custom-model-registries")},
+			expected: []string{"custom-model-registries"},
+		},
+		{
+			name:     "returns empty when both fields are unset",
+			objects:  []client.Object{newDSCWithComponentNamespaces("", "")},
+			expected: nil,
+		},
+		{
+			name:     "returns empty when DataScienceCluster is missing",
+			objects:  []client.Object{},
+			expected: nil,
+		},
+		{
+			name:    "returns empty on DataScienceCluster list error",
+			objects: []client.Object{},
+			interceptor: &interceptor.Funcs{
+				List: func(_ context.Context, _ client.WithWatch, _ client.ObjectList, _ ...client.ListOption) error {
+					return errors.New("connection refused")
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			opts := []fakeclient.ClientOpts{fakeclient.WithObjects(tt.objects...)}
+			if tt.interceptor != nil {
+				opts = append(opts, fakeclient.WithInterceptorFuncs(*tt.interceptor))
+			}
+
+			cli, err := fakeclient.New(opts...)
+			g.Expect(err).ShouldNot(HaveOccurred())
+
+			g.Expect(cluster.ConfiguredComponentCacheNamespaces(t.Context(), cli)).To(Equal(tt.expected))
+		})
+	}
+
+	t.Run("returns empty when client is nil", func(t *testing.T) {
+		t.Parallel()
+		g := NewWithT(t)
+		g.Expect(cluster.ConfiguredComponentCacheNamespaces(t.Context(), nil)).To(BeEmpty())
+	})
+}
+
+func newDSCWithComponentNamespaces(workbenchNS, registriesNS string) *dscv2.DataScienceCluster {
+	return &dscv2.DataScienceCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-dsc"},
+		Spec: dscv2.DataScienceClusterSpec{
+			Components: dscv2.Components{
+				Workbenches: componentApi.DSCWorkbenches{
+					WorkbenchesCommonSpec: componentApi.WorkbenchesCommonSpec{
+						WorkbenchNamespace: workbenchNS,
+					},
+				},
+				ModelRegistry: componentApi.DSCModelRegistry{
+					ModelRegistryCommonSpec: componentApi.ModelRegistryCommonSpec{
+						RegistriesNamespace: registriesNS,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -31,7 +31,7 @@ type Manager struct {
 // New creates a new Manager that wraps the given manager and
 // returns the wrapped client from GetClient().
 func New(mgr manager.Manager, opts ...Option) *Manager {
-	wrappedClient := opclient.New(mgr.GetClient())
+	wrappedClient := opclient.New(mgr.GetClient(), opclient.WithUncachedReader(mgr.GetAPIReader()))
 
 	m := &Manager{
 		Manager:       mgr,

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -27,6 +27,10 @@ func (m *mockManager) GetClient() client.Client {
 	return m.client
 }
 
+func (m *mockManager) GetAPIReader() client.Reader {
+	return nil
+}
+
 func TestNew_CreatesManagerWithWrappedClient(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
## Description

On RHOAI 3.4, Dashboard `ensureNamespacedRBAC` Get/Applies `Role`/`RoleBinding` in the DSC-configured workbench and model-registry namespaces. The operator informer cache only included platform defaults (`rhods-notebooks`, `rhoai-model-registries`). A cached GET then failed with `unknown namespace for the cache`, and Dashboard (and ModelRegistry, when Managed) stayed Not Ready.

This is a 3.4 in-tree Dashboard issue. 3.5+ is not affected (dashboard-operator owns that RBAC).

**Fix**
1. At manager start, add `spec.components.workbenches.workbenchNamespace` and `spec.components.modelregistry.registriesNamespace` from the existing DSC to `oDHCache` (in addition to the defaults).
2. Wrap the manager client so `Get`/`List` retry via `APIReader` when the cache rejects a namespace (covers a custom NS set after the operator is already running).

**Out of scope:** if ModelRegistry is enabled later with a custom namespace, Dashboard may reconcile before that namespace exists and skip RBAC (it does not watch ModelRegistry). That is a separate race, not the cache error from this Jira.

https://redhat.atlassian.net/browse/RHOAIENG-89623

## Release tracking

Release: rhoai-3.4.x

Jira: https://redhat.atlassian.net/browse/RHOAIENG-89623

## How Has This Been Tested?

**Manual on 3.4.4** (`quay.io/jstourac/opendatahub-operator:fixCache`)
- Custom `workbenchNamespace` (`custom`): operator logs `adding configured component namespace to cache`; Role/RoleBinding `rhods-dashboard-notebooks` in that NS; no `unknown namespace for the cache`.
- Enable ModelRegistry with `registriesNamespace: custom-model-registries`: `default-modelregistry` Ready; after operator restart (cache seed + Dashboard re-reconcile), Role/RoleBinding `rhods-dashboard-model-registries` in that NS; no cache errors.

## Screenshot or short clip

N/A

## Merge criteria

- [x] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [x] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [x] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are already listed in ODH-Build-Config and RHOAI-Build-Config, and links are included in PR description

### E2E test suite update requirement

- [x] Skip requirement to update E2E test suite for this PR

#### E2E update requirement opt-out justification

Bug is Get/Apply of namespaced RBAC in a **non-default** workbench/registries namespace. Default e2e namespaces are already hardcoded in the cache, so they cannot reproduce this. Component e2e suites run in parallel and cannot safely own a custom shared namespace. Covered by unit tests for cache namespace selection, uncached Get/List fallback, and Dashboard RBAC in both custom namespaces.