### PR TITLE
fix(e2e): filter nested JUnit parent failures [rhoai-3.3]

### DIFF
--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -39,19 +39,19 @@ RUN apt-get update -y && \
     mv kubectl /usr/local/bin/ && \
     apt-get clean all
 
-# install gotestsum and build test2json
-RUN go install gotest.tools/gotestsum@latest \
+# install test reporting tools and build test2json
+RUN go install gotest.tools/gotestsum@v1.13.0 \
+ && go install github.com/jstemmer/go-junit-report/v2@v2.1.0 \
  && go build -o /usr/local/bin/test2json cmd/test2json
 
 WORKDIR /e2e
 
 COPY --from=builder /workspace/e2e-tests .
+COPY tests/e2e/scripts/run_e2e_tests.sh /e2e/run_e2e_tests.sh
 
-RUN chmod +x ./e2e-tests
+RUN chmod +x ./e2e-tests /e2e/run_e2e_tests.sh
 
 RUN mkdir -p results
 
-CMD gotestsum --junitfile-project-name odh-operator-e2e --junitfile results/xunit_report.xml --format testname --raw-command \
--- test2json -p e2e ./e2e-tests --test.parallel=1 --test.v=test2json --deletion-policy=never \
---operator-namespace=$E2E_TEST_OPERATOR_NAMESPACE --applications-namespace=$E2E_TEST_APPLICATIONS_NAMESPACE \
---workbenches-namespace=$E2E_TEST_WORKBENCHES_NAMESPACE --dsc-monitoring-namespace=$E2E_TEST_DSC_MONITORING_NAMESPACE
+# run main go command
+ENTRYPOINT ["/e2e/run_e2e_tests.sh"]

--- a/tests/e2e/scripts/run_e2e_tests.sh
+++ b/tests/e2e/scripts/run_e2e_tests.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Run the RHOAI/ODH operator e2e suite and produce a leaf-oriented JUnit report.
+#
+# Go reports a failed subtest and every failed parent as separate failures.
+# Keep the raw artifacts for diagnostics, then exclude parent results from the
+# JUnit report consumed by the CI failure importer, so deeply nested subtest
+# failures produce one actionable failure instead of one failure per ancestor.
+
+mkdir -p results
+
+echo "Using gotestsum with leaf-oriented JUnit XML"
+
+# Keep raw JUnit content outside *.xml globs so CI ingests only the final report.
+raw_junit_report=results/xunit_report.unfiltered
+test_events=results/test-events.json
+
+set +e
+gotestsum --junitfile-project-name odh-operator-e2e \
+  --junitfile "$raw_junit_report" --jsonfile "$test_events" \
+  --format testname --raw-command \
+  -- test2json -p e2e ./e2e-tests --test.parallel=1 --test.v=test2json --deletion-policy=never \
+  --operator-namespace="$E2E_TEST_OPERATOR_NAMESPACE" \
+  --applications-namespace="$E2E_TEST_APPLICATIONS_NAMESPACE" \
+  --workbenches-namespace="$E2E_TEST_WORKBENCHES_NAMESPACE" \
+  --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
+  "$@"
+test_status=$?
+set -e
+
+# Ignore only parent results. Their captured output is retained by the
+# converter as suite-level output. If this leaves no failure/error despite
+# a failed test process, retain the unfiltered report so parent-only
+# failures (for example setup, cleanup, or watchdog failures) remain visible.
+if go-junit-report -parser gojson \
+  -subtest-mode ignore-parent-results \
+  -in "$test_events" \
+  -out results/xunit_report.xml; then
+  if [ "$test_status" -ne 0 ] && \
+    ! grep -Eq '<(failure|error)([[:space:]>])' results/xunit_report.xml; then
+    echo "Warning: no leaf failure found; retaining unfiltered JUnit report" >&2
+    cp -- "$raw_junit_report" results/xunit_report.xml
+  fi
+else
+  report_status=$?
+  echo "Error: failed to generate leaf-oriented JUnit report" >&2
+  if [ -s "$raw_junit_report" ]; then
+    echo "Retaining unfiltered JUnit report"
+    cp -- "$raw_junit_report" results/xunit_report.xml
+  else
+    if [ "$test_status" -ne 0 ]; then
+      exit "$test_status"
+    fi
+    exit "$report_status"
+  fi
+fi
+
+exit "$test_status"


### PR DESCRIPTION
## Description

Backport of opendatahub-io/opendatahub-operator#4038 to the `rhoai-3.3` branch.

Go reports a failed subtest and every failed parent as separate failures, so a single deeply-nested leaf failure surfaces once per ancestor. In the RC pipeline this causes duplicate blocker Jira issues to be filed for one root cause. This change regenerates the CI-consumed JUnit report with parent results ignored, so a nested subtest failure produces **one** actionable failure instead of one per ancestor. Raw test events and the unfiltered JUnit report are preserved for diagnostics; parent-only failures (setup/cleanup/watchdog) fall back to the unfiltered report; the original test-process exit status is preserved. Reporting tools are pinned in the E2E image for reproducible builds.

## Release tracking

Release: rhoai-3.3
Jira: https://redhat.atlassian.net/browse/RHOAIENG-89737
Upstream PR: https://github.com/opendatahub-io/opendatahub-operator/pull/4038
Related backport (rhoai-3.6-ea.1): https://github.com/red-hat-data-services/rhods-operator/pull/43069

## Notes on the backport

`rhoai-3.3` predates the `run_e2e_tests.sh` refactor that exists on `main`/`rhoai-3.6-ea.1`: on this branch the e2e run is inlined as a Dockerfile `CMD`, and there is no `run_e2e_tests.sh` and no `test-retry` machinery. Rather than cram the multi-step reporting/fallback logic into the inline `CMD`, this backport:

- **Introduces `tests/e2e/scripts/run_e2e_tests.sh`** (new file), adapted to 3.3's simpler `gotestsum` invocation — it preserves the existing 3.3 arguments (`--format testname`, `--test.parallel=1`, `--deletion-policy=never`, env-based namespaces) and only adds the report-generation/post-processing logic from the upstream PR.
- **Switches the E2E image to the script** via `ENTRYPOINT ["/e2e/run_e2e_tests.sh"]` (replacing the inline `CMD`) and `COPY`s the script into the image.
- **Pins the reporting tools** in the Dockerfile: `gotestsum@v1.13.0` and adds `go-junit-report/v2@v2.1.0` (previously `gotestsum@latest`).

The script produces the unfiltered report + raw `test-events.json`, then runs `go-junit-report -parser gojson -subtest-mode ignore-parent-results` to build `results/xunit_report.xml`, with the unfiltered-report fallback for parent-only failures and preservation of the test-process exit status.

## How Has This Been Tested?

- `bash -n tests/e2e/scripts/run_e2e_tests.sh` — OK
- `shellcheck tests/e2e/scripts/run_e2e_tests.sh` — no findings
- Reporting logic verified against real `go test -json` output with the pinned `go-junit-report/v2 v2.1.0`:
  - a nested leaf failure yields exactly **1** failed testcase (`.../dashboard/Validate_component_enabled`) in the filtered report vs. **5** (leaf + 4 ancestors) in the unfiltered report;
  - a parent-only failure yields **0** leaf failures, which triggers the unfiltered-report fallback.
