### PR TITLE
fix(cache): scope Role/RoleBinding cache to label-filtered AllNamespaces

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -50,6 +50,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -106,6 +107,7 @@ import (
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/initialinstall"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/logger"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/manager"
+	odhlabels "github.com/opendatahub-io/opendatahub-operator/v2/pkg/metadata/labels"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/operatorconfig"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/resources"
 	"github.com/opendatahub-io/opendatahub-operator/v2/pkg/upgrade"
@@ -322,6 +324,21 @@ func main() { //nolint:funlen,maintidx,gocyclo
 		os.Exit(1)
 	}
 
+	// rbacCache extends oDHCache with a catch-all entry that watches Role and
+	// RoleBinding objects in any namespace, but only those labelled
+	// platform.opendatahub.io/part-of=dashboard. The deploy action stamps that
+	// label on every Role/RoleBinding it creates, so the informer picks them up
+	// regardless of which namespace they land in (default or custom). Named
+	// namespace entries in oDHCache take precedence over the AllNamespaces entry,
+	// so platform-namespace Roles remain fully cached and cluster-wide fan-out
+	// from tenant Role events is bounded to dashboard-labelled objects only.
+	rbacCache := maps.Clone(oDHCache)
+	rbacCache[cache.AllNamespaces] = cache.Config{
+		LabelSelector: k8slabels.SelectorFromSet(map[string]string{
+			odhlabels.PlatformPartOf: strings.ToLower(componentApi.DashboardKind),
+		}),
+	}
+
 	cacheOptions := cache.Options{
 		Scheme: scheme,
 		ByObject: map[client.Object]cache.ByObject{
@@ -342,10 +359,10 @@ func main() { //nolint:funlen,maintidx,gocyclo
 				Namespaces: oDHCache,
 			},
 			&rbacv1.Role{}: {
-				Namespaces: oDHCache,
+				Namespaces: rbacCache,
 			},
 			&rbacv1.RoleBinding{}: {
-				Namespaces: oDHCache,
+				Namespaces: rbacCache,
 			},
 		},
 		DefaultTransform: func(in any) (any, error) {


### PR DESCRIPTION
When workbenchNamespace or registriesNamespace is set to a non-default value on the DataScienceCluster, the operator cache (ByObject) only covers the platform-default namespaces. The deploy action's Get call on Role/RoleBinding objects in the custom namespace fails with "unknown namespace for the cache", which keeps Dashboard from becoming Ready.

Fix by cloning oDHCache into a separate rbacCache and adding an AllNamespaces entry scoped to platform.opendatahub.io/part-of=dashboard. The deploy action already stamps that label on every Role/RoleBinding it creates, so the informer picks up dashboard Roles in any namespace without widening fan-out from tenant Role events to all controllers.

Named namespace entries in oDHCache take precedence over AllNamespaces for platform-default namespaces, keeping those fully cached. All other types stay on the unmodified oDHCache.

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-89623


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
