### PR TITLE
fix(e2e): filter nested JUnit parent failures [rhoai-3.4]

### DIFF
--- a/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
+++ b/Dockerfiles/e2e-tests/e2e-tests.Dockerfile
@@ -41,8 +41,9 @@ RUN apt-get update -y && apt-get upgrade -y && \
     mv kubectl /usr/local/bin/ && \
     apt-get clean all
 
-# install gotestsum and build test2json
-RUN go install gotest.tools/gotestsum@latest \
+# install test reporting tools and build test2json
+RUN go install gotest.tools/gotestsum@v1.13.0 \
+ && go install github.com/jstemmer/go-junit-report/v2@v2.1.0 \
  && go build -o /usr/local/bin/test2json cmd/test2json
 
 WORKDIR /e2e

--- a/tests/e2e/scripts/run_e2e_tests.sh
+++ b/tests/e2e/scripts/run_e2e_tests.sh
@@ -120,11 +120,19 @@ if [ "$USE_TEST_RETRY" = "true" ] || [ "$USE_TEST_RETRY" = "1" ]; then
     --tag="$E2E_TEST_TAG" \
     "$@"
 else
-  echo "Using gotestsum (standard JUnit XML, no enrichment)"
+  echo "Using gotestsum with leaf-oriented JUnit XML"
 
-  # Run with gotestsum (existing behavior - DEFAULT)
-  exec gotestsum --junitfile-project-name odh-operator-e2e \
-    --junitfile results/xunit_report.xml --format testname --raw-command \
+  # Go reports a failed subtest and every failed parent as separate failures.
+  # Keep the raw artifacts for diagnostics, then exclude parent results from
+  # the JUnit report consumed by the CI failure importer.
+  # Keep raw JUnit content outside *.xml globs so CI ingests only final report.
+  raw_junit_report=results/xunit_report.unfiltered
+  test_events=results/test-events.json
+
+  set +e
+  gotestsum --junitfile-project-name odh-operator-e2e \
+    --junitfile "$raw_junit_report" --jsonfile "$test_events" \
+    --format testname --raw-command \
     -- test2json -t -p e2e ./e2e-tests --test.v=test2json --test.parallel=8 \
     --deletion-policy="$E2E_TEST_DELETION_POLICY" \
     --clean-up-previous-resources="$E2E_TEST_CLEAN_UP_PREVIOUS_RESOURCES" \
@@ -142,4 +150,35 @@ else
     --dsc-monitoring-namespace="$E2E_TEST_DSC_MONITORING_NAMESPACE" \
     --tag="$E2E_TEST_TAG" \
     "$@"
+  test_status=$?
+  set -e
+
+  # Ignore only parent results. Their captured output is retained by the
+  # converter as suite-level output. If this leaves no failure/error despite
+  # a failed test process, retain the unfiltered report so parent-only
+  # failures (for example setup, cleanup, or watchdog failures) remain visible.
+  if go-junit-report -parser gojson \
+    -subtest-mode ignore-parent-results \
+    -in "$test_events" \
+    -out results/xunit_report.xml; then
+    if [ "$test_status" -ne 0 ] && \
+      ! grep -Eq '<(failure|error)([[:space:]>])' results/xunit_report.xml; then
+      echo "Warning: no leaf failure found; retaining unfiltered JUnit report" >&2
+      cp -- "$raw_junit_report" results/xunit_report.xml
+    fi
+  else
+    report_status=$?
+    echo "Error: failed to generate leaf-oriented JUnit report" >&2
+    if [ -s "$raw_junit_report" ]; then
+      echo "Retaining unfiltered JUnit report"
+      cp -- "$raw_junit_report" results/xunit_report.xml
+    else
+      if [ "$test_status" -ne 0 ]; then
+        exit "$test_status"
+      fi
+      exit "$report_status"
+    fi
+  fi
+
+  exit "$test_status"
 fi


### PR DESCRIPTION
## Description

Backport of opendatahub-io/opendatahub-operator#4038 to the `rhoai-3.4` branch.

Generate the CI JUnit XML from raw Go test events with parent results ignored, so deeply nested subtest failures produce **one** actionable failure instead of one failure per ancestor. This prevents the RC pipeline from filing duplicate blocker Jira issues for a single leaf failure. Raw test events and the unfiltered JUnit report are preserved for diagnostics; parent-only failures (setup/cleanup/watchdog) fall back to the unfiltered report; the original test-process exit status is preserved. Reporting tools are pinned in the E2E image for reproducible builds.

## Release tracking

Release: rhoai-3.4
Jira: https://redhat.atlassian.net/browse/RHOAIENG-89737
Upstream PR: https://github.com/opendatahub-io/opendatahub-operator/pull/4038
Related backports: rhoai-3.6-ea.1 (#43069), rhoai-3.3 (#43238)

## Notes on the backport

`rhoai-3.4` already has `tests/e2e/scripts/run_e2e_tests.sh` (the `USE_TEST_RETRY` if/else structure), so this is a near-clean port of the upstream change:

- Applied the report-generation/post-processing logic to the default (`gotestsum`) branch: produce the unfiltered report + raw `test-events.json`, then regenerate `results/xunit_report.xml` with `go-junit-report -parser gojson -subtest-mode ignore-parent-results`, with the unfiltered-report fallback for parent-only failures and preservation of the test-process exit status.
- Pinned the reporting tools in the Dockerfile: `gotestsum@v1.13.0` and added `go-junit-report/v2@v2.1.0` (previously `gotestsum@latest`).
- The downstream `gotestsum` invocation differs from upstream — it uses `--format testname` and does not carry `--test.run='^TestOdhOperator'` — so that pre-existing argument list was preserved unchanged; only the reporting logic and pinned tool versions were applied.

## How Has This Been Tested?

- `bash -n tests/e2e/scripts/run_e2e_tests.sh` — OK
- `shellcheck tests/e2e/scripts/run_e2e_tests.sh` — no findings
- Reporting logic verified against real `go test -json` output with the pinned `go-junit-report/v2 v2.1.0` (during the rhoai-3.3 backport, identical filtering path): a nested leaf failure yields exactly **1** failed testcase in the filtered report vs. **5** (leaf + 4 ancestors) in the unfiltered report; a parent-only failure yields **0** leaf failures, triggering the unfiltered-report fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
