### PR TITLE
Fix malformed image digests in operator-nudging.yaml

### DIFF
--- a/build/operator-nudging.yaml
+++ b/build/operator-nudging.yaml
@@ -136,7 +136,7 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_MOD_ARCH_MLFLOW_IMAGE
   value: quay.io/rhoai/odh-mod-arch-mlflow-rhel9@sha256:72da9df1353bb583feeb9dee9afa1a4439fba5749bbaf2599c301c0009fc1cb4
 - name: RELATED_IMAGE_ODH_MOD_ARCH_MODEL_REGISTRY_IMAGE
-  value: quay.io/rhoai/odh-mod-arch-model-registry-rhel9@sha256:sha256:8b040b818f211081c893e5686bdda91314508582c4e976d481a22b7ffdb004c2
+  value: quay.io/rhoai/odh-mod-arch-model-registry-rhel9@sha256:8b040b818f211081c893e5686bdda91314508582c4e976d481a22b7ffdb004c2
 - name: RELATED_IMAGE_ODH_MUST_GATHER_IMAGE
   value: quay.io/rhoai/odh-must-gather-rhel9@sha256:2529285eb0f827726931a6cd8647a6f268b9dd567fc94b544500a15120f4fd29
 - name: RELATED_IMAGE_ODH_NOTEBOOK_CONTROLLER_IMAGE
@@ -208,7 +208,7 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
   value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:8ffadfa20532a007e02ba214f7c91ad9f863297a74433a592806cd3aa5281156
 - name: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
-  value: quay.io/rhoai/odh-vllm-cpu-rhel9@4f33c61bb9d8e11311245995d1148010bc05f77546d4b39cecc35a6606f47113
+  value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:4f33c61bb9d8e11311245995d1148010bc05f77546d4b39cecc35a6606f47113
 - name: RELATED_IMAGE_ODH_WORKBENCHES_OPERATOR_IMAGE
   value: quay.io/rhoai/odh-workbenches-operator-rhel9@sha256:96c73966142a6cbf5a8b3dd69cbf92cae432987edde6a1cc39aa200915e7772c
 - name: RELATED_IMAGE_ODH_WORKBENCH_CODESERVER_DATASCIENCE_CPU_PY312_IMAGE


### PR DESCRIPTION
## Summary
- Fix double `sha256:` prefix on `odh-mod-arch-model-registry-rhel9` digest (`sha256:sha256:` → `sha256:`)
- Fix missing `sha256:` prefix on `odh-vllm-cpu` (`RELATED_IMAGE_ODH_VLLM_CPU_IMAGE`) digest

These corrupted entries came from Konflux build-nudge PRs and cause 404 errors when operator-processor runs with `--use-existing-digests` (z-stream nightly workflow), as the malformed digests fail Quay API manifest lookups.

## Test plan
- [ ] Verify operator-processor with `--use-existing-digests` no longer 404s on these two images
- [ ] Re-run z-stream nightly workflow after merge

Tracker: https://redhat.atlassian.net/browse/RHOAIENG-93181