### PR TITLE
[sync] fix(e2e): skip dashboard ConfigMap deletion recovery for disabled modules

### DIFF
--- a/tests/e2e/dashboard_test.go
+++ b/tests/e2e/dashboard_test.go
@@ -211,12 +211,60 @@ func (tc *DashboardTestCtx) ValidateVAPBlocksDashboardCRCreation(t *testing.T) {
 	})
 }
 
+// moduleSlugToName maps the app.kubernetes.io/component label value (manifest
+// slug) on a ConfigMap to the module name used in the Dashboard CR's
+// status.moduleStatuses map.
+var moduleSlugToName = map[string]string{
+	"automl":         "automl",
+	"autorag":        "autorag",
+	"eval-hub":       "evalHub",
+	"model-registry": "modelRegistry",
+	"mlflow":         "mlflow",
+	"agent-ops":      "agentOps",
+	"notebooks":      "notebooks",
+	"gen-ai":         "genAi",
+	"maas":           "maas",
+}
+
+// isModuleDeployed checks the Dashboard CR's status.moduleStatuses to determine
+// whether a module identified by its manifest slug is currently deployed. This
+// reflects the fully resolved state including DSC component gates, explicit
+// spec.modules overrides, and inter-module dependencies.
+func (tc *DashboardTestCtx) isModuleDeployed(slug string) bool {
+	moduleName, known := moduleSlugToName[slug]
+	if !known {
+		return true
+	}
+
+	dashboard := tc.FetchResource(
+		WithMinimalObject(gvk.Dashboard, tc.NamespacedName),
+	)
+	if dashboard == nil {
+		return true
+	}
+
+	statuses, found, err := unstructured.NestedMap(dashboard.Object, "status", "moduleStatuses", moduleName)
+	if err != nil || !found {
+		return true
+	}
+
+	phase, _ := statuses["phase"].(string)
+
+	return phase == "Deployed" || phase == "Degraded"
+}
+
 // ValidateAllDeletionRecovery runs the standard set of deletion recovery tests.
 // Before running, it waits for all dashboard-labeled deployments to complete any
 // in-progress rollouts. Earlier tests (Validate_update_operand_resources,
 // Validate_dynamically_watches_operands) can trigger a rhods-dashboard rollout
 // that restarts the dashboard-operator pod; if deletion recovery runs while the
 // operator is mid-restart, it cannot recreate deleted ConfigMaps in time.
+//
+// Dashboard modules gate on DSC component states (e.g. automl requires
+// aipipelines=Managed). Prior tests or parallel suites may change those states.
+// The dashboard-operator does not clean up ConfigMaps for disabled modules, so
+// they still exist on the cluster but will not be recreated after deletion.
+// This override excludes ConfigMaps belonging to disabled modules.
 func (tc *DashboardTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 	t.Helper()
 
@@ -245,11 +293,87 @@ func (tc *DashboardTestCtx) ValidateAllDeletionRecovery(t *testing.T) {
 		WithCustomErrorMsg("All dashboard deployments should be fully rolled out before testing deletion recovery"),
 	)
 
-	// Run all the standard recovery tests first
-	tc.ComponentTestCtx.ValidateAllDeletionRecovery(t)
+	tc.validateDashboardDeletionRecovery(t)
 
 	// Add Dashboard-specific recovery test
 	t.Run("Route deletion recovery", func(t *testing.T) {
 		tc.ValidateResourceDeletionRecovery(t, gvk.Route, types.NamespacedName{Namespace: tc.AppsNamespace})
 	})
+}
+
+// validateDashboardDeletionRecovery runs the standard deletion recovery tests
+// with a dashboard-specific ConfigMap handler that excludes disabled modules.
+func (tc *DashboardTestCtx) validateDashboardDeletionRecovery(t *testing.T) {
+	t.Helper()
+
+	skipUnless(t, Smoke, Tier1)
+
+	savedOpts := tc.DefaultResourceOpts
+	tc.DefaultResourceOpts = []ResourceOpts{
+		WithEventuallyTimeout(tc.TestTimeouts.deletionRecoveryTimeout),
+		WithEventuallyPollingInterval(tc.TestTimeouts.defaultEventuallyPollInterval),
+	}
+	defer func() { tc.DefaultResourceOpts = savedOpts }()
+
+	testCases := []TestCase{
+		{"ConfigMap deletion recovery", tc.validateConfigMapDeletionRecovery},
+		{"Service deletion recovery", func(t *testing.T) {
+			t.Helper()
+			tc.ValidateResourceDeletionRecovery(t, gvk.Service, types.NamespacedName{Namespace: tc.AppsNamespace})
+		}},
+		{"RBAC deletion recovery", tc.ValidateRBACDeletionRecovery},
+		{"ServiceAccount deletion recovery", tc.ValidateServiceAccountDeletionRecovery},
+		{"Deployment deletion recovery", tc.ValidateDeploymentDeletionRecovery},
+	}
+
+	RunTestCases(t, testCases)
+}
+
+// validateConfigMapDeletionRecovery tests that dashboard ConfigMaps are
+// recreated after deletion. ConfigMaps whose app.kubernetes.io/component label
+// identifies a module that is not currently deployed are skipped — the
+// dashboard-operator does not recreate resources for disabled modules, but it
+// also does not clean up their ConfigMaps, so they may still exist on the
+// cluster as stale resources.
+//
+// Module deployment state is read from the Dashboard CR's status.moduleStatuses
+// immediately before each subtest, which reflects the fully resolved state
+// including DSC component gates, explicit spec.modules overrides, and
+// inter-module dependencies.
+func (tc *DashboardTestCtx) validateConfigMapDeletionRecovery(t *testing.T) {
+	t.Helper()
+
+	nn := types.NamespacedName{Namespace: tc.AppsNamespace}
+	listOptions := &client.ListOptions{
+		LabelSelector: k8slabels.Set{
+			labels.PlatformPartOf: strings.ToLower(tc.GVK.Kind),
+		}.AsSelector(),
+		Namespace: nn.Namespace,
+	}
+
+	existingResources := tc.FetchResources(
+		WithMinimalObject(gvk.ConfigMap, nn),
+		WithListOptions(listOptions),
+	)
+
+	if len(existingResources) == 0 {
+		t.Logf("No ConfigMap resources found for component %s, skipping", tc.GVK.Kind)
+		return
+	}
+
+	for _, resource := range existingResources {
+		t.Run("ConfigMap_"+resource.GetName(), func(t *testing.T) {
+			t.Helper()
+
+			moduleSlug := resource.GetLabels()["app.kubernetes.io/component"]
+			if moduleSlug != "" && !tc.isModuleDeployed(moduleSlug) {
+				t.Skipf("ConfigMap %s belongs to module %q which is not currently deployed", resource.GetName(), moduleSlug)
+				return
+			}
+
+			tc.EnsureResourceDeletedThenRecreated(
+				WithMinimalObject(gvk.ConfigMap, resources.NamespacedNameFromObject(&resource)),
+			)
+		})
+	}
 }


### PR DESCRIPTION
backport sync for https://github.com/opendatahub-io/opendatahub-operator/pull/4064

does not affect product, only test suite update

<!---
Many thanks for submitting your Pull Request ❤️!

Please complete the following sections for a smooth review.
-->

## Description
<!--- Describe your changes in detail -->

<!-- For RHOAI PRs, request review on #ai-core-platform-requests Slack channel -->

## Release tracking
<!-- Optional. Set a target release only if this PR must ship in a specific release; it will be prioritized accordingly. -->
<!-- Target release for this PR, e.g. rhoai-3.6 or rhoai-3.7ea1 -->
Release: 3.6-ea.1
<!-- Required only if a Release is set above. Full link to a jira ticket, e.g. https://redhat.atlassian.net/browse/RHOAIENG-XXXXX -->
Jira: https://redhat.atlassian.net/browse/RHOAIENG-91077


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshot or short clip
<!--- If applicable, attach a screenshot or a short clip demonstrating the feature. -->

## Merge criteria
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] You have read the [contributors guide](https://github.com/opendatahub-io/opendatahub-operator/blob/incubation/CONTRIBUTING.md).
- [ ] Commit messages are meaningful - have a clear and concise summary and detailed explanation of what was changed and why.
- [ ] Pull Request contains a description of the solution, a link to the JIRA issue, and to any dependent or related Pull Request.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
- [ ] The developer has run the integration test pipeline and verified that it passed successfully
- [ ] New RELATED_IMAGE mappings are listed in ODH-Build-Config and RHOAI-Build-Config (CI validates names against build-config repos). Include links to build-config PRs in the description.

### E2E test suite update requirement

When bringing new changes to the operator code, such changes are by default required to be accompanied by extending and/or updating the E2E test suite accordingly.

To opt-out of this requirement:
1. **Please inspect the [opt-out guidelines](https://github.com/opendatahub-io/opendatahub-operator/blob/main/docs/e2e-update-requirement-guidelines.md)**, to determine if the nature of the PR changes allows for skipping this requirement
2. If opt-out is applicable, provide justification in the dedicated `E2E update requirement opt-out justification` section below
3. Check the checkbox below:
- [ ] Skip requirement to update E2E test suite for this PR
4. Submit/save these changes to the PR description. This will automatically trigger the check.

#### E2E update requirement opt-out justification
<!--- If you checked the box above, please provide a short summary of reasons for opting-out of this requirement -->
<!--- This section can be left empty if you're not opting out of the E2E requirement -->
