### PR TITLE
[TESTING] - Add odh-mcp-lifecycle-operator to operator manifests

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -77,6 +77,9 @@ map:
     dest: ogx
     git.url: https://github.com/red-hat-data-services/ogx-k8s-operator
     git.commit: ab105bfc832acf8e86302b5e61b312fbaff8fa5c
+  odh-mcp-lifecycle-operator:
+    src: config/manifests
+    dest: mcplifecycleoperator
 additional_meta:
   odh-ai-gateway-payload-processing:
     git.url: https://github.com/red-hat-data-services/ai-gateway-payload-processing


### PR DESCRIPTION
Ensures 'odh-mcp-lifecycle-operator' has src/dest in build/manifests-config.yaml.

Repo: https://github.com/red-hat-data-services/mcp-lifecycle-operator
Jira: https://redhat.atlassian.net/browse/RHOAIENG-93082