### PR TITLE
Fix stale image digests in rhoai-3.5.1 operands-map and nudging-yaml

### DIFF
--- a/build/operands-map.yaml
+++ b/build/operands-map.yaml
@@ -120,13 +120,13 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_MODEL_REGISTRY_OPERATOR_IMAGE
   value: quay.io/rhoai/odh-model-registry-operator-rhel9@sha256:8f434e5296174a257f382c6401c07a29ca0752a3891d18c7bdc1915fad507302
 - name: RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE
-  value: quay.io/rhoai/odh-model-serving-api-rhel9@sha256:0f4cd9b8306a0a077d5b9eccc755db6cb5275b1ba25def29d596c08360343703
+  value: quay.io/rhoai/odh-model-serving-api-rhel9@sha256:5f819d9fe807ef212b6bd56f5c30c9cf4f81980678e0983e8fd2912396d916aa
 - name: RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
   value: quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:e08d86771138d497846077c7cac3c99b761d53de4dfe56002cab9ae8110893a8
 - name: RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE
-  value: quay.io/rhoai/odh-mod-arch-automl-rhel9@sha256:67c42968b6882c2c4514a1a9437d00666b6301f69bc08e1baaa001b838605b5c
+  value: quay.io/rhoai/odh-mod-arch-automl-rhel9@sha256:9161296cea3ed5989fd9800ceeb60be8f7c649e6fa0b624679631a1ea737a995
 - name: RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE
-  value: quay.io/rhoai/odh-mod-arch-autorag-rhel9@sha256:9e52eda39704b9910f699da7e62ccc6a4c041be1deb709e3c32ca5556a6faafd
+  value: quay.io/rhoai/odh-mod-arch-autorag-rhel9@sha256:562540247160d1798862a311772dc8d6cee65f07477318910236822cf5dd6879
 - name: RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE
   value: quay.io/rhoai/odh-mod-arch-eval-hub-rhel9@sha256:8189b19f33efb338cacb76e69871948918d0b6927af28b49c62050fb15874e83
 - name: RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE
@@ -208,7 +208,7 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
   value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:8ffadfa20532a007e02ba214f7c91ad9f863297a74433a592806cd3aa5281156
 - name: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
-  value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:4f33c61bb9d8e11311245995d1148010bc05f77546d4b39cecc35a6606f47113
+  value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:8ffadfa20532a007e02ba214f7c91ad9f863297a74433a592806cd3aa5281156
 - name: RELATED_IMAGE_ODH_WORKBENCHES_OPERATOR_IMAGE
   value: quay.io/rhoai/odh-workbenches-operator-rhel9@sha256:b7d432fe3339a8eb80c1c935e93736fe4ed46cb4dec1ad45c2fea8771df9b4e5
 - name: RELATED_IMAGE_ODH_WORKBENCH_CODESERVER_DATASCIENCE_CPU_PY312_IMAGE

--- a/build/operator-nudging.yaml
+++ b/build/operator-nudging.yaml
@@ -120,13 +120,13 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_MODEL_REGISTRY_OPERATOR_IMAGE
   value: quay.io/rhoai/odh-model-registry-operator-rhel9@sha256:8f434e5296174a257f382c6401c07a29ca0752a3891d18c7bdc1915fad507302
 - name: RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE
-  value: quay.io/rhoai/odh-model-serving-api-rhel9@sha256:0f4cd9b8306a0a077d5b9eccc755db6cb5275b1ba25def29d596c08360343703
+  value: quay.io/rhoai/odh-model-serving-api-rhel9@sha256:5f819d9fe807ef212b6bd56f5c30c9cf4f81980678e0983e8fd2912396d916aa
 - name: RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
   value: quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:e08d86771138d497846077c7cac3c99b761d53de4dfe56002cab9ae8110893a8
 - name: RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE
-  value: quay.io/rhoai/odh-mod-arch-automl-rhel9@sha256:67c42968b6882c2c4514a1a9437d00666b6301f69bc08e1baaa001b838605b5c
+  value: quay.io/rhoai/odh-mod-arch-automl-rhel9@sha256:9161296cea3ed5989fd9800ceeb60be8f7c649e6fa0b624679631a1ea737a995
 - name: RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE
-  value: quay.io/rhoai/odh-mod-arch-autorag-rhel9@sha256:9e52eda39704b9910f699da7e62ccc6a4c041be1deb709e3c32ca5556a6faafd
+  value: quay.io/rhoai/odh-mod-arch-autorag-rhel9@sha256:562540247160d1798862a311772dc8d6cee65f07477318910236822cf5dd6879
 - name: RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE
   value: quay.io/rhoai/odh-mod-arch-eval-hub-rhel9@sha256:8189b19f33efb338cacb76e69871948918d0b6927af28b49c62050fb15874e83
 - name: RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE
@@ -208,7 +208,7 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
   value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:8ffadfa20532a007e02ba214f7c91ad9f863297a74433a592806cd3aa5281156
 - name: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
-  value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:4f33c61bb9d8e11311245995d1148010bc05f77546d4b39cecc35a6606f47113
+  value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:8ffadfa20532a007e02ba214f7c91ad9f863297a74433a592806cd3aa5281156
 - name: RELATED_IMAGE_ODH_WORKBENCHES_OPERATOR_IMAGE
   value: quay.io/rhoai/odh-workbenches-operator-rhel9@sha256:b7d432fe3339a8eb80c1c935e93736fe4ed46cb4dec1ad45c2fea8771df9b4e5
 - name: RELATED_IMAGE_ODH_WORKBENCH_CODESERVER_DATASCIENCE_CPU_PY312_IMAGE


### PR DESCRIPTION
## Summary

4 images in the rhoai-3.5.1 z-stream branch had version labels from older releases, causing conforma snapshot generation failures with \"version label does not match expected v3.5.1\".

All 4 were found by comparing rhoai-3.5.1 digests against the rhoai-3.5 release branch (scanned 117 unique repo@digest pairs — only these 4 were stale).

## Changes

Both operands-map.yaml and operator-nudging.yaml updated:

| Image | Stale label | Stale digest | Fix digest |
|---|---|---|---|
| odh-mod-arch-automl-rhel9 | v3.4.0-ea.2 | sha256:67c42968... | sha256:9161296c... (v3.5.1) |
| odh-mod-arch-autorag-rhel9 | v3.4.0-ea.2 | sha256:9e52eda3... | sha256:56254024... (v3.5.1) |
| odh-model-serving-api-rhel9 | v3.4.0 | sha256:0f4cd9b8... | sha256:5f819d9f... (v3.5.1) |
| odh-vllm-cpu-rhel9 (RELATED_IMAGE_ODH_VLLM_CPU_IMAGE) | v2.25.0 | sha256:4f33c61b... | sha256:8ffadfa2... (v3.5.1) |

Fix digests sourced from rhoai-3.5 release branch operands-map (last written by regular rhoai-3.5 nightly, v3.5.1 labels confirmed).

## Test plan
- [ ] Re-run z-stream nightly on rhoai-3.5.1 after merge
- [ ] Conforma should pass with no version label mismatches