### PR TITLE
Fix stale image digests in rhoai-3.5 operator-nudging.yaml

### DIFF
--- a/build/operator-nudging.yaml
+++ b/build/operator-nudging.yaml
@@ -120,13 +120,13 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_MODEL_REGISTRY_OPERATOR_IMAGE
   value: quay.io/rhoai/odh-model-registry-operator-rhel9@sha256:6d3226f6c02fcb1fc0f3c6d9038f6bd49a95e731c23d12057a89921ceb62a93b
 - name: RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE
-  value: quay.io/rhoai/odh-model-serving-api-rhel9@sha256:0f4cd9b8306a0a077d5b9eccc755db6cb5275b1ba25def29d596c08360343703
+  value: quay.io/rhoai/odh-model-serving-api-rhel9@sha256:5f819d9fe807ef212b6bd56f5c30c9cf4f81980678e0983e8fd2912396d916aa
 - name: RELATED_IMAGE_ODH_MOD_ARCH_AGENT_OPS_IMAGE
   value: quay.io/rhoai/odh-mod-arch-agent-ops-rhel9@sha256:e08d86771138d497846077c7cac3c99b761d53de4dfe56002cab9ae8110893a8
 - name: RELATED_IMAGE_ODH_MOD_ARCH_AUTOML_IMAGE
-  value: quay.io/rhoai/odh-mod-arch-automl-rhel9@sha256:67c42968b6882c2c4514a1a9437d00666b6301f69bc08e1baaa001b838605b5c
+  value: quay.io/rhoai/odh-mod-arch-automl-rhel9@sha256:9161296cea3ed5989fd9800ceeb60be8f7c649e6fa0b624679631a1ea737a995
 - name: RELATED_IMAGE_ODH_MOD_ARCH_AUTORAG_IMAGE
-  value: quay.io/rhoai/odh-mod-arch-autorag-rhel9@sha256:9e52eda39704b9910f699da7e62ccc6a4c041be1deb709e3c32ca5556a6faafd
+  value: quay.io/rhoai/odh-mod-arch-autorag-rhel9@sha256:562540247160d1798862a311772dc8d6cee65f07477318910236822cf5dd6879
 - name: RELATED_IMAGE_ODH_MOD_ARCH_EVAL_HUB_IMAGE
   value: quay.io/rhoai/odh-mod-arch-eval-hub-rhel9@sha256:8189b19f33efb338cacb76e69871948918d0b6927af28b49c62050fb15874e83
 - name: RELATED_IMAGE_ODH_MOD_ARCH_GEN_AI_IMAGE
@@ -208,7 +208,7 @@ relatedImages:
 - name: RELATED_IMAGE_ODH_VLLM_CPU_FAST_2_IMAGE
   value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:8ffadfa20532a007e02ba214f7c91ad9f863297a74433a592806cd3aa5281156
 - name: RELATED_IMAGE_ODH_VLLM_CPU_IMAGE
-  value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:4f33c61bb9d8e11311245995d1148010bc05f77546d4b39cecc35a6606f47113
+  value: quay.io/rhoai/odh-vllm-cpu-rhel9@sha256:8ffadfa20532a007e02ba214f7c91ad9f863297a74433a592806cd3aa5281156
 - name: RELATED_IMAGE_ODH_WORKBENCHES_OPERATOR_IMAGE
   value: quay.io/rhoai/odh-workbenches-operator-rhel9@sha256:cf58c974cd7a3eadd794c000f855b8cfd3378e5068d3a0375eb9e7c7fb551ef2
 - name: RELATED_IMAGE_ODH_WORKBENCH_CODESERVER_DATASCIENCE_CPU_PY312_IMAGE


### PR DESCRIPTION
## Summary

4 images in `build/operator-nudging.yaml` on the rhoai-3.5 branch have stale digests from older releases. The `build/operands-map.yaml` already has the correct v3.5.1 digests for all 4 — this PR aligns the nudging-yaml to match.

These stale nudging-yaml entries cause conforma snapshot failures when the z-stream nightly runs with `--use-existing-digests` (nudging-yaml values take priority over operands-map).

Scanned all 140 unique repo@digest pairs across operands-map.yaml and operator-nudging.yaml — only these 4 were stale.

## Changes (operator-nudging.yaml only)

| Image | Stale label | Stale digest | Fix digest |
|---|---|---|---|
| odh-mod-arch-automl-rhel9 | v3.4.0-ea.2 | sha256:67c42968... | sha256:9161296c... (v3.5.1) |
| odh-mod-arch-autorag-rhel9 | v3.4.0-ea.2 | sha256:9e52eda3... | sha256:56254024... (v3.5.1) |
| odh-model-serving-api-rhel9 | v3.4.0 | sha256:0f4cd9b8... | sha256:5f819d9f... (v3.5.1) |
| odh-vllm-cpu-rhel9 (RELATED_IMAGE_ODH_VLLM_CPU_IMAGE) | v2.25.0 | sha256:4f33c61b... | sha256:8ffadfa2... (v3.5.1) |

Fix digests sourced from rhoai-3.5 operands-map.yaml (already correct).

## Related
- Same fix on rhoai-3.5.1: https://github.com/red-hat-data-services/rhods-operator/pull/43756