### PR TITLE
Cherry-pick: Update odh-ai-gateway-operator to 1a57deb for rhoai-3.5.1

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -60,7 +60,7 @@ map:
     src: config
     dest: aigateway
     git.url: https://github.com/red-hat-data-services/ai-gateway-operator
-    git.commit: 37cede17bfe93552df07263edf75945a76bb0de9
+    git.commit: e3c4c05f9e338470e09945d68012124bdbee2ff8
   odh-mcp-lifecycle-module-operator:
     src: config
     dest: mcplifecycleoperator

--- a/build/operands-map.yaml
+++ b/build/operands-map.yaml
@@ -1,6 +1,6 @@
 relatedImages:
 - name: RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE
-  value: quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:0790caeaffeed64479722981ccfc432c40cbf184c85fa826202dd60f2330aa97
+  value: "quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:1a57debca696d794d18db6b07bfa35ec0cf603257357bc36b7f3bd7ed51d184d"
 - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE
   value: quay.io/rhoai/odh-ai-gateway-payload-processing-rhel9@sha256:e5bc7a88a63916e482ac1a31b1be9d4eaa9431dbe4fd14d80b6992b2f4cfc14d
 - name: RELATED_IMAGE_ODH_AUTOML_IMAGE

--- a/build/operator-nudging.yaml
+++ b/build/operator-nudging.yaml
@@ -1,6 +1,6 @@
 relatedImages:
 - name: RELATED_IMAGE_ODH_AI_GATEWAY_OPERATOR_IMAGE
-  value: quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:0790caeaffeed64479722981ccfc432c40cbf184c85fa826202dd60f2330aa97
+  value: quay.io/rhoai/odh-ai-gateway-operator-rhel9@sha256:1a57debca696d794d18db6b07bfa35ec0cf603257357bc36b7f3bd7ed51d184d
 - name: RELATED_IMAGE_ODH_AI_GATEWAY_PAYLOAD_PROCESSING_IMAGE
   value: quay.io/rhoai/odh-ai-gateway-payload-processing-rhel9@sha256:e5bc7a88a63916e482ac1a31b1be9d4eaa9431dbe4fd14d80b6992b2f4cfc14d
 - name: RELATED_IMAGE_ODH_AUTOML_IMAGE

--- a/prefetched-manifests/aigateway/rbac/role.yaml
+++ b/prefetched-manifests/aigateway/rbac/role.yaml
@@ -159,6 +159,18 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - batch
   resources:
   - cronjobs
@@ -425,6 +437,7 @@ rules:
   resources:
   - aitenants/status
   - configs/status
+  - externalmodels/status
   - maasauthpolicies/status
   - maasmodelrefs/status
   - maassubscriptions/status


### PR DESCRIPTION
## Summary

Cherry-picks two commits from rhoai-3.5 to update `odh-ai-gateway-operator-rhel9` to the latest build (`sha256:1a57deb...`, built from ai-gateway-operator commit `e3c4c05f`).

## Commits cherry-picked

1. d47883d9 — "Updating the operator repo with latest images and manifests"
   - build/operands-map.yaml: odh-ai-gateway-operator-rhel9 sha256:0790cae... → sha256:1a57deb...
   - build/manifests-config.yaml: git.commit 37cede17... → e3c4c05f...
   - prefetched-manifests/aigateway/rbac/role.yaml: add RBAC rules for horizontalpodautoscalers and externalmodels/status

2. 04b92c53 — "chore(deps): update odh-ai-gateway-operator-v3-5 to 1a57deb" (from PR #43760)
   - build/operator-nudging.yaml: odh-ai-gateway-operator-rhel9 sha256:0790cae... → sha256:1a57deb...

## Conflict resolution

operands-map.yaml had a minor conflict (rhoai-3.5.1 branch had unquoted value, cherry-pick had quoted). Resolved by taking the cherry-pick version (`sha256:1a57debca696d794d18db6b07bfa35ec0cf603257357bc36b7f3bd7ed51d184d`).

## Related
- Source commit: https://github.com/red-hat-data-services/rhods-operator/commit/d47883d94caae2296f0408d6db10ba08d45d2599
- Source PR: https://github.com/red-hat-data-services/rhods-operator/pull/43760